### PR TITLE
Fixed broken mroonga_default_parser or mroonga_log_file variable 

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -635,10 +635,15 @@ static void mrn_log_file_update(THD *thd, struct st_mysql_sys_var *var,
   MRN_DBUG_ENTER_FUNCTION();
   const char *new_value = *((const char **)save);
   char **old_value_ptr = (char **)var_ptr;
+  const char *new_log_file_name;
+
   grn_ctx ctx;
 
   grn_ctx_init(&ctx, 0);
   mrn_change_encoding(&ctx, system_charset_info);
+  
+  new_log_file_name = *old_value_ptr;
+
   if (strcmp(*old_value_ptr, new_value) == 0) {
     GRN_LOG(&ctx, GRN_LOG_NOTICE,
             "log file isn't changed "
@@ -665,7 +670,6 @@ static void mrn_log_file_update(THD *thd, struct st_mysql_sys_var *var,
       }
     }
 
-    const char *new_log_file_name;
     if (log_file_open_errno == 0) {
       GRN_LOG(&ctx, GRN_LOG_NOTICE,
               "log file is changed: <%s> -> <%s>",
@@ -682,8 +686,9 @@ static void mrn_log_file_update(THD *thd, struct st_mysql_sys_var *var,
                 "log file can't be opened: <%s>: <%s>",
                 new_value, strerror(log_file_open_errno));
       }
-      new_log_file_name = *old_value_ptr;
     }
+  }
+
 #ifdef MRN_NEED_FREE_STRING_MEMALLOC_PLUGIN_VAR
     char *old_log_file_name = *old_value_ptr;
     *old_value_ptr = my_strdup(new_log_file_name, MYF(MY_WME));
@@ -691,7 +696,7 @@ static void mrn_log_file_update(THD *thd, struct st_mysql_sys_var *var,
 #else
     *old_value_ptr = my_strdup(new_log_file_name, MYF(MY_WME));
 #endif
-  }
+
   grn_ctx_fin(&ctx);
 
   DBUG_VOID_RETURN;
@@ -723,6 +728,7 @@ static void mrn_default_parser_update(THD *thd, struct st_mysql_sys_var *var,
     GRN_LOG(&ctx, GRN_LOG_NOTICE,
             "default fulltext parser is changed: <%s> -> <%s>",
             *old_value_ptr, new_value);
+  }
 
 #ifdef MRN_NEED_FREE_STRING_MEMALLOC_PLUGIN_VAR
     my_free(*old_value_ptr, MYF(0));
@@ -730,7 +736,7 @@ static void mrn_default_parser_update(THD *thd, struct st_mysql_sys_var *var,
 #else
     *old_value_ptr = (char *)new_value;
 #endif
-  }
+
   grn_ctx_fin(&ctx);
 
   DBUG_VOID_RETURN;


### PR DESCRIPTION
after SET GLOBAL same as before value,  variables is broken.

```
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 2
Server version: 5.5.36 MySQL Community Server (GPL)

Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show global variables like 'mroonga_default_parser';
+------------------------+-------------+
| Variable_name          | Value       |
+------------------------+-------------+
| mroonga_default_parser | TokenBigram |
+------------------------+-------------+
1 row in set (0.00 sec)

mysql> set global mroonga_default_parser=TokenBigram;
Query OK, 0 rows affected (0.00 sec)

mysql> show global variables like 'mroonga_default_parser';
+------------------------+------------------+
| Variable_name          | Value            |
+------------------------+------------------+
| mroonga_default_parser | /tmp/#sql_5fbd_0 |
+------------------------+------------------+
1 row in set (0.00 sec)
```

And also, crashed during shutdown.

```
Version: '5.5.36'  socket: '/var/lib/mysql/mysql.sock'  port: 3306  MySQL Community Server (GPL)
140419 17:48:42 [Note] /usr/sbin/mysqld: Normal shutdown

140419 17:48:42 [Note] Event Scheduler: Purging the queue. 0 events
140419 17:48:42  InnoDB: Starting shutdown...
140419 17:48:43  InnoDB: Shutdown completed; log sequence number 1595675
08:48:43 UTC - mysqld got signal 11 ;
This could be because you hit a bug. It is also possible that this binary
or one of the libraries it was linked against is corrupt, improperly built,
or misconfigured. This error can also be caused by malfunctioning hardware.
We will try our best to scrape up some info that will hopefully help
diagnose the problem, but since we have already crashed, 
something is definitely wrong and this may fail.

key_buffer_size=8388608
read_buffer_size=131072
max_used_connections=1
max_threads=151
thread_count=0
connection_count=0
It is possible that mysqld could use up to 
key_buffer_size + (read_buffer_size + sort_buffer_size)*max_threads = 338511 K  bytes of memory
Hope that's ok; if not, decrease some variables in the equation.

Thread pointer: 0x0
Attempting backtrace. You can use the following information to find out
where mysqld died. If you see no messages after this, something went
terribly wrong...
stack_bottom = 0 thread_stack 0x40000
/usr/sbin/mysqld(my_print_stacktrace+0x35)[0x7a6125]
/usr/sbin/mysqld(handle_fatal_signal+0x403)[0x673b23]
/lib64/libpthread.so.0(+0xf710)[0x7f44776e8710]
/lib64/libc.so.6(+0x7878a)[0x7f44768f578a]
/usr/sbin/mysqld(free_root+0x11a)[0x79b97a]
/usr/sbin/mysqld[0x587083]
/usr/sbin/mysqld[0x5872e1]
/usr/sbin/mysqld(_Z15plugin_shutdownv+0x205)[0x587a75]
/usr/sbin/mysqld[0x5044f7]
/usr/sbin/mysqld(_Z10unireg_endv+0xe)[0x5047de]
/usr/sbin/mysqld[0x507f25]
/usr/sbin/mysqld(kill_server_thread+0x10)[0x508020]
/lib64/libpthread.so.0(+0x79d1)[0x7f44776e09d1]
/lib64/libc.so.6(clone+0x6d)[0x7f4476965b6d]
The manual page at http://dev.mysql.com/doc/mysql/en/crashing.html contains
information that should help you find out what is causing the crash.
140419 17:48:43 mysqld_safe Number of processes running now: 0
140419 17:48:43 mysqld_safe mysqld restarted
```
