### PR TITLE
mroonga_lock_timeout doesn't refrect when it's specified at mysqld starts up

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1396,6 +1396,7 @@ static int mrn_init(void *p)
                    mrn_long_term_share_get_key, 0, 0)) {
     goto error_allocated_long_term_share_hash_init;
   }
+  grn_set_lock_timeout(mrn_lock_timeout);
 
 #ifdef MRN_USE_MYSQL_DATA_HOME
   mrn::PathMapper::default_mysql_data_home_path = mysql_data_home;


### PR DESCRIPTION
Detail:
 MySQL system variable "mroonga_lock_timeout" added in Mroonga 3.12 doesn't refrect lock timeout value at Groonga's layer lock, when it is setted at mysqld's startup, by my.cnf and by command-line argument.
 "SET GLOBAL mroonga_lock_timeout" works well, but both of starting "bin/mysqld_safe --mroonga-lock-timeout=5" and writing "mroonga-lock-timeout= 5" into my.cnf doesn't work as expected.
 Because of that, grn_set_lock_timeout is only called when "SET GLOBAL mroonga_lock_timeout"'s execution, mrn_init should call grn_set_lock_timeout too.

How to repeat:
 --write mroonga-lock-timeout=5 into my.cnf and start mysqld.
 --at connection 1.
 mysql> SELECT @@global.mroonga_lock_timeout; -- This prints "5" as expected.
 mysql> CREATE DATABASE mroonga;
 mysql> CREATE TABLE mroonga.t1 (num int) Engine= Mroonga;
 --at connection 2.
 shell> ruby -e require "groonga"; Groonga::Database.open("/path/to/mroonga.mrn"); Groonga["t1"].lock; exit' # force locking table.
 --at connection 1.
 mysql> INSERT INTO mroonga.t1 VALUES (1); -- This doesn't return over "5"ms as expected.

(gdb) bt
#0  0x0000003eb480ed2d in nanosleep () from /lib64/libpthread.so.0
#1  0x00007fb46d4bb1d9 in grn_nanosleep (nanoseconds=<value optimized out>) at ctx.c:82
#2  0x00007fb46d5c30f2 in grn_io_lock (ctx=0x7fb41c03f518, io=0x7fb41c36be30, timeout=10000000) at io.c:1320

..<snip>

 grn_io_lock receives timeout value 10000000, this isn't the value specified in my.cnf.

Suggested fix:
 Add grn_set_lock_timeout() in mrn_init() like attached patch.
