### PR TITLE
fix build error for VC++ 2013

### DIFF
--- a/lib/mrn_time_converter.cpp
+++ b/lib/mrn_time_converter.cpp
@@ -24,14 +24,14 @@
 
 #include "mrn_time_converter.hpp"
 
-#include <limits>
-
 #ifdef min
 #  undef min
 #endif
 #ifdef max
 #  undef max
 #endif
+
+#include <limits>
 
 // for debug
 #define MRN_CLASS_NAME "mrn::TimeConverter"


### PR DESCRIPTION
fix following compilation error for VC++ 2013:

``` log
45>C:\mrnwork\powershell\work\source\include\mysql/psi/mysql_file.h(541):
error
C3861: 'fgets': identifier not found
...
```
