### PR TITLE
doc install:fix quote

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -218,7 +218,7 @@ Install::
   % sudo yum install -y mysql55-mysql-server
   % sudo /etc/init.d/mysql55-mysqld start
   % sudo yum install -y mysql55-mroonga
-  (% sudo scl enable mysql55 mysqladmin -u root password 'new-password')
+  (% sudo scl enable mysql55 "mysqladmin -u root password 'new-password'")
 
 If you want to use `MeCab <http://mecab.sourceforge.net/>`_ as a tokenizer, install groonga-tokenizer-mecab package.
 


### PR DESCRIPTION
`scl enable mysql55` command requires quotes if have more than one argument.
