### PR TITLE
doc: add mroonga_vector_column_delimiter variable

### DIFF
--- a/doc/locale/en/LC_MESSAGES/reference.po
+++ b/doc/locale/en/LC_MESSAGES/reference.po
@@ -1700,3 +1700,13 @@ msgstr "It is the end text of wordN."
 
 msgid "It returns snippet string."
 msgstr "It returns snippet string."
+
+msgid ""
+"The delimiter when outputting a vector column.  The default value is a white space."
+msgstr ""
+"The delimiter when outputting a vector column.  The default value is a white space."
+
+msgid ""
+"Here is an example SQL to change the delimiter to a semicolon from a white space::"
+msgstr ""
+"Here is an example SQL to change the delimiter to a semicolon from a white space::"

--- a/doc/locale/ja/LC_MESSAGES/reference.po
+++ b/doc/locale/ja/LC_MESSAGES/reference.po
@@ -1540,3 +1540,13 @@ msgstr "N番目の単語の終了テキストを指定します。"
 
 msgid "It returns snippet string."
 msgstr "スニペット文字列を返します。"
+
+msgid ""
+"The delimiter when outputting a vector column.  The default value is a white space."
+msgstr ""
+"ベクターカラムを出力する際の区切り文字。デフォルト値は空白です。"
+
+msgid ""
+"Here is an example SQL to change the delimiter to a semicolon from a white space::"
+msgstr ""
+"区切り文字を空白からセミコロンに変更するSQL例です::"

--- a/doc/source/reference/server_variables.rst
+++ b/doc/source/reference/server_variables.rst
@@ -300,3 +300,30 @@ value.
    SELECT * FROM diaries WHERE MATCH (tags) AGAINST ("gr" IN BOOLEAN MODE);
    -- id	title	tags
    -- 1	Hello groonga!	groonga install
+
+mroonga_vector_column_delimiter
+-------------------------------
+
+The delimiter when outputting a vector column.  The default value is a white space.
+
+Here is an example SQL to change the delimiter to a semicolon from a white space::
+
+
+  mysql> SHOW VARIABLES LIKE 'mroonga_vector_column_delimiter';
+  +---------------------------------+-------+
+  | Variable_name                   | Value |
+  +---------------------------------+-------+
+  | mroonga_vector_column_delimiter |       |
+  +---------------------------------+-------+
+  1 row in set (0.00 sec)
+
+
+  mysql> SET GLOBAL mroonga_vector_column_delimiter = ';';
+  Query OK, 0 rows affected (0.00 sec)
+
+  mysql> SHOW GLOBAL VARIABLES LIKE 'mroonga_vector_column_delimiter';
+  +---------------------------------+-------+
+  | Variable_name                   | Value |
+  +---------------------------------+-------+
+  | mroonga_vector_column_delimiter | ;     |
+  +---------------------------------+-------+


### PR DESCRIPTION
I added a document about mroonga vector column delimiter variable.
Please refer the following preview.

http://createfield.com/en/reference/server_variables.html#mroonga-vector-column-delimiter
http://createfield.com/ja/reference/server_variables.html#mroonga-vector-column-delimiter
