### PR TITLE
storage: support specifying normalizer in table comment

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -2833,14 +2833,21 @@ int ha_mroonga::storage_create(const char *name, TABLE *table,
     KEY key_info = table->s->key_info[pkey_nr];
     int key_parts = KEY_N_KEY_PARTS(&key_info);
     if (key_parts == 1) {
-      Field *field = &(key_info.key_part->field[0]);
-      if (should_normalize(field)) {
-        grn_obj *normalizer = find_normalizer(&key_info);
-        if (normalizer) {
-          grn_info_type info_type = GRN_INFO_NORMALIZER;
-          grn_obj_set_info(ctx, table_obj, info_type, normalizer);
-          grn_obj_unlink(ctx, normalizer);
+      grn_obj *normalizer = NULL;
+      if (tmp_share->normalizer) {
+        normalizer =  grn_ctx_get(ctx,
+                                  tmp_share->normalizer,
+                                  tmp_share->normalizer_length);
+      } else {
+        Field *field = &(key_info.key_part->field[0]);
+        if (should_normalize(field)) {
+          normalizer = find_normalizer(&key_info);
         }
+      }
+      if (normalizer) {
+        grn_info_type info_type = GRN_INFO_NORMALIZER;
+        grn_obj_set_info(ctx, table_obj, info_type, normalizer);
+        grn_obj_unlink(ctx, normalizer);
       }
       if (tmp_share->default_tokenizer) {
         grn_obj *default_tokenizer =

--- a/mrn_table.cpp
+++ b/mrn_table.cpp
@@ -404,6 +404,9 @@ int mrn_parse_table_param(MRN_SHARE *share, TABLE *table)
         case 6:
           MRN_PARAM_STR("engine", engine);
           break;
+        case 10:
+          MRN_PARAM_STR("normalizer", normalizer);
+          break;
         case 13:
           MRN_PARAM_STR("token_filters", token_filters);
           break;

--- a/mrn_table.hpp
+++ b/mrn_table.hpp
@@ -53,6 +53,8 @@ typedef struct st_mroonga_share
   int                 engine_length;
   char                *default_tokenizer;
   int                 default_tokenizer_length;
+  char                *normalizer;
+  int                 normalizer_length;
   char                *token_filters;
   int                 token_filters_length;
   plugin_ref          plugin;

--- a/mysql-test/mroonga/storage/create/table/normalizer/r/table_comment.result
+++ b/mysql-test/mroonga/storage/create/table/normalizer/r/table_comment.result
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS memos;
+DROP TABLE IF EXISTS terms;
+SET NAMES utf8;
+CREATE TABLE terms (
+term VARCHAR(64) NOT NULL PRIMARY KEY
+) COMMENT='default_tokenizer "TokenBigram", normalizer "NormalizerAuto"' DEFAULT CHARSET=utf8;
+CREATE TABLE memos (
+id INT NOT NULL PRIMARY KEY,
+content TEXT NOT NULL,
+FULLTEXT INDEX (content) COMMENT 'table "terms"'
+) DEFAULT CHARSET=utf8;
+INSERT INTO memos VALUES (1, "1日の消費㌍は約2000㌔㌍");
+SELECT * FROM memos
+WHERE MATCH (content) AGAINST ("+カロリー" IN BOOLEAN MODE);
+id	content
+1	1日の消費㌍は約2000㌔㌍
+DROP TABLE memos;
+DROP TABLE terms;

--- a/mysql-test/mroonga/storage/create/table/normalizer/t/table_comment.test
+++ b/mysql-test/mroonga/storage/create/table/normalizer/t/table_comment.test
@@ -1,0 +1,46 @@
+# Copyright(C) 2014  Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS memos;
+DROP TABLE IF EXISTS terms;
+--enable_warnings
+
+SET NAMES utf8;
+
+CREATE TABLE terms (
+  term VARCHAR(64) NOT NULL PRIMARY KEY
+) COMMENT='default_tokenizer "TokenBigram", normalizer "NormalizerAuto"' DEFAULT CHARSET=utf8;
+
+CREATE TABLE memos (
+  id INT NOT NULL PRIMARY KEY,
+  content TEXT NOT NULL,
+  FULLTEXT INDEX (content) COMMENT 'table "terms"'
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO memos VALUES (1, "1日の消費㌍は約2000㌔㌍");
+
+SELECT * FROM memos
+  WHERE MATCH (content) AGAINST ("+カロリー" IN BOOLEAN MODE);
+
+DROP TABLE memos;
+DROP TABLE terms;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
I've modified based on your comments https://github.com/mroonga/mroonga/pull/26 .

> Please recreate database for stable dump output. See also 3acf106

This test didn't use the `dump` command.
It uses `SELECT` SQL in the same way as the following test case.

https://github.com/mroonga/mroonga/blob/master/mysql-test/mroonga/storage/create/table/normalizer/t/fulltext_index.test
