### PR TITLE
storage: support column compression flag

### DIFF
--- a/mysql-test/mroonga/storage/column/groonga/scalar/r/lz4.result
+++ b/mysql-test/mroonga/storage/column/groonga/scalar/r/lz4.result
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS entries;
+CREATE TABLE entries (
+id INT UNSIGNED PRIMARY KEY,
+content TEXT COMMENT 'flags "COLUMN_SCALAR|COMPRESS_LZ4"'
+) DEFAULT CHARSET=utf8;
+INSERT INTO entries (id, content) VALUES (1, "I found Mroonga that is a MySQL storage engine to use Groonga!");
+SELECT * FROM entries;
+id	content
+1	I found Mroonga that is a MySQL storage engine to use Groonga!
+DROP TABLE entries;

--- a/mysql-test/mroonga/storage/column/groonga/scalar/r/zlib.result
+++ b/mysql-test/mroonga/storage/column/groonga/scalar/r/zlib.result
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS entries;
+CREATE TABLE entries (
+id INT UNSIGNED PRIMARY KEY,
+content TEXT COMMENT 'flags "COLUMN_SCALAR|COMPRESS_ZLIB"'
+) DEFAULT CHARSET=utf8;
+INSERT INTO entries (id, content) VALUES (1, "I found Mroonga that is a MySQL storage engine to use Groonga!");
+SELECT * FROM entries;
+id	content
+1	I found Mroonga that is a MySQL storage engine to use Groonga!
+DROP TABLE entries;

--- a/mysql-test/mroonga/storage/column/groonga/scalar/t/lz4.test
+++ b/mysql-test/mroonga/storage/column/groonga/scalar/t/lz4.test
@@ -1,0 +1,36 @@
+# Copyright(C) 2014  Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS entries;
+--enable_warnings
+
+CREATE TABLE entries (
+  id INT UNSIGNED PRIMARY KEY,
+  content TEXT COMMENT 'flags "COLUMN_SCALAR|COMPRESS_LZ4"'
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO entries (id, content) VALUES (1, "I found Mroonga that is a MySQL storage engine to use Groonga!");
+
+SELECT * FROM entries;
+
+DROP TABLE entries;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/groonga/scalar/t/zlib.test
+++ b/mysql-test/mroonga/storage/column/groonga/scalar/t/zlib.test
@@ -1,0 +1,36 @@
+# Copyright(C) 2014  Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS entries;
+--enable_warnings
+
+CREATE TABLE entries (
+  id INT UNSIGNED PRIMARY KEY,
+  content TEXT COMMENT 'flags "COLUMN_SCALAR|COMPRESS_ZLIB"'
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO entries (id, content) VALUES (1, "I found Mroonga that is a MySQL storage engine to use Groonga!");
+
+SELECT * FROM entries;
+
+DROP TABLE entries;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
This change supports column compression flags.
- `COMPRESS_ZLIB` 
- `COMPRESS_LZ4`
### Example

``` sql
CREATE TABLE entries (
  id INT UNSIGNED PRIMARY KEY,
  content TEXT COMMENT 'flags "COLUMN_SCALAR|COMPRESS_ZLIB"'
) Engine=Mroonga DEFAULT CHARSET=utf8;
```
