### PR TITLE
Support specifying options by table comment when primary key is using hash

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -3027,7 +3027,8 @@ int ha_mroonga::storage_create(const char *name, TABLE *table,
     DBUG_RETURN(error);
   }
 
-  if (table_flags == (GRN_OBJ_PERSISTENT | GRN_OBJ_TABLE_PAT_KEY)) {
+  if (table_flags == (GRN_OBJ_PERSISTENT | GRN_OBJ_TABLE_PAT_KEY) ||
+      table_flags == (GRN_OBJ_PERSISTENT | GRN_OBJ_TABLE_HASH_KEY)) {
     KEY key_info = table->s->key_info[pkey_nr];
     int key_parts = KEY_N_KEY_PARTS(&key_info);
     if (key_parts == 1) {

--- a/mysql-test/mroonga/storage/create/table/normalizer/primary_key/r/table_comment_with_using_hash.result
+++ b/mysql-test/mroonga/storage/create/table/normalizer/primary_key/r/table_comment_with_using_hash.result
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS memos;
+DROP TABLE IF EXISTS terms;
+SET NAMES utf8;
+CREATE TABLE terms (
+term VARCHAR(64) NOT NULL,
+PRIMARY KEY (term) USING HASH
+) COMMENT='default_tokenizer "TokenBigram", normalizer "NormalizerAuto"' DEFAULT CHARSET=utf8;
+CREATE TABLE memos (
+id INT NOT NULL PRIMARY KEY,
+content TEXT NOT NULL,
+FULLTEXT INDEX (content) COMMENT 'table "terms"'
+) DEFAULT CHARSET=utf8;
+INSERT INTO memos VALUES (1, "1日の消費㌍は約2000㌔㌍");
+SELECT * FROM memos
+WHERE MATCH (content) AGAINST ("+カロリー" IN BOOLEAN MODE);
+id	content
+1	1日の消費㌍は約2000㌔㌍
+DROP TABLE memos;
+DROP TABLE terms;

--- a/mysql-test/mroonga/storage/create/table/normalizer/primary_key/t/table_comment_with_using_hash.test
+++ b/mysql-test/mroonga/storage/create/table/normalizer/primary_key/t/table_comment_with_using_hash.test
@@ -1,0 +1,47 @@
+# Copyright(C) 2015  Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS memos;
+DROP TABLE IF EXISTS terms;
+--enable_warnings
+
+SET NAMES utf8;
+
+CREATE TABLE terms (
+  term VARCHAR(64) NOT NULL,
+  PRIMARY KEY (term) USING HASH
+) COMMENT='default_tokenizer "TokenBigram", normalizer "NormalizerAuto"' DEFAULT CHARSET=utf8;
+
+CREATE TABLE memos (
+  id INT NOT NULL PRIMARY KEY,
+  content TEXT NOT NULL,
+  FULLTEXT INDEX (content) COMMENT 'table "terms"'
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO memos VALUES (1, "1日の消費㌍は約2000㌔㌍");
+
+SELECT * FROM memos
+  WHERE MATCH (content) AGAINST ("+カロリー" IN BOOLEAN MODE);
+
+DROP TABLE memos;
+DROP TABLE terms;
+
+--source ../../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
``USING HASH``でハッシュキーのテーブルを作る場合にも、テーブルコメントを使ったノーマライザーなどを変更する方法が使いたいです。

ご検討ください。