### PR TITLE
Fix wrong keyword length when query include pragma

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -8089,7 +8089,7 @@ grn_rc ha_mroonga::generic_ft_init_ext_prepare_expression_in_boolean_mode(
     bool parsed = false;
     bool done = false;
     keyword++;
-    keyword_length++;
+    keyword_length--;
     while (!done) {
       uint consumed_keyword_length = 0;
       switch (keyword[0]) {

--- a/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/default_operator/plus/r/with_astarisk.result
+++ b/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/default_operator/plus/r/with_astarisk.result
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS memos;
+SET NAMES utf8;
+CREATE TABLE memos (
+content TEXT,
+FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8;
+INSERT INTO memos VALUES ("Today is good day.");
+INSERT INTO memos VALUES ("Tomorrow will be good day.");
+INSERT INTO memos VALUES ("Today is fine.");
+SELECT * FROM memos
+WHERE MATCH (content) AGAINST ("*D+ today fi*" IN BOOLEAN MODE);
+content
+Today is fine.
+DROP TABLE memos;

--- a/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/default_operator/plus/t/with_astarisk.test
+++ b/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/default_operator/plus/t/with_astarisk.test
@@ -1,0 +1,38 @@
+# Copyright(C) 2015  Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS memos;
+--enable_warnings
+
+SET NAMES utf8;
+CREATE TABLE memos (
+  content TEXT,
+  FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO memos VALUES ("Today is good day.");
+INSERT INTO memos VALUES ("Tomorrow will be good day.");
+INSERT INTO memos VALUES ("Today is fine.");
+
+SELECT * FROM memos
+         WHERE MATCH (content) AGAINST ("*D+ today fi*" IN BOOLEAN MODE);
+
+DROP TABLE memos;
+
+--source ../../../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
そのときのメモリの状況にもよるかもしれませんが、プラグマを使って*でおわるような場合、うまく検索できないことがあります。

プラグマが含まれているときのクエリの長さが2バイト多いような気がしましたので修正しました。

ご検討ください。