### PR TITLE
Fix mysql57-community-mroonga's installation issue.

### DIFF
--- a/packages/rpm/centos/mysql57-community-mroonga.spec.in
+++ b/packages/rpm/centos/mysql57-community-mroonga.spec.in
@@ -24,7 +24,7 @@
 
 Name:		mysql57-community-mroonga
 Version:	@VERSION@
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	A fast fulltext searchable storage engine for MySQL
 
 Group:		Applications/Databases
@@ -107,6 +107,7 @@ rm -rf $RPM_BUILD_ROOT
 if ! /sbin/service mysqld status > /dev/null; then
   /sbin/service mysqld start
   stop_after_installation=1
+  export MYSQL_PWD=`awk '/root@localhost/{print $NF}' /var/log/mysqld.log`
 else
   stop_after_installation=0
 fi
@@ -143,6 +144,12 @@ if [ "$1" = 2 ] ; then
 	     echo "  $command")
     fi
 fi
+
+if [ -n "$password_option" -a "$stop_after_installation" = "1" ]; then
+  $mysql_command -u root --connect-expired-password -e "ALTER USER user() IDENTIFIED BY '$MYSQL_PWD'"
+  password_option=""
+fi
+
 command="$mysql_command -u root $password_option < ${install_sql}"
 echo $command
 eval $command || \
@@ -150,6 +157,8 @@ eval $command || \
 	 echo "  $command")
 
 if [ "$stop_after_installation" = "1" ]; then
+  $mysql_command -u root -e "ALTER USER root@localhost PASSWORD EXPIRE"
+  unset MYSQL_PWD
   /sbin/service mysqld stop
 fi
 


### PR DESCRIPTION
This is patch for #77 

  - Login and update password using same password string.
    Because of autogenerated password is expired by default.
  - INSTALL PLUGIN using autogenerated password.
  - Expire password for resetting to fresh installed environment.