### PR TITLE
Omit error messages when checking whether root is password protected or not

### DIFF
--- a/packages/rpm/centos/mariadb-mroonga.spec.in
+++ b/packages/rpm/centos/mariadb-mroonga.spec.in
@@ -86,7 +86,7 @@ mv $RPM_BUILD_ROOT%{_datadir}/doc/mroonga/ mysql-mroonga-doc/
 rm -rf $RPM_BUILD_ROOT
 
 %post
-if /usr/bin/mysql -u root -e "quit"; then
+if /usr/bin/mysql -u root -e "quit" > /dev/null 2>&1; then
   password_option=""
 else
   password_option="-p"
@@ -128,7 +128,7 @@ eval $command || \
 %preun
 uninstall_sql=%{_datadir}/mroonga/uninstall.sql
 
-if mysql -u root -e "quit"; then
+if mysql -u root -e "quit" > /dev/null 2>&1; then
   password_option=""
 else
   password_option="-p"


### PR DESCRIPTION
In current version of `mariadb-mroonga.spec`, there is no both stdout and stderr output redirection to /dev/null when running mysql to determine if -p option is needed. Therefore if root account is password protected, the install script prints `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: NO)`. This kind of error message makes users a bit confusing and to think the installation was unsuccessful even though `Enter password:` prompt follows.

One more thing which didn't patch in this PR is that in the install script, it seems it checks mroonga version (through mysql command) without any password option specified even if `$password_option` is set. This also seems need to be fixed.