### PR TITLE
Support Syntax Script pragma

### DIFF
--- a/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/r/operator.result
+++ b/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/r/operator.result
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS diaries;
+SET NAMES utf8;
+CREATE TABLE diaries (
+id INT PRIMARY KEY,
+title VARCHAR(255),
+content TEXT,
+FULLTEXT INDEX (title, content)
+) DEFAULT CHARSET=utf8;
+INSERT INTO diaries VALUES(1, "Hello", "今日からはじめました。");
+INSERT INTO diaries VALUES(2, "天気", "明日の富士山の天気について");
+INSERT INTO diaries VALUES(3, "富士山", "今日も天気がよくてきれいに見える。");
+SELECT *, MATCH(title, content)
+AGAINST("*SS content @ '天気'" in BOOLEAN MODE) AS score
+FROM diaries
+WHERE MATCH(title, content)
+AGAINST("*SS content @ '天気'" in BOOLEAN MODE);
+id	title	content	score
+2	天気	明日の富士山の天気について	1
+3	富士山	今日も天気がよくてきれいに見える。	1
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/r/selector.result
+++ b/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/r/selector.result
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS items;
+DROP TABLE IF EXISTS readings;
+SET NAMES utf8;
+CREATE TABLE readings (
+reading VARCHAR(255) PRIMARY KEY
+) DEFAULT CHARSET=utf8
+COLLATE=utf8_bin
+COMMENT='default_tokenizer "TokenDelimit"';
+CREATE TABLE items (
+name VARCHAR(255) PRIMARY KEY,
+readings TEXT COMMENT 'flags "COLUMN_VECTOR", type "readings"',
+FULLTEXT INDEX items_index(readings) COMMENT 'table "readings"'
+) DEFAULT CHARSET=utf8;
+INSERT INTO items VALUES("日本", "ニホン ニッポン");
+INSERT INTO items VALUES("ローマ字", "ローマジ");
+INSERT INTO items VALUES("漢字", "カンジ");
+SELECT *, MATCH(readings)
+AGAINST("*SS sub_filter(readings, 'prefix_rk_search(_key, \"niho\")')" in BOOLEAN MODE) AS score
+FROM items
+WHERE MATCH(readings)
+AGAINST("*SS sub_filter(readings, 'prefix_rk_search(_key, \"niho\")')" in BOOLEAN MODE);
+name	readings	score
+日本	ニホン ニッポン	1
+DROP TABLE items;
+DROP TABLE readings;

--- a/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/t/operator.test
+++ b/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/t/operator.test
@@ -1,0 +1,43 @@
+# Copyright(C) 2016 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+SET NAMES utf8;
+CREATE TABLE diaries (
+  id INT PRIMARY KEY,
+  title VARCHAR(255),
+  content TEXT,
+  FULLTEXT INDEX (title, content)
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO diaries VALUES(1, "Hello", "今日からはじめました。");
+INSERT INTO diaries VALUES(2, "天気", "明日の富士山の天気について");
+INSERT INTO diaries VALUES(3, "富士山", "今日も天気がよくてきれいに見える。");
+
+SELECT *, MATCH(title, content)
+          AGAINST("*SS content @ '天気'" in BOOLEAN MODE) AS score
+       FROM diaries
+       WHERE MATCH(title, content)
+             AGAINST("*SS content @ '天気'" in BOOLEAN MODE);
+
+DROP TABLE diaries;
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/t/selector.test
+++ b/mysql-test/mroonga/storage/fulltext/boolean_mode/pragma/syntax_script/t/selector.test
@@ -1,0 +1,50 @@
+# Copyright(C) 2016 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS items;
+DROP TABLE IF EXISTS readings;
+--enable_warnings
+
+SET NAMES utf8;
+CREATE TABLE readings (
+  reading VARCHAR(255) PRIMARY KEY
+) DEFAULT CHARSET=utf8
+  COLLATE=utf8_bin
+  COMMENT='default_tokenizer "TokenDelimit"';
+
+CREATE TABLE items (
+  name VARCHAR(255) PRIMARY KEY,
+  readings TEXT COMMENT 'flags "COLUMN_VECTOR", type "readings"',
+  FULLTEXT INDEX items_index(readings) COMMENT 'table "readings"'
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO items VALUES("日本", "ニホン ニッポン");
+INSERT INTO items VALUES("ローマ字", "ローマジ");
+INSERT INTO items VALUES("漢字", "カンジ");
+
+SELECT *, MATCH(readings)
+          AGAINST("*SS sub_filter(readings, 'prefix_rk_search(_key, \"niho\")')" in BOOLEAN MODE) AS score
+       FROM items
+       WHERE MATCH(readings)
+             AGAINST("*SS sub_filter(readings, 'prefix_rk_search(_key, \"niho\")')" in BOOLEAN MODE);
+
+DROP TABLE items;
+DROP TABLE readings;
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
I want to use  [Script syntax](http://groonga.org/docs/reference/grn_expr/script_syntax.html) by specifying ``*SS`` pragma.

The following is example for using [prefix_rk_search](http://groonga.org/docs/reference/functions/prefix_rk_search.html).

```sql
CREATE TABLE readings (
reading VARCHAR(255) PRIMARY KEY
) DEFAULT CHARSET=utf8
COLLATE=utf8_bin
COMMENT='default_tokenizer "TokenDelimit"';

CREATE TABLE items (
name VARCHAR(255) PRIMARY KEY,
readings TEXT COMMENT 'flags "COLUMN_VECTOR", type "readings"',
FULLTEXT INDEX items_index(readings) COMMENT 'table "readings"'
) DEFAULT CHARSET=utf8;

INSERT INTO items VALUES("日本", "ニホン ニッポン");
INSERT INTO items VALUES("ローマ字", "ローマジ");
INSERT INTO items VALUES("漢字", "カンジ");

SELECT *,
MATCH(readings)
AGAINST("*SS sub_filter(readings, 'prefix_rk_search(_key, \"niho\")')" in BOOLEAN MODE) AS score
FROM items
WHERE
MATCH(readings)
AGAINST("*SS sub_filter(readings, 'prefix_rk_search(_key, \"niho\")')" in BOOLEAN MODE);
name	readings	score
日本	ニホン ニッポン	1
```