### PR TITLE
storage: convert mysql57's json type to Groonga's vector column

### DIFF
--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -664,9 +664,9 @@ private:
   int generic_store_bulk_blob(Field *field, grn_obj *buf);
   int generic_store_bulk_geometry(Field *field, grn_obj *buf);
 #ifdef MRN_HAVE_MYSQL_TYPE_JSON
-  int generic_store_bulk_json(Field *field, grn_obj *buf);
+  int generic_store_bulk_json(Field *field, grn_obj *buf, int nth_column);
 #endif
-  int generic_store_bulk(Field *field, grn_obj *buf);
+  int generic_store_bulk(Field *field, grn_obj *buf, int nth_column);
 
   void storage_store_field_string(Field *field,
                                   const char *value, uint value_length);

--- a/lib/mrn_grn.hpp
+++ b/lib/mrn_grn.hpp
@@ -33,6 +33,10 @@ namespace mrn {
       int column_type = (column->header.flags & GRN_OBJ_COLUMN_TYPE_MASK);
       return column_type == GRN_OBJ_COLUMN_VECTOR;
     }
+
+    bool is_weight_column(grn_obj *column) {
+      return column->header.flags & GRN_OBJ_WITH_WEIGHT;
+    }
   }
 }
 

--- a/mysql-test/mroonga/storage/column/groonga/json/r/int_vector.result
+++ b/mysql-test/mroonga/storage/column/groonga/json/r/int_vector.result
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+int_vector JSON COMMENT 'flags "COLUMN_VECTOR", type "Int64"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(int_vector) VALUES('[1, 10, 100]');
+SELECT * FROM logs;
+int_vector
+[1, 10, 100]
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+mroonga_command("dump --dump_plugins no --dump_records no")
+table_create mroonga_operations TABLE_NO_KEY
+column_create mroonga_operations record COLUMN_SCALAR UInt32
+column_create mroonga_operations table COLUMN_SCALAR ShortText
+column_create mroonga_operations type COLUMN_SCALAR ShortText
+
+table_create logs TABLE_NO_KEY
+column_create logs int_vector COLUMN_VECTOR Int64
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/groonga/json/r/text_reference_vector.result
+++ b/mysql-test/mroonga/storage/column/groonga/json/r/text_reference_vector.result
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+weight_reference_vector JSON COMMENT 'flags "COLUMN_VECTOR", type "ShortText"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(weight_reference_vector) VALUES('["start", "restart", "shutdown"]');
+SELECT * FROM logs;
+weight_reference_vector
+["start", "restart", "shutdown"]
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+mroonga_command("dump --dump_plugins no --dump_records no")
+table_create mroonga_operations TABLE_NO_KEY
+column_create mroonga_operations record COLUMN_SCALAR UInt32
+column_create mroonga_operations table COLUMN_SCALAR ShortText
+column_create mroonga_operations type COLUMN_SCALAR ShortText
+
+table_create logs TABLE_NO_KEY
+column_create logs weight_reference_vector COLUMN_VECTOR ShortText
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/groonga/json/r/text_vector.result
+++ b/mysql-test/mroonga/storage/column/groonga/json/r/text_vector.result
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+text_vector JSON COMMENT 'flags "COLUMN_VECTOR", type "ShortText"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(text_vector) VALUES('["start", "restart", "shutdown"]');
+SELECT * FROM logs;
+text_vector
+["start", "restart", "shutdown"]
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+mroonga_command("dump --dump_plugins no --dump_records no")
+table_create mroonga_operations TABLE_NO_KEY
+column_create mroonga_operations record COLUMN_SCALAR UInt32
+column_create mroonga_operations table COLUMN_SCALAR ShortText
+column_create mroonga_operations type COLUMN_SCALAR ShortText
+
+table_create logs TABLE_NO_KEY
+column_create logs text_vector COLUMN_VECTOR ShortText
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/groonga/json/r/weight_reference_vector.result
+++ b/mysql-test/mroonga/storage/column/groonga/json/r/weight_reference_vector.result
@@ -1,0 +1,27 @@
+DROP TABLE IF EXISTS logs;
+DROP TABLE IF EXISTS tags;
+CREATE TABLE tags (
+name VARCHAR(255) PRIMARY KEY
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+CREATE TABLE logs (
+weight_reference_vector JSON COMMENT 'flags "COLUMN_VECTOR|WITH_WEIGHT", type "tags"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(weight_reference_vector) VALUES('{"start": 1, "restart": 10, "shutdown": 1}');
+SELECT * FROM logs;
+weight_reference_vector
+{"START": 1, "RESTART": 10, "SHUTDOWN": 1}
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+mroonga_command("dump --dump_plugins no --dump_records no")
+table_create mroonga_operations TABLE_NO_KEY
+column_create mroonga_operations record COLUMN_SCALAR UInt32
+column_create mroonga_operations table COLUMN_SCALAR ShortText
+column_create mroonga_operations type COLUMN_SCALAR ShortText
+
+table_create tags TABLE_PAT_KEY ShortText --normalizer NormalizerMySQLGeneralCI
+column_create tags name COLUMN_SCALAR ShortText
+
+table_create logs TABLE_NO_KEY
+
+column_create logs weight_reference_vector COLUMN_VECTOR|WITH_WEIGHT tags
+DROP TABLE logs;
+DROP TABLE IF EXISTS tags;

--- a/mysql-test/mroonga/storage/column/groonga/json/r/weight_vector.result
+++ b/mysql-test/mroonga/storage/column/groonga/json/r/weight_vector.result
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+weight_vector JSON COMMENT 'flags "COLUMN_VECTOR|WITH_WEIGHT", type "ShortText"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(weight_vector) VALUES('{"start": 1, "restart": 10, "shutdown": 1}');
+SELECT * FROM logs;
+weight_vector
+{"start": 1, "restart": 10, "shutdown": 1}
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+mroonga_command("dump --dump_plugins no --dump_records no")
+table_create mroonga_operations TABLE_NO_KEY
+column_create mroonga_operations record COLUMN_SCALAR UInt32
+column_create mroonga_operations table COLUMN_SCALAR ShortText
+column_create mroonga_operations type COLUMN_SCALAR ShortText
+
+table_create logs TABLE_NO_KEY
+column_create logs weight_vector COLUMN_VECTOR|WITH_WEIGHT ShortText
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/groonga/json/t/int_vector.test
+++ b/mysql-test/mroonga/storage/column/groonga/json/t/int_vector.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2016 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_version_57_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_100_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  int_vector JSON COMMENT 'flags "COLUMN_VECTOR", type "Int64"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(int_vector) VALUES('[1, 10, 100]');
+
+SELECT * FROM logs;
+
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/groonga/json/t/text_reference_vector.test
+++ b/mysql-test/mroonga/storage/column/groonga/json/t/text_reference_vector.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2016 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_version_57_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_100_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  weight_reference_vector JSON COMMENT 'flags "COLUMN_VECTOR", type "ShortText"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(weight_reference_vector) VALUES('["start", "restart", "shutdown"]');
+
+SELECT * FROM logs;
+
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/groonga/json/t/text_vector.test
+++ b/mysql-test/mroonga/storage/column/groonga/json/t/text_vector.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2016 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_version_57_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_100_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  text_vector JSON COMMENT 'flags "COLUMN_VECTOR", type "ShortText"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(text_vector) VALUES('["start", "restart", "shutdown"]');
+
+SELECT * FROM logs;
+
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/groonga/json/t/weight_reference_vector.test
+++ b/mysql-test/mroonga/storage/column/groonga/json/t/weight_reference_vector.test
@@ -1,0 +1,45 @@
+# Copyright(C) 2016 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_version_57_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_100_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+DROP TABLE IF EXISTS tags;
+--enable_warnings
+
+CREATE TABLE tags (
+  name VARCHAR(255) PRIMARY KEY
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE logs (
+  weight_reference_vector JSON COMMENT 'flags "COLUMN_VECTOR|WITH_WEIGHT", type "tags"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(weight_reference_vector) VALUES('{"start": 1, "restart": 10, "shutdown": 1}');
+
+SELECT * FROM logs;
+
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+
+DROP TABLE logs;
+DROP TABLE IF EXISTS tags;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/groonga/json/t/weight_vector.test
+++ b/mysql-test/mroonga/storage/column/groonga/json/t/weight_vector.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2016 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+--source ../../../../../include/mroonga/have_version_57_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_100_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  weight_vector JSON COMMENT 'flags "COLUMN_VECTOR|WITH_WEIGHT", type "ShortText"'
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(weight_vector) VALUES('{"start": 1, "restart": 10, "shutdown": 1}');
+
+SELECT * FROM logs;
+
+SELECT mroonga_command("dump --dump_plugins no --dump_records no");
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
I implemented convert mysql57's JSON type field to Groonga's vector column and weight vector column.
This implementation be able to create vector column and weight vector column from MySQL.

How about this implementation?
Currently,  the JSON type doesn't allow any index.
https://github.com/mysql/mysql-server/blob/5.7/sql/sql_table.cc#L4149-L4154
So, It can't be create index to the JSON type field for now...
