### PR TITLE
Add warning about deprecated using keyword "parser"

### DIFF
--- a/mrn_table.cpp
+++ b/mrn_table.cpp
@@ -516,6 +516,7 @@ int mrn_add_index_param(MRN_SHARE *share, KEY *key_info, int i)
   char *sprit_ptr[2];
   char *tmp_ptr, *start_ptr;
 #endif
+  THD *thd = current_thd;
   MRN_DBUG_ENTER_FUNCTION();
 
 #if MYSQL_VERSION_ID >= 50500
@@ -578,6 +579,10 @@ int mrn_add_index_param(MRN_SHARE *share, KEY *key_info, int i)
         MRN_PARAM_STR_LIST("table", index_table, i);
         break;
       case 6:
+        push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN, 
+                            ER_WARN_DEPRECATED_SYNTAX,
+                            ER(ER_WARN_DEPRECATED_SYNTAX),
+                            "parser", "tokenizer");
         MRN_PARAM_STR_LIST("parser", key_tokenizer, i);
         break;
       case 9:


### PR DESCRIPTION
Mroonga 5.04 introduced new keyword to specify a tokeninzer on Full Text Index.
http://mroonga.org/ja/docs/news.html#release-5-04

Release note says "parser" keyword had been deprecated and able to use until Mroonga 6.X.X.
Do you mean "parser" keyword will be removed in Mroonga 7.00?
(I seem "default_parser" had been already removed.)


The patch to add warning when using "parser" keyword.
This behaves like following.

```
mysql56> create table t4 (num serial, val varchar(32), FULLTEXT KEY (val) Comment 'parser "TokenBigram"') Engine Mroonga;
Query OK, 0 rows affected, 1 warning (0.06 sec)

mysql56> show warnings;
+---------+------+----------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                      |
+---------+------+----------------------------------------------------------------------------------------------+
| Warning | 1287 | 'parser' is deprecated and will be removed in a future release. Please use tokenizer instead |
+---------+------+----------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```