### PR TITLE
doc developer release: Use Visual Studio 12(2013) in building instruction in Windows

### DIFF
--- a/doc/source/developer/release.rst
+++ b/doc/source/developer/release.rst
@@ -249,7 +249,7 @@ zip 展開機能はとても遅いので 7-zip などを使いましょう。展
 
  > mkdir build-32
  > cd build-32
- > cmake ..\source -G "Visual Studio 10" > config.log
+ > cmake ..\source -G "Visual Studio 12" > config.log
  > cmake --build . --config RelWithDebInfo > build.log
  > cmake --build . --config RelWithDebInfo --target msi > msi.log
  > move *.msi ..\
@@ -258,7 +258,7 @@ zip 展開機能はとても遅いので 7-zip などを使いましょう。展
  > cd ..
  > mkdir build-64
  > cd build-64
- > cmake ..\source -G "Visual Studio 10 Win64" > config.log
+ > cmake ..\source -G "Visual Studio 12 Win64" > config.log
  > cmake --build . --config RelWithDebInfo > build.log
  > cmake --build . --config RelWithDebInfo --target msi > msi.log
  > move *.msi ..\


### PR DESCRIPTION
We should use Visual Studio 12(2013) instead of Visual Studio 10(2010) in documents!