### PR TITLE
cmake: add missing link to libgroonga  when mroonga is bundled and libgroonga isn't bundled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ else()
   set(MRN_LIBRARY_DIRS
     ${MRN_LIBRARY_DIRS}
     ${GROONGA_LIBRARY_DIRS})
+  set(MRN_LIBRARIES ${GROONGA_LIBRARIES})
 endif()
 
 include_directories(


### PR DESCRIPTION
It seems there isn't link to libgroonga.so when mroonga is bundled and libgroonga isn't bundled.
Maybe you are not providing this case but I want to bundle mroonga to MySQL without libgroonga for my purpose.