### PR TITLE
Support INDEX_MEDIUM/INDEX_SMALL

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1520,7 +1520,7 @@ static bool mrn_parse_grn_index_column_flags(THD *thd,
                                              grn_ctx *ctx,
                                              const char *flag_names,
                                              uint flag_names_length,
-                                             grn_obj_flags *index_column_flags)
+                                             grn_column_flags *index_column_flags)
 {
   const char *flag_names_end = flag_names + flag_names_length;
   bool found = false;
@@ -1546,6 +1546,14 @@ static bool mrn_parse_grn_index_column_flags(THD *thd,
     } else if (rest_length >= 11 && !memcmp(flag_names, "WITH_WEIGHT", 11)) {
       *index_column_flags |= GRN_OBJ_WITH_WEIGHT;
       flag_names += 11;
+      found = true;
+    } else if (rest_length >= 11 && !memcmp(flag_names, "INDEX_SMALL", 11)) {
+      *index_column_flags |= GRN_OBJ_INDEX_SMALL;
+      flag_names += 11;
+      found = true;
+    } else if (rest_length >= 12 && !memcmp(flag_names, "INDEX_MEDIUM", 12)) {
+      *index_column_flags |= GRN_OBJ_INDEX_MEDIUM;
+      flag_names += 12;
       found = true;
     } else {
       char invalid_flag_name[MRN_MESSAGE_BUFFER_SIZE];
@@ -3042,7 +3050,7 @@ int ha_mroonga::wrapper_create_index_fulltext(const char *grn_table_name,
     GRN_OBJ_PERSISTENT;
   grn_obj *index_table;
 
-  grn_obj_flags index_column_flags = GRN_OBJ_COLUMN_INDEX | GRN_OBJ_PERSISTENT;
+  grn_column_flags index_column_flags = GRN_OBJ_COLUMN_INDEX | GRN_OBJ_PERSISTENT;
 
   if (!find_index_column_flags(key_info, &index_column_flags)) {
     index_column_flags |= GRN_OBJ_WITH_POSITION;
@@ -3851,7 +3859,7 @@ int ha_mroonga::storage_create_index(TABLE *table, const char *grn_table_name,
 
   grn_obj *index_table = index_tables[i];
 
-  grn_obj_flags index_column_flags = GRN_OBJ_COLUMN_INDEX | GRN_OBJ_PERSISTENT;
+  grn_column_flags index_column_flags = GRN_OBJ_COLUMN_INDEX | GRN_OBJ_PERSISTENT;
 
   if (!find_index_column_flags(key_info, &index_column_flags)) {
     grn_obj *tokenizer = grn_obj_get_info(ctx, index_table,
@@ -9766,7 +9774,7 @@ grn_obj *ha_mroonga::find_normalizer(KEY *key, const char *name)
   DBUG_RETURN(normalizer);
 }
 
-bool ha_mroonga::find_index_column_flags(KEY *key, grn_obj_flags *index_column_flags)
+bool ha_mroonga::find_index_column_flags(KEY *key, grn_column_flags *index_column_flags)
 {
   MRN_DBUG_ENTER_METHOD();
   bool found = false;

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -632,7 +632,7 @@ private:
   bool have_custom_normalizer(KEY *key) const;
   grn_obj *find_normalizer(KEY *key);
   grn_obj *find_normalizer(KEY *key, const char *name);
-  bool find_index_column_flags(KEY *key, grn_obj_flags *index_column_flags);
+  bool find_index_column_flags(KEY *key, grn_column_flags *index_column_flags);
   bool find_token_filters(KEY *key, grn_obj *token_filters);
   bool find_token_filters_put(grn_obj *token_filters,
                               const char *token_filter_name,

--- a/mysql-test/mroonga/storage/create/table/index/flags/r/index_medium.result
+++ b/mysql-test/mroonga/storage/create/table/index/flags/r/index_medium.result
@@ -1,0 +1,10 @@
+SET NAMES utf8;
+CREATE TABLE memos (
+content VARCHAR(64) NOT NULL,
+content_size INT NOT NULL,
+KEY (content_size) COMMENT 'flags "INDEX_MEDIUM"'
+) DEFAULT CHARSET=utf8;
+SELECT mroonga_command("dump --dump_plugins no --dump_schema no");
+mroonga_command("dump --dump_plugins no --dump_schema no")
+column_create memos#content_size index COLUMN_INDEX|INDEX_MEDIUM memos content_size
+DROP TABLE memos;

--- a/mysql-test/mroonga/storage/create/table/index/flags/r/index_small.result
+++ b/mysql-test/mroonga/storage/create/table/index/flags/r/index_small.result
@@ -1,0 +1,10 @@
+SET NAMES utf8;
+CREATE TABLE memos (
+content VARCHAR(64) NOT NULL,
+is_read BOOL NOT NULL,
+KEY (is_read) COMMENT 'flags "INDEX_SMALL"'
+) DEFAULT CHARSET=utf8;
+SELECT mroonga_command("dump --dump_plugins no --dump_schema no");
+mroonga_command("dump --dump_plugins no --dump_schema no")
+column_create memos#is_read index COLUMN_INDEX|INDEX_SMALL memos is_read
+DROP TABLE memos;

--- a/mysql-test/mroonga/storage/create/table/index/flags/t/index_medium.test
+++ b/mysql-test/mroonga/storage/create/table/index/flags/t/index_medium.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2017  Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_query_log
+DROP DATABASE test;
+CREATE DATABASE test;
+USE test;
+--enable_query_log
+
+SET NAMES utf8;
+
+CREATE TABLE memos (
+  content VARCHAR(64) NOT NULL,
+  content_size INT NOT NULL,
+  KEY (content_size) COMMENT 'flags "INDEX_MEDIUM"'
+) DEFAULT CHARSET=utf8;
+
+SELECT mroonga_command("dump --dump_plugins no --dump_schema no");
+
+DROP TABLE memos;
+
+--source ../../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/create/table/index/flags/t/index_small.test
+++ b/mysql-test/mroonga/storage/create/table/index/flags/t/index_small.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2017  Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_query_log
+DROP DATABASE test;
+CREATE DATABASE test;
+USE test;
+--enable_query_log
+
+SET NAMES utf8;
+
+CREATE TABLE memos (
+  content VARCHAR(64) NOT NULL,
+  is_read BOOL NOT NULL,
+  KEY (is_read) COMMENT 'flags "INDEX_SMALL"'
+) DEFAULT CHARSET=utf8;
+
+SELECT mroonga_command("dump --dump_plugins no --dump_schema no");
+
+DROP TABLE memos;
+
+--source ../../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
I would like to use ``GRN_OBJ_INDEX_MEDIUM`` flags on Mroonga to optimize memory usage for index of int column.