### PR TITLE
Add mroonga_operations_disable_recording variable

### DIFF
--- a/doc/source/reference/server_variables.rst
+++ b/doc/source/reference/server_variables.rst
@@ -471,6 +471,33 @@ value.
 
 TODO:
 
+.. _server-variable-mroonga-enable-operations-recording:
+
+``mroonga_enable_operations_recording``
+---------------------------------------
+
+Whether recording operations for recover is enabled or not. 
+The default value is ``ON`` that means operations are recording 
+to Groonga database. 
+It needs to reopen the database with `` FLUSH TABLES`` in order 
+to reflect the variable is changed.
+
+Here is an example SQL to disable operations recording::
+
+
+  mysql> SET GLOBAL mroonga_enable_operations_recording = false;
+  Query OK, 0 rows affected (0.00 sec)
+
+  mysql> FLUSH TABLES;
+  Query OK, 0 rows affected (0.00 sec)
+
+  mysql> SHOW GLOBAL VARIABLES LIKE 'mroonga_enable_operations_recording';
+  +-------------------------------------+-------+
+  | Variable_name                       | Value |
+  +-------------------------------------+-------+
+  | mroonga_enable_operations_recording | OFF   |
+  +-------------------------------------+-------+
+
 .. _server-variable-mroonga-vector-column-delimiter:
 
 ``mroonga_vector_column_delimiter``

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -623,6 +623,7 @@ static char *mrn_vector_column_delimiter = NULL;
 static mrn_bool mrn_libgroonga_support_zlib = false;
 static mrn_bool mrn_libgroonga_support_lz4 = false;
 static mrn_bool mrn_libgroonga_support_zstd = false;
+static mrn_bool mrn_enable_operations_recording = true;
 #ifdef MRN_SUPPORT_THDVAR_SET
 static const char *mrn_boolean_mode_sytnax_flag_names[] = {
   "DEFAULT",
@@ -1165,6 +1166,25 @@ static MYSQL_SYSVAR_BOOL(libgroonga_support_zstd, mrn_libgroonga_support_zstd,
                          NULL,
                          grn_check_zstd_support());
 
+static void mrn_enable_operations_recording_update(THD *thd, struct st_mysql_sys_var *var,
+                                                   void *var_ptr, const void *save)
+{
+  MRN_DBUG_ENTER_FUNCTION();
+  const bool new_value = *static_cast<const bool *>(save);
+  bool *old_value_ptr = static_cast<bool *>(var_ptr);
+
+  *old_value_ptr = new_value;
+
+  DBUG_VOID_RETURN;
+}
+
+static MYSQL_SYSVAR_BOOL(enable_operations_recording, mrn_enable_operations_recording,
+                         PLUGIN_VAR_RQCMDARG,
+                         "Whether recording operations for recovery is enabled or not",
+                         NULL,
+                         mrn_enable_operations_recording_update,
+                         true);
+
 #ifdef MRN_SUPPORT_THDVAR_SET
 static MYSQL_THDVAR_SET(boolean_mode_syntax_flags,
                         PLUGIN_VAR_RQCMDARG,
@@ -1224,6 +1244,7 @@ static struct st_mysql_sys_var *mrn_system_variables[] =
   MYSQL_SYSVAR(max_n_records_for_estimate),
   MYSQL_SYSVAR(libgroonga_embedded),
   MYSQL_SYSVAR(query_log_file),
+  MYSQL_SYSVAR(enable_operations_recording),
   NULL
 };
 
@@ -4110,6 +4131,11 @@ int ha_mroonga::ensure_database_open(const char *name, mrn::Database **db)
 
   delete operations_;
   operations_ = new mrn::Operations(ctx);
+  if (mrn_enable_operations_recording) {
+    operations_->enable_recording();
+  } else {
+    operations_->disable_recording();
+  }
 
   DBUG_RETURN(error);
 }

--- a/lib/mrn_operations.cpp
+++ b/lib/mrn_operations.cpp
@@ -70,6 +70,8 @@ namespace mrn {
       columns_.record_ = grn_ctx_get(ctx_, TABLE_NAME "." COLUMN_RECORD_NAME, -1);
     }
 
+    is_enabled_recording_ = true;
+
     DBUG_VOID_RETURN;
   }
 
@@ -104,6 +106,10 @@ namespace mrn {
                            const char *table_name, size_t table_name_size) {
     MRN_DBUG_ENTER_METHOD();
 
+    if (!is_enabled_recording_) {
+      DBUG_RETURN(GRN_ID_NIL);
+    }
+
     grn_id id = grn_table_add(ctx_, table_, NULL, 0, NULL);
 
     GRN_TEXT_SETS(ctx_, &text_buffer_, type);
@@ -118,6 +124,10 @@ namespace mrn {
   void Operations::record_target(grn_id id, grn_id record_id) {
     MRN_DBUG_ENTER_METHOD();
 
+    if (!is_enabled_recording_) {
+      DBUG_VOID_RETURN;
+    }
+
     GRN_UINT32_SET(ctx_, &id_buffer_, record_id);
     grn_obj_set_value(ctx_, columns_.record_,  id, &id_buffer_, GRN_OBJ_SET);
 
@@ -127,7 +137,27 @@ namespace mrn {
   void Operations::finish(grn_id id) {
     MRN_DBUG_ENTER_METHOD();
 
+    if (!is_enabled_recording_) {
+      DBUG_VOID_RETURN;
+    }
+
     grn_table_delete_by_id(ctx_, table_, id);
+
+    DBUG_VOID_RETURN;
+  }
+
+  void Operations::enable_recording() {
+    MRN_DBUG_ENTER_METHOD();
+
+    is_enabled_recording_ = true;
+
+    DBUG_VOID_RETURN;
+  }
+
+  void Operations::disable_recording() {
+    MRN_DBUG_ENTER_METHOD();
+
+    is_enabled_recording_ = false;
 
     DBUG_VOID_RETURN;
   }

--- a/lib/mrn_operations.hpp
+++ b/lib/mrn_operations.hpp
@@ -35,6 +35,9 @@ namespace mrn {
     void record_target(grn_id id, grn_id target_id);
     void finish(grn_id id);
 
+    void enable_recording();
+    void disable_recording();
+
     grn_hash *collect_processing_table_names();
 
     int repair(const char *table_name, size_t table_name_size);
@@ -50,6 +53,7 @@ namespace mrn {
       grn_obj *table_;
       grn_obj *record_;
     } columns_;
+    bool is_enabled_recording_;
   };
 }
 

--- a/mysql-test/mroonga/storage/variable/enable_operations_recording/r/insert.result
+++ b/mysql-test/mroonga/storage/variable/enable_operations_recording/r/insert.result
@@ -1,0 +1,12 @@
+SET GLOBAL mroonga_enable_operations_recording = true;
+FLUSH TABLES;
+CREATE TABLE diaries (
+title TEXT
+) DEFAULT CHARSET=utf8;
+INSERT INTO diaries VALUES("Research for Mroonga");
+SELECT * FROM diaries;
+title
+Research for Mroonga
+DROP TABLE diaries;
+SET GLOBAL mroonga_enable_operations_recording = false;
+FLUSH TABLES;

--- a/mysql-test/mroonga/storage/variable/enable_operations_recording/t/insert.test
+++ b/mysql-test/mroonga/storage/variable/enable_operations_recording/t/insert.test
@@ -1,0 +1,36 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/have_mroonga_helper.inc
+
+SET GLOBAL mroonga_enable_operations_recording = true;
+FLUSH TABLES;
+
+CREATE TABLE diaries (
+  title TEXT
+) DEFAULT CHARSET=utf8;
+
+INSERT INTO diaries VALUES("Research for Mroonga");
+
+SELECT * FROM diaries;
+
+DROP TABLE diaries;
+
+SET GLOBAL mroonga_enable_operations_recording = false;
+FLUSH TABLES;
+
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
I would like to disable recording operations for recovery because It takes a long time to rebuild the index in huge database case.
