### PR TITLE
mariadb 10.2: support virtual column

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -2832,6 +2832,9 @@ ulonglong ha_mroonga::wrapper_table_flags() const
 #ifdef HA_GENERATED_COLUMNS
   table_flags |= HA_GENERATED_COLUMNS;
 #endif
+#ifdef HA_CAN_VIRTUAL_COLUMNS
+  table_flags |= HA_CAN_VIRTUAL_COLUMNS;
+#endif
   DBUG_RETURN(table_flags);
 }
 
@@ -2863,6 +2866,9 @@ ulonglong ha_mroonga::storage_table_flags() const
 #endif
 #ifdef HA_GENERATED_COLUMNS
   flags |= HA_GENERATED_COLUMNS;
+#endif
+#ifdef HA_CAN_VIRTUAL_COLUMNS
+  flags |= HA_CAN_VIRTUAL_COLUMNS;
 #endif
   DBUG_RETURN(flags);
 }

--- a/mysql-test/mroonga/include/mroonga/skip_mariadb_10_1_or_earlier.inc
+++ b/mysql-test/mroonga/include/mroonga/skip_mariadb_10_1_or_earlier.inc
@@ -1,0 +1,24 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../include/mroonga/check_version.inc
+--source ../../include/mroonga/check_mariadb.inc
+
+if (!$version_10_2_or_later) {
+  if ($mariadb) {
+    --skip This test is not for MariaDB 5.x or MariaDB 10.0.x, 10.1.x
+  }
+}

--- a/mysql-test/mroonga/storage/column/generated/stored/t/add_column.test
+++ b/mysql-test/mroonga/storage/column/generated/stored/t/add_column.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/stored/t/delete.test
+++ b/mysql-test/mroonga/storage/column/generated/stored/t/delete.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/stored/t/drop_column.test
+++ b/mysql-test/mroonga/storage/column/generated/stored/t/drop_column.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/stored/t/insert.test
+++ b/mysql-test/mroonga/storage/column/generated/stored/t/insert.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/stored/t/update.test
+++ b/mysql-test/mroonga/storage/column/generated/stored/t/update.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/stored/t/add_column.test
+++ b/mysql-test/mroonga/wrapper/column/generated/stored/t/add_column.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/stored/t/delete.test
+++ b/mysql-test/mroonga/wrapper/column/generated/stored/t/delete.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/stored/t/drop_column.test
+++ b/mysql-test/mroonga/wrapper/column/generated/stored/t/drop_column.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/stored/t/insert.test
+++ b/mysql-test/mroonga/wrapper/column/generated/stored/t/insert.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/stored/t/update.test
+++ b/mysql-test/mroonga/wrapper/column/generated/stored/t/update.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings


### PR DESCRIPTION
#159 

supported virtual(computed) column of MariaDB.

Virtual(computed) columns starting with 5.2, 10.2.1
https://mariadb.com/kb/en/mariadb/virtual-computed-columns/

JSON functions starting with 10.2.3
https://mariadb.com/kb/en/mariadb/json-functions/

added JSON as an alias for TEXT with 10.2.7
https://jira.mariadb.org/browse/MDEV-9144