### PR TITLE
Support virtual type without index

### DIFF
--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -262,27 +262,6 @@ extern "C" {
 #  define MRN_HAVE_PSI_SERVER
 #endif
 
-#if (defined(HA_CAN_VIRTUAL_COLUMNS) || defined(HA_GENERATED_COLUMNS))
-#  define MRN_SUPPORT_GENERATED_COLUMNS
-#endif
-
-#if defined(HA_CAN_VIRTUAL_COLUMNS)
-#  define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
-     (!field->stored_in_db())
-#elif defined(HA_GENERATED_COLUMNS)
-#  define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
-     (!field->stored_in_db)
-#endif
-
-#if defined(HA_CAN_VIRTUAL_COLUMNS)
-#  define MRN_GENERATED_COLUMNS_UNSUPPORTED_CREATE_INDEX_ERROR \
-     (my_error(ER_KEY_BASED_ON_GENERATED_VIRTUAL_COLUMN, MYF(0)))
-#elif defined(HA_GENERATED_COLUMNS)
-#  define MRN_GENERATED_COLUMNS_UNSUPPORTED_CREATE_INDEX_ERROR \
-      (my_error(ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN, MYF(0), \
-                "Creating index/key"))
-#endif
-
 class ha_mroonga;
 
 /* structs */

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -262,6 +262,27 @@ extern "C" {
 #  define MRN_HAVE_PSI_SERVER
 #endif
 
+#if (defined(HA_CAN_VIRTUAL_COLUMNS) || defined(HA_GENERATED_COLUMNS))
+#  define MRN_SUPPORT_GENERATED_COLUMNS
+#endif
+
+#if defined(HA_CAN_VIRTUAL_COLUMNS)
+#  define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
+     (!field->stored_in_db())
+#elif defined(HA_GENERATED_COLUMNS)
+#  define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
+     (!field->stored_in_db)
+#endif
+
+#if defined(HA_CAN_VIRTUAL_COLUMNS)
+#  define MRN_GENERATED_COLUMNS_UNSUPPORTED_CREATE_INDEX_ERROR \
+     (my_error(ER_KEY_BASED_ON_GENERATED_VIRTUAL_COLUMN, MYF(0)))
+#elif defined(HA_GENERATED_COLUMNS)
+#  define MRN_GENERATED_COLUMNS_UNSUPPORTED_CREATE_INDEX_ERROR \
+      (my_error(ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN, MYF(0), \
+                "Creating index/key"))
+#endif
+
 class ha_mroonga;
 
 /* structs */

--- a/mrn_err.h
+++ b/mrn_err.h
@@ -39,5 +39,8 @@
 #define ER_MRN_INVALID_INDEX_FLAG_NUM 16508
 #define ER_MRN_INVALID_INDEX_FLAG_STR \
   "The index flag '%-.64s' is invalid. It is ignored"
+#define ER_MRN_KEY_BASED_ON_GENERATED_VIRTUAL_COLUMN_NUM 16509
+#define ER_MRN_KEY_BASED_ON_GENERATED_VIRTUAL_COLUMN_STR \
+  "Index for virtual generated column is not supported: %s"
 
 #endif /* MRN_ERR_H_ */

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -432,4 +432,30 @@
 #  define MRN_ALTER_INPLACE_INFO_ADD_STORED_GENERATED_COLUMN 0
 #endif
 
+#if (defined(HA_CAN_VIRTUAL_COLUMNS) || defined(HA_GENERATED_COLUMNS))
+#  define MRN_SUPPORT_GENERATED_COLUMNS
+#endif
+
+#if defined(HA_CAN_VIRTUAL_COLUMNS)
+#  if (MYSQL_VERSION_ID >= 100200)
+#    define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
+       (!field->stored_in_db())
+#  elif (MYSQL_VERSION_ID >= 50500)
+#    define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
+       (!field->stored_in_db)
+#  else
+#    define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) false
+#  endif
+#elif defined(HA_GENERATED_COLUMNS)
+#  if (MYSQL_VERSION_ID >= 50708)
+#    define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
+       (field->is_virtual_gcol())
+#  elif (MYSQL_VERSION_ID >= 50706)
+#    define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) \
+       (!field->stored_in_db)
+#  else
+#    define MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field) false
+#  endif
+#endif
+
 #endif /* MRN_MYSQL_COMPAT_H_ */

--- a/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/r/add_index.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/r/add_index.result
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+ALTER TABLE logs ADD INDEX (message);
+ERROR HY000: mroonga: storage: failed to create index: Index for virtual generated column is not supported: message
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/r/create_table_with_index.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/r/create_table_with_index.result
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL,
+FULLTEXT INDEX (message)
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+ERROR HY000: mroonga: storage: failed to create index: Index for virtual generated column is not supported: message

--- a/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/t/add_index.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/t/add_index.test
@@ -1,0 +1,35 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+--error 16509
+ALTER TABLE logs ADD INDEX (message);
+
+DROP TABLE logs;
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/t/create_table_with_index.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/mariadb_10_2_or_later/t/create_table_with_index.test
@@ -1,0 +1,32 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+--error 16509
+CREATE TABLE logs (
+  id INT,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL,
+  FULLTEXT INDEX (message)
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/generated/virtual/mysql_5_7_or_later/r/add_index.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/mysql_5_7_or_later/r/add_index.result
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+ALTER TABLE logs ADD INDEX (message);
+ERROR HY000: Table storage engine 'Mroonga' does not support the create option 'Index on virtual generated column'
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/mysql_5_7_or_later/t/add_index.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/mysql_5_7_or_later/t/add_index.test
@@ -1,0 +1,35 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+--error ER_ILLEGAL_HA_CREATE_OPTION
+ALTER TABLE logs ADD INDEX (message);
+
+DROP TABLE logs;
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/generated/virtual/r/add_column.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/r/add_column.result
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+SELECT * FROM logs;
+id	record	message
+1	{"level": "info", "message": "start"}	"start"
+2	{"level": "info", "message": "restart"}	"restart"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/r/add_column.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/r/add_column.result
@@ -3,8 +3,8 @@ CREATE TABLE logs (
 id INT,
 record JSON
 ) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
-ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
 INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
 INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
 INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
 SELECT * FROM logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/r/delete.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/r/delete.result
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+DELETE FROM logs WHERE id = 1;
+SELECT * FROM logs;
+id	record	message
+2	{"level": "info", "message": "restart"}	"restart"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/r/drop_column.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/r/drop_column.result
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+ALTER TABLE logs DROP COLUMN message;
+SELECT * FROM logs;
+id	record
+1	{"level": "info", "message": "start"}
+2	{"level": "info", "message": "restart"}
+3	{"level": "warn", "message": "abort"}
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/r/insert.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/r/insert.result
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+SELECT * FROM logs;
+id	record	message
+1	{"level": "info", "message": "start"}	"start"
+2	{"level": "info", "message": "restart"}	"restart"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/r/update.result
+++ b/mysql-test/mroonga/storage/column/generated/virtual/r/update.result
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+UPDATE logs SET record = '{"level": "info", "message": "shutdown"}' WHERE id = 2;
+SELECT * FROM logs;
+id	record	message
+1	{"level": "info", "message": "start"}	"start"
+2	{"level": "info", "message": "shutdown"}	"shutdown"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/add_column.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/add_column.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT,
+  record JSON
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/add_column.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/add_column.test
@@ -27,9 +27,10 @@ CREATE TABLE logs (
   record JSON
 ) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
 
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+
 ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
 
-INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
 INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
 INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
 

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/add_column.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/add_column.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/delete.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/delete.test
@@ -1,0 +1,40 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+DELETE FROM logs WHERE id = 1;
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/delete.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/delete.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/drop_column.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/drop_column.test
@@ -1,0 +1,40 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+ALTER TABLE logs DROP COLUMN message;
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/drop_column.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/drop_column.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/insert.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/insert.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/insert.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/insert.test
@@ -1,0 +1,38 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/update.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/update.test
@@ -14,7 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/storage/column/generated/virtual/t/update.test
+++ b/mysql-test/mroonga/storage/column/generated/virtual/t/update.test
@@ -1,0 +1,40 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+UPDATE logs SET record = '{"level": "info", "message": "shutdown"}' WHERE id = 2;
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/r/add_index.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/r/add_index.result
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+ALTER TABLE logs ADD FULLTEXT INDEX (message);
+ERROR HY000: mroonga: wrapper: failed to create index: Index for virtual generated column is not supported: message
+DROP TABLE logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/r/create_table_with_index.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/r/create_table_with_index.result
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL,
+FULLTEXT INDEX (message)
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+ERROR HY000: mroonga: wrapper: failed to create index: Index for virtual generated column is not supported: message

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/t/add_index.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/t/add_index.test
@@ -1,0 +1,36 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+--error 16509
+ALTER TABLE logs ADD FULLTEXT INDEX (message);
+
+DROP TABLE logs;
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/t/create_table_with_index.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/mariadb_10_2_or_later/t/create_table_with_index.test
@@ -1,0 +1,33 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+--error 16509
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL,
+  FULLTEXT INDEX (message)
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/mysql_5_7_or_later/r/add_index.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/mysql_5_7_or_later/r/add_index.result
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+ALTER TABLE logs ADD INDEX (message);
+ERROR HY000: mroonga: wrapper: failed to create index: Index for virtual generated column is not supported: message
+DROP TABLE logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/mysql_5_7_or_later/t/add_index.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/mysql_5_7_or_later/t/add_index.test
@@ -1,0 +1,36 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../../include/mroonga/have_mysql_5_7_or_later.inc
+--source ../../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+--error 16509
+ALTER TABLE logs ADD INDEX (message);
+
+DROP TABLE logs;
+
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/r/add_column.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/r/add_column.result
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+SELECT * FROM logs;
+id	record	message
+1	{"level": "info", "message": "start"}	"start"
+2	{"level": "info", "message": "restart"}	"restart"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/r/add_column.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/r/add_column.result
@@ -3,8 +3,8 @@ CREATE TABLE logs (
 id INT PRIMARY KEY,
 record JSON
 ) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
-ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
 INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
 INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
 INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
 SELECT * FROM logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/r/delete.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/r/delete.result
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+DELETE FROM logs WHERE id = 1;
+SELECT * FROM logs;
+id	record	message
+2	{"level": "info", "message": "restart"}	"restart"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/r/drop_column.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/r/drop_column.result
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+ALTER TABLE logs DROP COLUMN message;
+SELECT * FROM logs;
+id	record
+1	{"level": "info", "message": "start"}
+2	{"level": "info", "message": "restart"}
+3	{"level": "warn", "message": "abort"}
+DROP TABLE logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/r/insert.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/r/insert.result
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+SELECT * FROM logs;
+id	record	message
+1	{"level": "info", "message": "start"}	"start"
+2	{"level": "info", "message": "restart"}	"restart"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/r/update.result
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/r/update.result
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+id INT PRIMARY KEY,
+record JSON,
+message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+UPDATE logs SET record = '{"level": "info", "message": "shutdown"}' WHERE id = 2;
+SELECT * FROM logs;
+id	record	message
+1	{"level": "info", "message": "start"}	"start"
+2	{"level": "info", "message": "shutdown"}	"shutdown"
+3	{"level": "warn", "message": "abort"}	"abort"
+DROP TABLE logs;

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/add_column.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/add_column.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/add_column.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/add_column.test
@@ -28,9 +28,10 @@ CREATE TABLE logs (
   record JSON
 ) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
 
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+
 ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
 
-INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
 INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
 INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
 

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/add_column.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/add_column.test
@@ -1,0 +1,40 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+ALTER TABLE logs ADD COLUMN message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL;
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/delete.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/delete.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/delete.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/delete.test
@@ -1,0 +1,41 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+DELETE FROM logs WHERE id = 1;
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/drop_column.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/drop_column.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/drop_column.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/drop_column.test
@@ -1,0 +1,41 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+ALTER TABLE logs DROP COLUMN message;
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/insert.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/insert.test
@@ -1,0 +1,39 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/insert.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/insert.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/update.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/update.test
@@ -15,7 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source include/have_innodb.inc
---source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_version_5_7_or_later.inc
+--source ../../../../../include/mroonga/skip_mariadb_10_1_or_earlier.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings

--- a/mysql-test/mroonga/wrapper/column/generated/virtual/t/update.test
+++ b/mysql-test/mroonga/wrapper/column/generated/virtual/t/update.test
@@ -1,0 +1,41 @@
+# Copyright(C) 2017 Naoya Murakami <naoya@createfield.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source include/have_innodb.inc
+--source ../../../../../include/mroonga/have_mariadb_10_2_or_later.inc
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS logs;
+--enable_warnings
+
+CREATE TABLE logs (
+  id INT PRIMARY KEY,
+  record JSON,
+  message VARCHAR(255) GENERATED ALWAYS AS (json_extract(`record`, '$.message')) VIRTUAL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COMMENT = 'ENGINE "InnoDB"';
+
+INSERT INTO logs(id, record) VALUES (1, '{"level": "info", "message": "start"}');
+INSERT INTO logs(id, record) VALUES (2, '{"level": "info", "message": "restart"}');
+INSERT INTO logs(id, record) VALUES (3, '{"level": "warn", "message": "abort"}');
+
+UPDATE logs SET record = '{"level": "info", "message": "shutdown"}' WHERE id = 2;
+
+SELECT * FROM logs;
+
+DROP TABLE logs;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
#159, #161

I've implemented to support ``VIRTUAL`` type for generated/computed column.
It is not supported index.
(MySQL5.7 doesn't allow to create fulltext index for virtual generated column.)