### PR TITLE
deb: Error on preinst and postrm (missing depends to lsb-release )

### DIFF
--- a/packages/debian-mariadb-10.0/control.in
+++ b/packages/debian-mariadb-10.0/control.in
@@ -61,7 +61,8 @@ Depends:
 	libgroonga0 (>= @REQUIRED_GROONGA_VERSION@),
 	mariadb-server-10.0 (= MARIADB_VERSION),
 	mariadb-server-core-10.0 (= MARIADB_VERSION),
-	groonga-normalizer-mysql
+	groonga-normalizer-mysql,
+	lsb-release
 Conflicts:
 	mariadb-plugin-mroonga
 Description: A fast fulltext searchable storage engine for MariaDB 10.0.


### PR DESCRIPTION
I get follwoing error on installing mroonga  debian package to minimal stretch environment.

```
Preparing to unpack .../mariadb-server-10.1-mroonga_7.06-1_amd64.deb ...
/var/lib/dpkg/tmp.ci/preinst: 1: /var/lib/dpkg/tmp.ci/preinst: lsb_release: not found
dpkg: error processing archive /var/cache/apt/archives/mariadb-server-10.1-mroonga_7.06-1_amd64.deb (--unpack):
 subprocess new pre-installation script returned error exit status 127
/var/lib/dpkg/tmp.ci/postrm: 1: /var/lib/dpkg/tmp.ci/postrm: lsb_release: not found
dpkg: error while cleaning up:
 subprocess new post-removal script returned error exit status 127
Errors were encountered while processing:
 /var/cache/apt/archives/mariadb-server-10.1-mroonga_7.06-1_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

The packge calls lsb_release command on preinst and postrm hook, but dose
not depend to lsb-release package.

Here is a simple patch to fix mariadb-server-10.0-mroonga package.

mariadb-server-10.1-mroonga (for stretch) has same issue.
However I cannot find build env in this repository.