### PR TITLE
Enable "count-skip" optimization for multi-column fulltext search

### DIFF
--- a/lib/mrn_count_skip_checker.cpp
+++ b/lib/mrn_count_skip_checker.cpp
@@ -133,18 +133,10 @@ namespace mrn {
       {
         Item_func *func_item = static_cast<Item_func *>(where);
         if (func_item->functype() == Item_func::FT_FUNC) {
-          if (select_lex_->select_n_where_fields == 1) {
-            GRN_LOG(ctx_, GRN_LOG_DEBUG,
-                    "[mroonga][count-skip][true] "
-                    "only one full text search condition");
-            DBUG_RETURN(true);
-          } else {
-            GRN_LOG(ctx_, GRN_LOG_DEBUG,
-                    "[mroonga][count-skip][false] "
-                    "full text search condition and more conditions: %u",
-                    select_lex_->select_n_where_fields);
-            DBUG_RETURN(false);
-          }
+          GRN_LOG(ctx_, GRN_LOG_DEBUG,
+                  "[mroonga][count-skip][true] "
+                  "only one full text search condition");
+          DBUG_RETURN(true);
         } else {
           skippable = is_skippable(func_item);
           if (skippable) {

--- a/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/r/multi_column_index.result
+++ b/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/r/multi_column_index.result
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS memos;
+FLUSH STATUS;
+CREATE TABLE memos (
+title TEXT,
+content TEXT,
+FULLTEXT INDEX (title, content)
+) DEFAULT CHARSET=UTF8;
+INSERT INTO memos (title, content) VALUES ('On Groonga', 'Groonga is good.');
+INSERT INTO memos (title, content) VALUES ('More on Groonga', 'Groonga is very good.');
+INSERT INTO memos (title, content) VALUES ('Also on Mroonga', 'Mroonga is good.');
+INSERT INTO memos (title, content) VALUES ('Another memo', 'Mroonga is very good.');
+INSERT INTO memos (title, content) VALUES ('A reminder', 'Mroonga uses Groonga.');
+SELECT COUNT(*) FROM memos
+WHERE MATCH(title, content) AGAINST('+Groonga +More' IN BOOLEAN MODE);
+COUNT(*)
+1
+SHOW STATUS LIKE 'mroonga_count_skip';
+Variable_name	Value
+Mroonga_count_skip	1
+DROP TABLE memos;

--- a/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/r/multi_column_index.result
+++ b/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/r/multi_column_index.result
@@ -11,7 +11,7 @@ INSERT INTO memos (title, content) VALUES ('Also on Mroonga', 'Mroonga is good.'
 INSERT INTO memos (title, content) VALUES ('Another memo', 'Mroonga is very good.');
 INSERT INTO memos (title, content) VALUES ('A reminder', 'Mroonga uses Groonga.');
 SELECT COUNT(*) FROM memos
-WHERE MATCH(title, content) AGAINST('+Groonga +More' IN BOOLEAN MODE);
+WHERE MATCH(title, content) AGAINST('+Groonga +reminder' IN BOOLEAN MODE);
 COUNT(*)
 1
 SHOW STATUS LIKE 'mroonga_count_skip';

--- a/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/t/multi_column_index.test
+++ b/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/t/multi_column_index.test
@@ -1,0 +1,44 @@
+# Copyright(C) 2017 Fujimoto Seiji <fujimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS memos;
+--enable_warnings
+
+FLUSH STATUS;
+
+CREATE TABLE memos (
+  title TEXT,
+  content TEXT,
+  FULLTEXT INDEX (title, content)
+) DEFAULT CHARSET=UTF8;
+
+INSERT INTO memos (title, content) VALUES ('On Groonga', 'Groonga is good.');
+INSERT INTO memos (title, content) VALUES ('More on Groonga', 'Groonga is very good.');
+INSERT INTO memos (title, content) VALUES ('Also on Mroonga', 'Mroonga is good.');
+INSERT INTO memos (title, content) VALUES ('Another memo', 'Mroonga is very good.');
+INSERT INTO memos (title, content) VALUES ('A reminder', 'Mroonga uses Groonga.');
+
+SELECT COUNT(*) FROM memos
+ WHERE MATCH(title, content) AGAINST('+Groonga +More' IN BOOLEAN MODE);
+
+SHOW STATUS LIKE 'mroonga_count_skip';
+
+DROP TABLE memos;
+
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/t/multi_column_index.test
+++ b/mysql-test/mroonga/storage/optimization/count_skip/full_text_index/t/multi_column_index.test
@@ -35,7 +35,7 @@ INSERT INTO memos (title, content) VALUES ('Another memo', 'Mroonga is very good
 INSERT INTO memos (title, content) VALUES ('A reminder', 'Mroonga uses Groonga.');
 
 SELECT COUNT(*) FROM memos
- WHERE MATCH(title, content) AGAINST('+Groonga +More' IN BOOLEAN MODE);
+ WHERE MATCH(title, content) AGAINST('+Groonga +reminder' IN BOOLEAN MODE);
 
 SHOW STATUS LIKE 'mroonga_count_skip';
 


### PR DESCRIPTION
### Summary

Mroonga has [a feature](http://mroonga.org/docs/reference/optimizations.html#row-count) to skip the data retrieval routine when the MySQL/MariaDB server has no interest on the actual row records.

This patch enables the optimimization for a multi-column fulltext index query like this:

```sql
SELECT COUNT(*) FROM tbl WHERE MATCH (col1, col2) AGAINST ('q');
```

### How this patch solves the problem

In essence, this patch eliminates the following `if` conditional in CountSkipChecker:

```cpp
if (select_lex_->select_n_where_fields == 1) {
    ... // Enable optimization
} else {
    ... // Disable optimization
}
```

The observation behind this modification is that this conditional is somewhat meaningless, because, at this point in the code path, the query being executed is guaranteeed to:

* be not a nested query.
* select no field (column) other than `COUNT(*)`
* have no HAVING/GROUP condition.
* involve only a single table.
* have a full-text search func as its root WHERE conditional (`select_lex->where`)

and I cannot come up with a case where we actually require this `if` conditional.

Note that this conditional is introduced by bd4218290. I cannot find further information about this changeset, nor the rationale behind it.