### PR TITLE
appveyor: put Mroonga pdb in same directory with plugin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,6 +97,9 @@ build_script:
   - ps: .\source\storage\mroonga\packages\windows\install-mroonga.ps1
       -mariadbVersion $env:MARIADB_VERSION
       -platform $env:MROONGA_PLATFORM
+  - if not exist mariadb-%MARIADB_VERSION%-%MROONGA_PLATFORM%\lib\plugin\ha_mroonga.pdb (
+      copy mariadb-%MARIADB_VERSION%-%MROONGA_PLATFORM%\symbols\ha_mroonga.pdb mariadb-%MARIADB_VERSION%-%MROONGA_PLATFORM%\lib\plugin\
+    )
 
 test: off
 


### PR DESCRIPTION
MariaDB search symbols from same directory with plugin.

MariaDB 10.1: pdb is installed to lib/plugin/ha_mroonga.pdb
MariaDB 10.2/10.3: pdb is installed to symbols/ha_mroonga.pdb