### PR TITLE
appveyor: run mysql_install_db for MariaDB 10.4.

### DIFF
--- a/packages/windows/install-mroonga.ps1
+++ b/packages/windows/install-mroonga.ps1
@@ -45,7 +45,7 @@ function Shutdown-MySQL($LogPath) {
 function Install-Mroonga($mariadbVer, $arch, $installSqlDir) {
   Write-Output("Start to install Mroonga")
   cd "mariadb-$mariadbVer-$arch"
-  if ("$mariadbVer" -eq "10.4.7") {
+  if ("$mariadbVer".StartsWith("10.4")) {
     Write-Output("Clean data directory")
     Remove-Item data -Recurse
     Run-MySQLInstallDB


### PR DESCRIPTION
In the previous versions, it requires to update install-mroonga.ps1
for each teeny release, so it is fixed for 10.4.*.