### PR TITLE
test: suppress warning since 10.3.18/10.4.8

### DIFF
--- a/mysql-test/mroonga/storage/index/multiple_column/select/t/varchar.test
+++ b/mysql-test/mroonga/storage/index/multiple_column/select/t/varchar.test
@@ -21,12 +21,14 @@ drop table if exists scores;
 --enable_warnings
 
 set names utf8mb4;
+--disable_warnings
 create table scores (
   given_name varchar(30) not null,
   family_name varchar(30) not null,
   score int not null,
   primary key property (given_name, family_name, score)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+--enable_warnings
 show create table scores;
 
 insert into scores values("Taro", "Yamada", 29);


### PR DESCRIPTION
  Warnings:
  Warning	1280	Name 'property' ignored for PRIMARY key.