### PR TITLE
travis: remove hardcoded DWITH_SSL option

### DIFF
--- a/tools/travis/before_script.sh
+++ b/tools/travis/before_script.sh
@@ -63,6 +63,8 @@ else
       sudo mkdir -p /usr/global/share
       sudo chown -R ${USER}: /usr/global/share/
       sed -i 's/-DWITH_BOOST/-DDOWNLOAD_BOOST=1 -DWITH_BOOST/' vendor/mysql/debian/rules
+      # Remove https://bugs.mysql.com/bug.php?id=97278 is fixed (hardcoded build host path issue exists on MySQL 5.7.28)
+      sed -i '/^-DWITH_SSL/d' vendor/mysql/debian/rules
       (cd vendor/mysql && fakeroot debian/rules override_dh_auto_configure)
       configure_args=("${configure_args[@]}"
                       "--with-mysql-build=$PWD/vendor/mysql/release")


### PR DESCRIPTION
It causes CMAKE configuration error because of failing to detect
installed OpenSSL library on that system

  --
  Wrong option or path for
  WITH_SSL=/export/home/pb2/build/sb_0-36131509-1569568392.28/dep2.

  Make sure you have specified a supported SSL version.

  Valid options are :

  system (use the OS openssl library),

  yes (synonym for system),

  </path/to/custom/openssl/installation>

  CMake Error at cmake/ssl.cmake:66 (MESSAGE):

    Please install the appropriate openssl developer package.

  Call Stack (most recent call first):

    cmake/ssl.cmake:265 (FATAL_SSL_NOT_FOUND_ERROR)

    CMakeLists.txt:573 (MYSQL_CHECK_SSL)

  -- Configuring incomplete, errors occurred!