### PR TITLE
travis percona: enable Percona Server 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,9 @@ matrix:
     - name: Percona Server 5.6
       env:
         - MYSQL_VERSION=percona-server-5.6
-    # TODO: Renable this.
-    # The latest Percona Server 5.7 is 5.7.29.32-1 but the latest source
-    # package is 5.7.28-31:
-    # http://repo.percona.com/percona/apt/pool/main/p/percona-server-5.7/
-    # - name: Percona Server 5.7
-    #   env:
-    #     - MYSQL_VERSION=percona-server-5.7
+    - name: Percona Server 5.7
+      env:
+        - MYSQL_VERSION=percona-server-5.7
     - name: Percona Server 8.0
       env:
         - MYSQL_VERSION=percona-server-8.0


### PR DESCRIPTION
Because the latest source package for Percona Server 5.7 was prepared.

TravisCI result for Percona Server5.7 has been sucess.
https://travis-ci.org/github/komainu8/mroonga/jobs/667043501