### PR TITLE
doc: use release page instead of direct download links for Windows packages

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install.po
+++ b/doc/locale/ja/LC_MESSAGES/install.po
@@ -863,28 +863,7 @@ msgstr ""
 "zipファイルをダウンロードして展開してください。環境に合わせてzipファイルを選"
 "ぶ必要があります"
 
-msgid "|mroonga_mariadb101_windows_package_link_32|"
-msgstr ""
-
-msgid "|mroonga_mariadb101_windows_package_link_64|"
-msgstr ""
-
-msgid "|mroonga_mariadb102_windows_package_link_32|"
-msgstr ""
-
-msgid "|mroonga_mariadb102_windows_package_link_64|"
-msgstr ""
-
-msgid "|mroonga_mariadb103_windows_package_link_32|"
-msgstr ""
-
-msgid "|mroonga_mariadb103_windows_package_link_64|"
-msgstr ""
-
-msgid "|mroonga_mariadb104_windows_package_link_32|"
-msgstr ""
-
-msgid "|mroonga_mariadb104_windows_package_link_64|"
+msgid "|mroonga_mariadb_windows_package_link|"
 msgstr ""
 
 msgid ""

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -100,13 +100,13 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 variables = {
-  "package_mroonga_version": os.environ["PACKAGE_MROONGA_VERSION"],
-  "download_base": "https://github.com/mroonga/mroonga/releases/tag"
+  "package_mroonga_version": os.environ["PACKAGE_MROONGA_VERSION"]
 }
+
 variables["windows_mariadb_package_link_label"] = \
   "MariaDB with Mroonga-{package_mroonga_version}".format(**variables)
 variables["windows_mariadb_package_link_basename"] = \
-  "{download_base}/v{package_mroonga_version}".format(**variables)
+  "https://github.com/mroonga/mroonga/releases/tag/v{package_mroonga_version}".format(**variables)
 
 rst_epilog = '''
 .. |mroonga_mariadb_windows_package_link| replace:: `{windows_mariadb_package_link_label}`_

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -101,46 +101,16 @@ pygments_style = 'sphinx'
 
 variables = {
   "package_mroonga_version": os.environ["PACKAGE_MROONGA_VERSION"],
-  "package_mariadb101_version": "10.1.41",
-  "package_mariadb102_version": "10.2.27",
-  "package_mariadb103_version": "10.3.18",
-  "package_mariadb104_version": "10.4.8",
-  "download_base": "https://github.com/mroonga/mroonga/releases/download"
+  "download_base": "https://github.com/mroonga/mroonga/releases/tag"
 }
-variables["windows_mariadb101_package_link_label"] = \
-  "MariaDB {package_mariadb101_version} with Mroonga {package_mroonga_version}".format(**variables)
-variables["windows_mariadb101_package_link_basename"] = \
-  "{download_base}/v{package_mroonga_version}/mariadb-{package_mariadb101_version}-with-mroonga-{package_mroonga_version}".format(**variables)
-variables["windows_mariadb102_package_link_label"] = \
-  "MariaDB {package_mariadb102_version} with Mroonga {package_mroonga_version}".format(**variables)
-variables["windows_mariadb102_package_link_basename"] = \
-  "{download_base}/v{package_mroonga_version}/mariadb-{package_mariadb102_version}-with-mroonga-{package_mroonga_version}".format(**variables)
-variables["windows_mariadb103_package_link_label"] = \
-  "MariaDB {package_mariadb103_version} with Mroonga {package_mroonga_version}".format(**variables)
-variables["windows_mariadb103_package_link_basename"] = \
-  "{download_base}/v{package_mroonga_version}/mariadb-{package_mariadb103_version}-with-mroonga-{package_mroonga_version}".format(**variables)
-variables["windows_mariadb104_package_link_label"] = \
-  "MariaDB {package_mariadb104_version} with Mroonga {package_mroonga_version}".format(**variables)
-variables["windows_mariadb104_package_link_basename"] = \
-  "{download_base}/v{package_mroonga_version}/mariadb-{package_mariadb104_version}-with-mroonga-{package_mroonga_version}".format(**variables)
+variables["windows_mariadb_package_link_label"] = \
+  "MariaDB with Mroonga-{package_mroonga_version}".format(**variables)
+variables["windows_mariadb_package_link_basename"] = \
+  "{download_base}/v{package_mroonga_version}".format(**variables)
 
 rst_epilog = '''
-.. |mroonga_mariadb101_windows_package_link_32| replace:: `{windows_mariadb101_package_link_label} (32bit)`_
-.. |mroonga_mariadb101_windows_package_link_64| replace:: `{windows_mariadb101_package_link_label} (64bit)`_
-.. _{windows_mariadb101_package_link_label} (32bit): {windows_mariadb101_package_link_basename}-win32.zip
-.. _{windows_mariadb101_package_link_label} (64bit): {windows_mariadb101_package_link_basename}-winx64.zip
-.. |mroonga_mariadb102_windows_package_link_32| replace:: `{windows_mariadb102_package_link_label} (32bit)`_
-.. |mroonga_mariadb102_windows_package_link_64| replace:: `{windows_mariadb102_package_link_label} (64bit)`_
-.. _{windows_mariadb102_package_link_label} (32bit): {windows_mariadb102_package_link_basename}-win32.zip
-.. _{windows_mariadb102_package_link_label} (64bit): {windows_mariadb102_package_link_basename}-winx64.zip
-.. |mroonga_mariadb103_windows_package_link_32| replace:: `{windows_mariadb103_package_link_label} (32bit)`_
-.. |mroonga_mariadb103_windows_package_link_64| replace:: `{windows_mariadb103_package_link_label} (64bit)`_
-.. _{windows_mariadb103_package_link_label} (32bit): {windows_mariadb103_package_link_basename}-win32.zip
-.. _{windows_mariadb103_package_link_label} (64bit): {windows_mariadb103_package_link_basename}-winx64.zip
-.. |mroonga_mariadb104_windows_package_link_32| replace:: `{windows_mariadb104_package_link_label} (32bit)`_
-.. |mroonga_mariadb104_windows_package_link_64| replace:: `{windows_mariadb104_package_link_label} (64bit)`_
-.. _{windows_mariadb104_package_link_label} (32bit): {windows_mariadb104_package_link_basename}-win32.zip
-.. _{windows_mariadb104_package_link_label} (64bit): {windows_mariadb104_package_link_basename}-winx64.zip
+.. |mroonga_mariadb_windows_package_link| replace:: `{windows_mariadb_package_link_label}`_
+.. _{windows_mariadb_package_link_label}: {windows_mariadb_package_link_basename}
 '''.format(**variables)
 
 # -- Options for HTML output ---------------------------------------------------

--- a/doc/source/install/windows.rst
+++ b/doc/source/install/windows.rst
@@ -36,14 +36,7 @@ Zip
 Download zip file and extract it. You need to choose a zip for your
 environment:
 
-  * |mroonga_mariadb101_windows_package_link_32|
-  * |mroonga_mariadb101_windows_package_link_64|
-  * |mroonga_mariadb102_windows_package_link_32|
-  * |mroonga_mariadb102_windows_package_link_64|
-  * |mroonga_mariadb103_windows_package_link_32|
-  * |mroonga_mariadb103_windows_package_link_64|
-  * |mroonga_mariadb104_windows_package_link_32|
-  * |mroonga_mariadb104_windows_package_link_64|
+  * |mroonga_mariadb_windows_package_link|
 
 Zip packages are pre-configured for easy to use, so no need to execute
 ``INSTALL PLUGIN`` and ``CREATE FUNCTION``.


### PR DESCRIPTION
Because We often forget to update the link,
if we make links that specify the version of MariaDB.