### PR TITLE
rpm centos: remove a needless procedure

### DIFF
--- a/packages/mysql-server-8.0-mroonga/yum/mysql80-community-mroonga.spec.in
+++ b/packages/mysql-server-8.0-mroonga/yum/mysql80-community-mroonga.spec.in
@@ -87,7 +87,6 @@ if [ ! -d ${mysql_source} ]; then
         -DWITH_BOOST=../.. \
         -DINSTALL_LIBDIR="%{_lib}/mysql" \
         -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
-    make %{?_smp_mflags} VERBOSE=1
     popd && popd
 fi
 %configure \


### PR DESCRIPTION
Because if we make MySQL8, run out of disk space for GitHub Actions