### PR TITLE
packages: drop Ubuntu 19.04

### DIFF
--- a/packages/mysql-server-5.7-mroonga/Rakefile
+++ b/packages/mysql-server-5.7-mroonga/Rakefile
@@ -13,7 +13,6 @@ class MySQLServer57MroongaPackageTask < MroongaPackageTask
     [
       ["xenial", "16.04"],
       ["bionic", "18.04"],
-      ["disco", "19.04"],
     ]
   end
 


### PR DESCRIPTION
It reached EOL on on January 23 2020.