### PR TITLE
packages: add a missing dependency package for Ubuntu 16.04

### DIFF
--- a/packages/mysql-server-5.7-mroonga/debian/control.in
+++ b/packages/mysql-server-5.7-mroonga/debian/control.in
@@ -16,7 +16,8 @@ Build-Depends:
 	cmake,
 	libwrap0-dev,
 	libedit-dev,
-	liblz4-dev
+	liblz4-dev,
+	libncurses5-dev
 Standards-Version: 3.9.1
 Homepage: http://mroonga.org/
 


### PR DESCRIPTION
Because if libncurses5-dev is missing, MySQL in Ubuntu 16.04 occurs the following build error.

```
CMake Error at cmake/readline.cmake:71 (MESSAGE):
  Curses library not found.  Please install appropriate package,

      remove CMakeCache.txt and rerun cmake.On Debian/Ubuntu, package name is libncurses5-dev, on Redhat and derivates it is ncurses-devel.
Call Stack (most recent call first):
  cmake/readline.cmake:100 (FIND_CURSES)
  cmake/readline.cmake:193 (MYSQL_USE_BUNDLED_EDITLINE)
  CMakeLists.txt:581 (MYSQL_CHECK_EDITLINE)
```

See more details: [build log](https://launchpadlibrarian.net/479172238/buildlog_ubuntu-xenial-i386.mysql-server-5.7-mroonga_10.02-1.ubuntu16.04.2_BUILDING.txt.gz)