### PR TITLE
packages mariadb-server-10.3: add support for Ubuntu 20.04(Focal Fossa)

### DIFF
--- a/packages/mariadb-server-10.3-mroonga/Rakefile
+++ b/packages/mariadb-server-10.3-mroonga/Rakefile
@@ -14,6 +14,7 @@ class MariaDBServer103MroongaPackageTask < MroongaPackageTask
   def ubuntu_targets_default
     [
       ["eoan", "19.10"],
+      ["focal", "20.04"],
     ]
   end
 


### PR DESCRIPTION
I confirming whether we can build packages for Ubuntu 20.04.
And this modify needs 6e1bc71562f81886b2e556c4f99e62b7ca9beedd.