### PR TITLE
appveyor: install zstd before bison packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ environment:
 install:
   - set PATH=C:\Ruby26-x64\bin;%PATH%
   - set PATH=C:\msys64\usr\bin;%PATH%
+  - pacman -Sy --noconfirm zstd
   - pacman -Sy --noconfirm bison
   - if "%USE_MASTER%" == "yes" (
       call


### PR DESCRIPTION
The bison package for pacman is compressed with the ZST algorithm from 3.6.2-1.
However, pacman can't handle that unless we first install zstd.