### PR TITLE
appveyor: drop MariaDB 10.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,12 +16,6 @@ clone_depth: 10
 environment:
   matrix:
     - CMAKE_GENERATOR_NAME: "Visual Studio 14 2015"
-      MARIADB_VERSION: 10.1.45
-      MROONGA_PLATFORM: "win32"
-    - CMAKE_GENERATOR_NAME: "Visual Studio 14 2015 Win64"
-      MARIADB_VERSION: 10.1.45
-      MROONGA_PLATFORM: "winx64"
-    - CMAKE_GENERATOR_NAME: "Visual Studio 14 2015"
       MARIADB_VERSION: 10.2.32
       MROONGA_PLATFORM: "win32"
     - CMAKE_GENERATOR_NAME: "Visual Studio 14 2015 Win64"


### PR DESCRIPTION
Because MariaDB 10.1 will be EOL soon.