### PR TITLE
packages: drop Ubuntu 19.10

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install.po
+++ b/doc/locale/ja/LC_MESSAGES/install.po
@@ -771,9 +771,6 @@ msgstr ""
 msgid "19.04 Disco Dingo"
 msgstr ""
 
-msgid "19.10 Eoan Ermine"
-msgstr ""
-
 msgid "Here are Ubuntu versions that supports MariaDB:"
 msgstr "MariaDBをサポートしているUbuntuのバージョンは次の通りです。"
 

--- a/doc/source/install/ubuntu.rst
+++ b/doc/source/install/ubuntu.rst
@@ -19,7 +19,6 @@ Here are supported Ubuntu versions:
   * 16.04 LTS Xenial Xerus
   * 18.04 Bionic Beaver
   * 19.04 Disco Dingo
-  * 19.10 Eoan Ermine
 
 Here are Ubuntu versions that supports MariaDB:
 

--- a/packages/mariadb-server-10.3-mroonga/Rakefile
+++ b/packages/mariadb-server-10.3-mroonga/Rakefile
@@ -13,7 +13,6 @@ class MariaDBServer103MroongaPackageTask < MroongaPackageTask
 
   def ubuntu_targets_default
     [
-      ["eoan", "19.10"],
       ["focal", "20.04"],
     ]
   end


### PR DESCRIPTION
It reached EOL on July 17 2020.
See: https://wiki.ubuntu.com/Releases