### PR TITLE
Add support for mariadb-server 10.5.5

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -5672,11 +5672,7 @@ int ha_mroonga::wrapper_delete_table(const char *name,
   }
 
 #ifdef MRN_HANDLER_DELETE_TABLE_HAVE_HTON_DROP_TABLE
-  if (ha_check_if_updates_are_ignored(ha_thd(), wrap_handlerton, "DROP")) {
-    error = 0;
-  } else {
-    error = wrap_handlerton->drop_table(wrap_handlerton, name);
-  }
+  error = wrap_handlerton->drop_table(wrap_handlerton, name);
 #elif defined(MRN_HANDLER_DELETE_TABLE_HAVE_TABLE_DEFINITION)
   error = hnd->ha_delete_table(name, table_def);
 #else

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -5671,7 +5671,13 @@ int ha_mroonga::wrapper_delete_table(const char *name,
     DBUG_RETURN(HA_ERR_OUT_OF_MEM);
   }
 
-#ifdef MRN_HANDLER_DELETE_TABLE_HAVE_TABLE_DEFINITION
+#ifdef MRN_HANDLER_DELETE_TABLE_HAVE_HTON_DROP_TABLE
+  if (ha_check_if_updates_are_ignored(ha_thd(), wrap_handlerton, "DROP")) {
+    error = 0;
+  } else {
+    error = wrap_handlerton->drop_table(wrap_handlerton, name);
+  }
+#elif defined(MRN_HANDLER_DELETE_TABLE_HAVE_TABLE_DEFINITION)
   error = hnd->ha_delete_table(name, table_def);
 #else
   error = hnd->ha_delete_table(name);

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -81,6 +81,10 @@ extern "C" {
 #  define MRN_HANDLER_HAVE_SET_HA_SHARE_REF
 #endif
 
+#if (MYSQL_VERSION_ID >= 100505) && defined(MRN_MARIADB_P)
+#  define MRN_HANDLER_DELETE_TABLE_HAVE_HTON_DROP_TABLE
+#endif
+
 #if MYSQL_VERSION_ID >= 50706 && !defined(MRN_MARIADB_P)
 #  define MRN_BIG_TABLES
 #elif defined(BIG_TABLES)


### PR DESCRIPTION
GitHub: fix GH-333 Reported by tomop-tg.

We use ha_drop_table instead of ha_delete_table.
Because ha_delete_table is deleted since mariadb-server 10.5.5
by below commit.

https://github.com/MariaDB/server/commit/c55c292832e2776d37e06c43174ac006e00143a2