### PR TITLE
test: follow error message change in mariadb-10.5.3, 10.4.13, 10.3.23, and 10.2.32

### DIFF
--- a/mysql-test/mroonga/storage/index/multiple_column/unique/t/decimal.test
+++ b/mysql-test/mroonga/storage/index/multiple_column/unique/t/decimal.test
@@ -30,7 +30,9 @@ select c1, c2, c3 from t1 force index(uk1) where c2 = -9876543210987654321098765
 select c1, c2, c3 from t1 force index(uk1) order by c2, c3;
 select c1, c2, c3 from t1 force index(uk1) order by c2 desc, c3 desc;
 select c2, c3 from t1 force index(uk1) order by c2, c3;
-#For MariaDB 10.2 or later
+# MariaDB 10.2 or later uses "..." to show the displayed value is truncated.
+# We will use "..." version instead of "000" version as expected value
+# when MySQL also uses "...".
 --replace_result 123.456000000000000000000000000000-0.000000000000000000000000... 123.456000000000000000000000000000-0.000000000000000000000000000
 --error ER_DUP_ENTRY
 insert into t1 values(6,123.456,0.000000000000000000000000000001);

--- a/mysql-test/mroonga/storage/index/multiple_column/unique/t/decimal.test
+++ b/mysql-test/mroonga/storage/index/multiple_column/unique/t/decimal.test
@@ -30,6 +30,8 @@ select c1, c2, c3 from t1 force index(uk1) where c2 = -9876543210987654321098765
 select c1, c2, c3 from t1 force index(uk1) order by c2, c3;
 select c1, c2, c3 from t1 force index(uk1) order by c2 desc, c3 desc;
 select c2, c3 from t1 force index(uk1) order by c2, c3;
+#For MariaDB 10.2 or later
+--replace_result 123.456000000000000000000000000000-0.000000000000000000000000... 123.456000000000000000000000000000-0.000000000000000000000000000
 --error ER_DUP_ENTRY
 insert into t1 values(6,123.456,0.000000000000000000000000000001);
 delete from t1 where c1 = 1;


### PR DESCRIPTION
Because the format of the error message in mariadb-server was modified by below commit.

https://github.com/MariaDB/server/commit/cb4da5da74b7a6f2e7c4f4ed1b0e5affe45fe2a2

However, the format of it is not modified in MySQL, PerconaServer, and MariaDB 10.1.
Therefore, we separated `mroonga/storage/index/multiple_column/unique/{t, r}/decimal.{test, result}`.