### PR TITLE
appveyor: add a patch for fixing link error

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,9 @@ install:
   - curl --location -O https://downloads.mariadb.org/f/mariadb-%MARIADB_VERSION%/source/mariadb-%MARIADB_VERSION%.tar.gz
   - tar xzf mariadb-%MARIADB_VERSION%.tar.gz
   - cd mariadb-%MARIADB_VERSION%
+  - if "%MARIADB_VERSION:~,5%" == "10.5." (
+      patch -p1 < ..\mroonga\packages\source\patches\mariadb-10.5.5-add-a-missing-export-symbol.diff
+    )
   - rmdir /S /Q storage\mroonga\
   - ps: $Env:MROONGA_VERSION = "$(Get-Content ..\mroonga\version)"
   - move ..\mroonga storage\mroonga

--- a/packages/source/patches/mariadb-10.5.5-add-a-missing-export-symbol.diff
+++ b/packages/source/patches/mariadb-10.5.5-add-a-missing-export-symbol.diff
@@ -1,0 +1,13 @@
+--- mariadb-10.5.5.orig/sql/sql_type.h	2020-09-09 13:20:40.113007137 +0900
++++ mariadb-10.5.5/sql/sql_type.h	2020-09-09 13:23:17.385795235 +0900
+@@ -7298,8 +7298,8 @@ extern MYSQL_PLUGIN_IMPORT Named_type_ha
+ 
+ extern Named_type_handler<Type_handler_bit>         type_handler_bit;
+ 
+-extern Named_type_handler<Type_handler_enum>        type_handler_enum;
+-extern Named_type_handler<Type_handler_set>         type_handler_set;
++extern MYSQL_PLUGIN_IMPORT Named_type_handler<Type_handler_enum>        type_handler_enum;
++extern MYSQL_PLUGIN_IMPORT Named_type_handler<Type_handler_set>         type_handler_set;
+ 
+ extern Named_type_handler<Type_handler_string>      type_handler_string;
+ extern Named_type_handler<Type_handler_var_string>  type_handler_var_string;


### PR DESCRIPTION
This patch resolves link error for packages for MariaDB10.5.5 of the Windows version.
We need to export the symbol of `type_handler_enum`. Because `type_handler_enum` is not defined in a header file.

Probably, this is a bug for MariaDB 10.5.5. Therefore, we will send a patch to upstream.
If the bug will be fixed in upstream, we will delete this patch.
