### PR TITLE
doc developer: remove a explanation about release

### DIFF
--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -70,20 +70,6 @@ Then you ask other developers to review (especially in case of adding new featur
 
 For adding and updating documents, please refer the description below.
 
-Release
--------
-
-We release the software when all tickets of the roadmap are closed.
-
-We do the following to release.
-
-* Create source packages
-* Create binary packages
-* Update documents on http://mroonga.org
-* Announce the release
-
-(This section will be moved to :doc:`developer/release`).
-
 Development environment
 -----------------------
 


### PR DESCRIPTION
Because this contents already moved to developer/release.