### PR TITLE
doc news: fix percona server version

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/news.po
+++ b/doc/locale/ja/LC_MESSAGES/news.po
@@ -38,7 +38,7 @@ msgid ""
 "[:doc:`/install/centos`] Added support for Percona Server 5.6.50, 5.7.32, "
 "and 8.0.21."
 msgstr ""
-"[:doc:`/install/centos`] Percona Server 5.6.45、5.7.27、8.0.21をサポートしま"
+"[:doc:`/install/centos`] Percona Server 5.6.50、5.7.32、8.0.21をサポートしま"
 "した。"
 
 msgid ""


### PR DESCRIPTION
v10.9-Percona Serverの対応バージョンの記述が正しくなかったようなので修正.