### PR TITLE
packages percona-server-8.0: use the bundled zlib only on CentOS 7

### DIFF
--- a/packages/percona-server-8.0-mroonga/yum/percona-server-80-mroonga.spec.in
+++ b/packages/percona-server-8.0-mroonga/yum/percona-server-80-mroonga.spec.in
@@ -76,7 +76,6 @@ fi
 %build
 mysql_source_base_name=percona-server-%{_mysql_version}-%{_percona_server_version}
 mysql_source=../${mysql_source_base_name}/${mysql_source_base_name}
-centos_version=%{_centos_ver}
 if [ ! -d ${mysql_source} ]; then
     specs_dir=
     MYSQL_RPMBUILD_TEST=no rpmbuild -bp \

--- a/packages/percona-server-8.0-mroonga/yum/percona-server-80-mroonga.spec.in
+++ b/packages/percona-server-8.0-mroonga/yum/percona-server-80-mroonga.spec.in
@@ -76,6 +76,7 @@ fi
 %build
 mysql_source_base_name=percona-server-%{_mysql_version}-%{_percona_server_version}
 mysql_source=../${mysql_source_base_name}/${mysql_source_base_name}
+centos_version=%{_centos_ver}
 if [ ! -d ${mysql_source} ]; then
     specs_dir=
     MYSQL_RPMBUILD_TEST=no rpmbuild -bp \
@@ -84,14 +85,24 @@ if [ ! -d ${mysql_source} ]; then
         ../../SPECS/%{_mysql_spec_file}
     pushd ${mysql_source}
     mkdir build && pushd build
-    cmake3 .. \
-        -DBUILD_CONFIG=mysql_release \
-        -DINSTALL_LAYOUT=RPM \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DWITH_BOOST=../.. \
-        -DWITH_ZLIB=bundled \
-        -DINSTALL_LIBDIR="%{_lib}/mysql" \
-        -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
+    if [ ${centos_version} -eq 7 ]; then
+      cmake3 .. \
+          -DBUILD_CONFIG=mysql_release \
+          -DINSTALL_LAYOUT=RPM \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DWITH_BOOST=../.. \
+          -DWITH_ZLIB=bundled \
+          -DINSTALL_LIBDIR="%{_lib}/mysql" \
+          -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
+    else
+      cmake3 .. \
+          -DBUILD_CONFIG=mysql_release \
+          -DINSTALL_LAYOUT=RPM \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DWITH_BOOST=../.. \
+          -DINSTALL_LIBDIR="%{_lib}/mysql" \
+          -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
+    fi
     popd && popd
 fi
 %configure \

--- a/packages/percona-server-8.0-mroonga/yum/percona-server-80-mroonga.spec.in
+++ b/packages/percona-server-8.0-mroonga/yum/percona-server-80-mroonga.spec.in
@@ -85,24 +85,16 @@ if [ ! -d ${mysql_source} ]; then
         ../../SPECS/%{_mysql_spec_file}
     pushd ${mysql_source}
     mkdir build && pushd build
-    if [ ${centos_version} -eq 7 ]; then
-      cmake3 .. \
-          -DBUILD_CONFIG=mysql_release \
-          -DINSTALL_LAYOUT=RPM \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DWITH_BOOST=../.. \
-          -DWITH_ZLIB=bundled \
-          -DINSTALL_LIBDIR="%{_lib}/mysql" \
-          -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
-    else
-      cmake3 .. \
-          -DBUILD_CONFIG=mysql_release \
-          -DINSTALL_LAYOUT=RPM \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DWITH_BOOST=../.. \
-          -DINSTALL_LIBDIR="%{_lib}/mysql" \
-          -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
-    fi
+    cmake3 .. \
+        -DBUILD_CONFIG=mysql_release \
+        -DINSTALL_LAYOUT=RPM \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DWITH_BOOST=../.. \
+%if %{_centos_ver} == 7
+        -DWITH_ZLIB=bundled \
+%endif
+        -DINSTALL_LIBDIR="%{_lib}/mysql" \
+        -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
     popd && popd
 fi
 %configure \


### PR DESCRIPTION
Because CentOS 8 ships zlib 1.2.11.