### PR TITLE
packages windows: Use an archive for uploading an artifact

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -186,7 +186,6 @@ jobs:
       # Artifact
       - name: Compress the artifact
         run: |
-          ls mariadb-${{ matrix.mariadb-version }}-${{ matrix.package-platform }}
           Compress-Archive `
             -Path mariadb-${{ matrix.mariadb-version }}-${{ matrix.package-platform }}\* `
             -DestinationPath "${{ steps.info.outputs.artifact-name }}.zip"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -184,10 +184,16 @@ jobs:
             ..\mroonga\
 
       # Artifact
+      - name: Compress the artifact
+        run: |
+          ls mariadb-${{ matrix.mariadb-version }}-${{ matrix.package-platform }}
+          Compress-Archive `
+            -Path mariadb-${{ matrix.mariadb-version }}-${{ matrix.package-platform }}\* `
+            -DestinationPath "${{ steps.info.outputs.artifact-name }}.zip"
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.info.outputs.artifact-name }}
-          path: mariadb-${{ matrix.mariadb-version }}-${{ matrix.package-platform }}
+          path: ${{ steps.info.outputs.artifact-name }}.zip
 
       # Release
       - name: Ensure creating release
@@ -205,13 +211,6 @@ jobs:
             const script = fs.readFileSync(path).toString();
             const func = new AsyncFunction("require", "github", "context", script);
             return await func(require, github, context);
-      - name: Compress the artifact
-        if: |
-          startsWith(github.ref, 'refs/tags/')
-        run: |
-          Compress-Archive `
-            -Path mariadb-${{ matrix.mariadb-version }}-${{ matrix.package-platform }} `
-            -DestinationPath "${{ steps.info.outputs.artifact-name }}.zip"
       - name: Upload the artifact to release
         uses: actions/upload-release-asset@v1.0.1
         if: |


### PR DESCRIPTION
Because if we don't use an archive for uploading an artifact, an
artifact uploading becomes slow.