### PR TITLE
packages centos-7: use the old Apache Arrow

### DIFF
--- a/packages/mariadb-server-10.2-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mariadb-server-10.2-mroonga/yum/centos-7/Dockerfile
@@ -19,6 +19,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     MariaDB-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/mariadb-server-10.3-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mariadb-server-10.3-mroonga/yum/centos-7/Dockerfile
@@ -19,6 +19,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     MariaDB-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/mariadb-server-10.4-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mariadb-server-10.4-mroonga/yum/centos-7/Dockerfile
@@ -19,6 +19,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     MariaDB-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/mariadb-server-10.5-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mariadb-server-10.5-mroonga/yum/centos-7/Dockerfile
@@ -19,6 +19,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     MariaDB-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/mysql-server-5.6-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mysql-server-5.6-mroonga/yum/centos-7/Dockerfile
@@ -14,6 +14,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     mysql-community-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/mysql-server-5.7-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mysql-server-5.7-mroonga/yum/centos-7/Dockerfile
@@ -14,6 +14,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     mysql-community-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/mysql-server-8.0-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mysql-server-8.0-mroonga/yum/centos-7/Dockerfile
@@ -18,6 +18,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     mysql-community-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake3 \
     cyrus-sasl-devel \
     devtoolset-${DEVTOOLSET_VERSION} \

--- a/packages/percona-server-5.6-mroonga/yum/centos-7/Dockerfile
+++ b/packages/percona-server-5.6-mroonga/yum/centos-7/Dockerfile
@@ -11,6 +11,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     Percona-Server-devel-56 \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/percona-server-5.7-mroonga/yum/centos-7/Dockerfile
+++ b/packages/percona-server-5.7-mroonga/yum/centos-7/Dockerfile
@@ -12,6 +12,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     Percona-Server-devel-57 \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cyrus-sasl-devel \
     gcc \

--- a/packages/percona-server-8.0-mroonga/yum/centos-7/Dockerfile
+++ b/packages/percona-server-8.0-mroonga/yum/centos-7/Dockerfile
@@ -18,6 +18,7 @@ RUN \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     percona-server-devel \
+    arrow-devel-2.0.0-1.el7.x86_64 \
     cmake \
     cmake3 \
     cyrus-sasl-devel \


### PR DESCRIPTION
Because libgroonga 10.1.1 depends on libarrow 2.0.0.
However, currently the repository of Apache Arrow on CentOS7 provide
libarrow 3.0.0.

Therefore, we can't build Mroonga on CentOS7 now.
(e.g. https://github.com/mroonga/mroonga/runs/1767521129?check_suite_focus=true#step:12:1368)

This patch is temporary modification until release Groonga 11.0.0.