### PR TITLE
packages mysql-server-8.0: use bundled zlib on centos7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,11 +201,9 @@ AC_DEFUN([CONFIG_OPTION_MYSQL],[
     mysql_protobuf_include_dir="$ac_mysql_source_dir/extra/protobuf/protobuf-3.11.4/src"
     MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_protobuf_include_dir"
   fi
-  if test -d "$ac_mysql_source_dir/extra/zlib"; then
+  if test -d "$ac_mysql_build_dir/extra/zlib"; then
     mysql_zlib_include_dir="$ac_mysql_source_dir/extra/zlib"
     MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_zlib_include_dir"
-  fi
-  if test -d "$ac_mysql_build_dir/extra/zlib"; then
     mysql_zlib_config_include_dir="$ac_mysql_build_dir/extra/zlib"
     MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_zlib_config_include_dir"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -201,9 +201,13 @@ AC_DEFUN([CONFIG_OPTION_MYSQL],[
     mysql_protobuf_include_dir="$ac_mysql_source_dir/extra/protobuf/protobuf-3.11.4/src"
     MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_protobuf_include_dir"
   fi
-  if test -d "$ac_mysql_build_dir/extra/zlib"; then
+  if test -d "$ac_mysql_source_dir/extra/zlib"; then
     mysql_zlib_include_dir="$ac_mysql_source_dir/extra/zlib"
     MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_zlib_include_dir"
+  fi
+  if test -d "$ac_mysql_build_dir/extra/zlib"; then
+    mysql_zlib_config_include_dir="$ac_mysql_build_dir/extra/zlib"
+    MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_zlib_config_include_dir"
   fi
   MYSQL_INCLUDES="$MYSQL_INCLUDES -I$ac_mysql_source_dir"
   MYSQL_INCLUDES="$MYSQL_INCLUDES $($ac_mysql_config --include)"

--- a/configure.ac
+++ b/configure.ac
@@ -201,6 +201,10 @@ AC_DEFUN([CONFIG_OPTION_MYSQL],[
     mysql_protobuf_include_dir="$ac_mysql_source_dir/extra/protobuf/protobuf-3.11.4/src"
     MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_protobuf_include_dir"
   fi
+  if test -d "$ac_mysql_build_dir/extra/zlib"; then
+    mysql_zlib_include_dir="$ac_mysql_source_dir/extra/zlib"
+    MYSQL_INCLUDES="$MYSQL_INCLUDES -I$mysql_zlib_include_dir"
+  fi
   MYSQL_INCLUDES="$MYSQL_INCLUDES -I$ac_mysql_source_dir"
   MYSQL_INCLUDES="$MYSQL_INCLUDES $($ac_mysql_config --include)"
   AC_SUBST(MYSQL_INCLUDES)

--- a/packages/mysql-server-8.0-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mysql-server-8.0-mroonga/yum/centos-7/Dockerfile
@@ -47,6 +47,5 @@ RUN \
     tar \
     time \
     wget \
-    which \
-    zlib-devel && \
+    which && \
   yum clean ${quiet} all

--- a/packages/mysql-server-8.0-mroonga/yum/mysql80-community-mroonga.spec.in
+++ b/packages/mysql-server-8.0-mroonga/yum/mysql80-community-mroonga.spec.in
@@ -80,6 +80,9 @@ if [ ! -d ${mysql_source} ]; then
         -DINSTALL_LAYOUT=RPM \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DWITH_BOOST=../.. \
+%if %{_centos_ver} == 7
+        -DWITH_ZLIB=bundled \
+%endif
         -DINSTALL_LIBDIR="%{_lib}/mysql" \
         -DINSTALL_PLUGINDIR="%{_lib}/mysql/plugin"
     popd && popd

--- a/packages/mysql-server-8.0-mroonga/yum/mysql80-community-mroonga.spec.in
+++ b/packages/mysql-server-8.0-mroonga/yum/mysql80-community-mroonga.spec.in
@@ -1,6 +1,6 @@
 %define _centos_ver %{?centos_ver:%{centos_ver}}%{!?centos_ver:5}
 
-%define mysql_version_default 8.0.22
+%define mysql_version_default 8.0.23
 %define mysql_release_default 1
 %define mysql_dist_default    el%{_centos_ver}
 %define mysql_download_base_url_default http://repo.mysql.com/yum/mysql-8.0-community/el/%{_centos_ver}/SRPMS/


### PR DESCRIPTION
1. mysql-server use the "crc32_z" function since version 8.0.23. This function is included zlib library, since version 1.2.9.
    If the version of zlib library is old that is provided on our OS (e.g. CentOS7), we can't build Mroonga.

2. mysql-server use the "z_size_t" type. This type is included "zconf.h".
    However, "zconf.h" does not exist in MySQL source directory.
    This header is generated in MySQL build directory after build MySQL.
    Therefore, we use the zlib library that is bundled MySQL 8.