### PR TITLE
Don't use raw bitmap

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -6660,7 +6660,7 @@ int ha_mroonga::wrapper_write_row_index(mrn_write_row_buf_t buf)
     DBUG_RETURN(0);
   }
 
-  mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+  mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
   uint i;
   uint n_keys = table->s->keys;
   for (i = 0; i < n_keys; i++) {
@@ -6735,7 +6735,7 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
       DBUG_RETURN(error);
   }
 
-  mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+  mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
   for (i = 0; i < n_columns; i++) {
     Field *field = table->field[i];
 
@@ -7007,7 +7007,7 @@ int ha_mroonga::storage_write_row_multiple_column_indexes(mrn_write_row_buf_t bu
 
   int error = 0;
 
-  mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+  mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
   uint i;
   uint n_keys = table->s->keys;
   for (i = 0; i < n_keys; i++) {
@@ -7309,7 +7309,7 @@ int ha_mroonga::wrapper_update_row_index(const uchar *old_data,
     DBUG_RETURN(0);
   }
 
-  mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+  mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
   uint i;
   uint n_keys = table->s->keys;
   for (i = 0; i < n_keys; i++) {
@@ -7431,7 +7431,7 @@ int ha_mroonga::storage_update_row(const uchar *old_data,
       grn_obj new_value;
       GRN_VOID_INIT(&new_value);
       {
-        mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+        mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
         generic_store_bulk(field, &new_value);
       }
       grn_obj casted_value;
@@ -7460,7 +7460,7 @@ int ha_mroonga::storage_update_row(const uchar *old_data,
   storage_store_fields_for_prep_update(old_data, new_data, record_id);
   {
     mrn::Lock lock(&(share->record_mutex), have_unique_index());
-    mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+    mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
     if ((error = storage_prepare_delete_row_unique_indexes(old_data,
                                                            record_id))) {
       DBUG_RETURN(error);
@@ -7486,7 +7486,7 @@ int ha_mroonga::storage_update_row(const uchar *old_data,
 #endif
 
     if (bitmap_is_set(table->write_set, MRN_FIELD_FIELD_INDEX(field))) {
-      mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+      mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
       DBUG_PRINT("info", ("mroonga: update column %d(%d)",i,MRN_FIELD_FIELD_INDEX(field)));
 
       if (field->is_null()) continue;
@@ -7567,7 +7567,7 @@ int ha_mroonga::storage_update_row(const uchar *old_data,
   if (table->found_next_number_field &&
       !table->s->next_number_keypart &&
       new_data == table->record[0]) {
-    mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+    mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
     Field_num *field = (Field_num *) table->found_next_number_field;
     if (MRN_FIELD_IS_UNSIGNED(field) || field->val_int() > 0) {
       MRN_LONG_TERM_SHARE *long_term_share = share->long_term_share;
@@ -7624,7 +7624,7 @@ int ha_mroonga::storage_update_row_index(const uchar *old_data,
 
   my_ptrdiff_t ptr_diff = mrn_compute_ptr_diff_for_key(old_data, table->record[0]);
 
-  mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+  mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
   uint i;
   uint n_keys = table->s->keys;
   mrn_change_encoding(ctx, NULL);
@@ -7847,7 +7847,7 @@ int ha_mroonga::wrapper_delete_row_index(const uchar *buf)
     DBUG_RETURN(0);
   }
 
-  mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+  mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
   uint i;
   uint n_keys = table->s->keys;
   for (i = 0; i < n_keys; i++) {
@@ -7998,7 +7998,7 @@ int ha_mroonga::storage_delete_row_index(const uchar *buf)
   GRN_TEXT_INIT(&key, 0);
   GRN_TEXT_INIT(&encoded_key, 0);
 
-  mrn::DebugColumnAccess debug_column_access(table, table->read_set);
+  mrn::DebugColumnAccess debug_column_access(table, &(table->read_set));
   uint i;
   uint n_keys = table->s->keys;
   mrn_change_encoding(ctx, NULL);
@@ -12407,7 +12407,7 @@ void ha_mroonga::storage_store_fields(uchar *buf, grn_id record_id)
         }
       }
 
-      mrn::DebugColumnAccess debug_column_access(table, table->write_set);
+      mrn::DebugColumnAccess debug_column_access(table, &(table->write_set));
       DBUG_PRINT("info", ("mroonga: store column %d(%d)",i,MRN_FIELD_FIELD_INDEX(field)));
       field->move_field_offset(ptr_diff);
       if (FIELD_NAME_EQUAL(field, MRN_COLUMN_NAME_ID)) {
@@ -12452,7 +12452,7 @@ void ha_mroonga::storage_store_fields_for_prep_update(const uchar *old_data,
     if (!bitmap_is_set(table->read_set, MRN_FIELD_FIELD_INDEX(field)) &&
         !bitmap_is_set(table->write_set, MRN_FIELD_FIELD_INDEX(field)) &&
         bitmap_is_set(&multiple_column_key_bitmap, MRN_FIELD_FIELD_INDEX(field))) {
-      mrn::DebugColumnAccess debug_column_access(table, table->write_set);
+      mrn::DebugColumnAccess debug_column_access(table, &(table->write_set));
       DBUG_PRINT("info", ("mroonga: store column %d(%d)",i,MRN_FIELD_FIELD_INDEX(field)));
       grn_obj value;
       GRN_OBJ_INIT(&value, GRN_BULK, 0, grn_obj_get_range(ctx, grn_columns[i]));
@@ -12488,7 +12488,7 @@ void ha_mroonga::storage_store_fields_by_index(uchar *buf)
   if (KEY_N_KEY_PARTS(key_info) == 1) {
     my_ptrdiff_t ptr_diff = buf - table->record[0];
     Field *field = key_info->key_part->field;
-    mrn::DebugColumnAccess debug_column_access(table, table->write_set);
+    mrn::DebugColumnAccess debug_column_access(table, &(table->write_set));
     field->move_field_offset(ptr_diff);
     storage_store_field(field, (const char *)key, key_length);
     field->move_field_offset(-ptr_diff);

--- a/lib/mrn_debug_column_access.cpp
+++ b/lib/mrn_debug_column_access.cpp
@@ -22,14 +22,14 @@
 #include <table.h>
 
 namespace mrn {
-  DebugColumnAccess::DebugColumnAccess(TABLE *table, MY_BITMAP *bitmap)
+  DebugColumnAccess::DebugColumnAccess(TABLE *table, MY_BITMAP **bitmap)
     : table_(table),
       bitmap_(bitmap) {
 #ifndef DBUG_OFF
 #  ifdef MRN_DBUG_TMP_USE_BITMAP_PP
-    map_ = dbug_tmp_use_all_columns(table_, &bitmap_);
-#  else
     map_ = dbug_tmp_use_all_columns(table_, bitmap_);
+#  else
+    map_ = dbug_tmp_use_all_columns(table_, *bitmap_);
 #  endif
 #endif
   }
@@ -37,9 +37,9 @@ namespace mrn {
   DebugColumnAccess::~DebugColumnAccess() {
 #ifndef DBUG_OFF
 #  ifdef MRN_DBUG_TMP_USE_BITMAP_PP
-    dbug_tmp_restore_column_map(&bitmap_, map_);
-#  else
     dbug_tmp_restore_column_map(bitmap_, map_);
+#  else
+    dbug_tmp_restore_column_map(*bitmap_, map_);
 #  endif
 #endif
   }

--- a/lib/mrn_debug_column_access.cpp
+++ b/lib/mrn_debug_column_access.cpp
@@ -1,6 +1,7 @@
 /* -*- c-basic-offset: 2 -*- */
 /*
   Copyright(C) 2012-2018 Kouhei Sutou <kou@clear-code.com>
+  Copyright(C) 2021 Horimoto Yasuhiro <horimoto@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -25,13 +26,21 @@ namespace mrn {
     : table_(table),
       bitmap_(bitmap) {
 #ifndef DBUG_OFF
+#  ifdef DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
+    map_ = dbug_tmp_use_all_columns(table_, &bitmap_);
+#  else
     map_ = dbug_tmp_use_all_columns(table_, bitmap_);
+#  endif
 #endif
   }
 
   DebugColumnAccess::~DebugColumnAccess() {
 #ifndef DBUG_OFF
+#  ifdef DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
+    dbug_tmp_restore_column_map(&bitmap_, map_);
+#  else
     dbug_tmp_restore_column_map(bitmap_, map_);
+#  endif
 #endif
   }
 }

--- a/lib/mrn_debug_column_access.cpp
+++ b/lib/mrn_debug_column_access.cpp
@@ -26,7 +26,7 @@ namespace mrn {
     : table_(table),
       bitmap_(bitmap) {
 #ifndef DBUG_OFF
-#  ifdef DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
+#  ifdef MRN_DBUG_TMP_USE_BITMAP_PP
     map_ = dbug_tmp_use_all_columns(table_, &bitmap_);
 #  else
     map_ = dbug_tmp_use_all_columns(table_, bitmap_);
@@ -36,7 +36,7 @@ namespace mrn {
 
   DebugColumnAccess::~DebugColumnAccess() {
 #ifndef DBUG_OFF
-#  ifdef DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
+#  ifdef MRN_DBUG_TMP_USE_BITMAP_PP
     dbug_tmp_restore_column_map(&bitmap_, map_);
 #  else
     dbug_tmp_restore_column_map(bitmap_, map_);

--- a/lib/mrn_debug_column_access.hpp
+++ b/lib/mrn_debug_column_access.hpp
@@ -31,7 +31,7 @@ namespace mrn {
     TABLE *table_;
     MY_BITMAP *bitmap_;
 #ifndef DBUG_OFF
-#  ifdef DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
+#  ifdef MRN_DBUG_TMP_USE_BITMAP_PP
     MY_BITMAP *map_;
 #  else
     my_bitmap_map *map_;

--- a/lib/mrn_debug_column_access.hpp
+++ b/lib/mrn_debug_column_access.hpp
@@ -29,7 +29,7 @@
 namespace mrn {
   class DebugColumnAccess {
     TABLE *table_;
-    MY_BITMAP *bitmap_;
+    MY_BITMAP **bitmap_;
 #ifndef DBUG_OFF
 #  ifdef MRN_DBUG_TMP_USE_BITMAP_PP
     MY_BITMAP *map_;
@@ -38,7 +38,7 @@ namespace mrn {
 #  endif
 #endif
   public:
-    DebugColumnAccess(TABLE *table, MY_BITMAP *bitmap);
+    DebugColumnAccess(TABLE *table, MY_BITMAP **bitmap);
     ~DebugColumnAccess();
   };
 }

--- a/lib/mrn_debug_column_access.hpp
+++ b/lib/mrn_debug_column_access.hpp
@@ -1,6 +1,7 @@
 /* -*- c-basic-offset: 2 -*- */
 /*
   Copyright(C) 2012-2018 Kouhei Sutou <kou@clear-code.com>
+  Copyright(C) 2021 Horimoto Yasuhiro <horimoto@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -23,12 +24,18 @@
 #include <mrn_mysql.h>
 #include <my_bitmap.h>
 
+#include "mrn_mysql_compat.h"
+
 namespace mrn {
   class DebugColumnAccess {
     TABLE *table_;
     MY_BITMAP *bitmap_;
 #ifndef DBUG_OFF
+#  ifdef DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
+    MY_BITMAP *map_;
+#  else
     my_bitmap_map *map_;
+#  endif
 #endif
   public:
     DebugColumnAccess(TABLE *table, MY_BITMAP *bitmap);

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -1,7 +1,7 @@
 /* -*- c-basic-offset: 2 -*- */
 /*
   Copyright(C) 2011-2020 Sutou Kouhei <kou@clear-code.com>
-  Copyright(C) 2020 Horimoto Yasuhiro <horimoto@clear-code.com>
+  Copyright(C) 2020-2021 Horimoto Yasuhiro <horimoto@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -947,4 +947,11 @@ typedef HASH mrn_table_def_cache_type;
 #else
 #  define MRN_BITMAP_INIT(map, buf, n_bits) \
     bitmap_init((map), (buf), (n_bits), false)
+#endif
+
+#if defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 100237 || \
+                               MYSQL_VERSION_ID >= 100328 || \
+                               MYSQL_VERSION_ID >= 100418 || \
+                               MYSQL_VERSION_ID >= 100509)
+#  define DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -953,5 +953,5 @@ typedef HASH mrn_table_def_cache_type;
                                MYSQL_VERSION_ID >= 100328 || \
                                MYSQL_VERSION_ID >= 100418 || \
                                MYSQL_VERSION_ID >= 100509)
-#  define DO_NOT_USE_RAW_BITMAP_FOR_DEBUG
+#  define MRN_DBUG_TMP_USE_BITMAP_PP
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -949,9 +949,9 @@ typedef HASH mrn_table_def_cache_type;
     bitmap_init((map), (buf), (n_bits), false)
 #endif
 
-#if defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 100237 || \
-                               MYSQL_VERSION_ID >= 100328 || \
-                               MYSQL_VERSION_ID >= 100418 || \
-                               MYSQL_VERSION_ID >= 100509)
+#if defined(MRN_MARIADB_P) && ((MYSQL_VERSION_ID >= 100237 && MYSQL_VERSION_ID < 100300) || \
+                               (MYSQL_VERSION_ID >= 100328 && MYSQL_VERSION_ID < 100400) || \
+                               (MYSQL_VERSION_ID >= 100418 && MYSQL_VERSION_ID < 100500) || \
+                               (MYSQL_VERSION_ID >= 100509))
 #  define MRN_DBUG_TMP_USE_BITMAP_PP
 #endif


### PR DESCRIPTION
Because the following patch changes function prototypes for "dbug_tmp_restore_column_maps" and "dbug_tmp_use_all_columns".

See: https://github.com/MariaDB/server/commit/21809f9a450df1bc44cef36377f96b516ac4a9ae