### PR TITLE
github-actions: use libmysqlclient-dev for /usr/bin/mysql_config

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -86,7 +86,7 @@ jobs:
             gettext \
             groonga-normalizer-mysql \
             libgroonga-dev \
-            libmysqld-dev \
+            libmysqlclient-dev \
             libtool \
             python3-pip \
             ruby


### PR DESCRIPTION
GitHub actions has updated the OS version to Ubuntu 20.0.4 lately.

libmysqld-dev is obsolete in Ubuntu 20.0.4 LTS.
Therefore, we use libmysqlclient-dev instead of it for `/usr/bin/mysql_config`.