### PR TITLE
packages mariadb-server: Install Judy-Devel directly 

### DIFF
--- a/packages/mariadb-server-10.3-mroonga/yum/centos-8/Dockerfile
+++ b/packages/mariadb-server-10.3-mroonga/yum/centos-8/Dockerfile
@@ -20,6 +20,13 @@ RUN \
   dnf install --enablerepo=powertools -y ${quiet} \
     'dnf-command(builddep)' \
     'dnf-command(download)' && \
+  # Install Judy-Devel directly.
+  # Because dnf --enablerepo=powertools install Judy-devel is fail.
+  # Probably, the metadata of the PowerTolls repository of CentOS8 has been broken.
+  # Therefore, we install Judy-Devel from RPM.
+  # We will remove this command when the metadata will be fixed.
+  yum install -y ${quiet} \
+    http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm && \
   dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
   dnf download -y ${quiet} --source MariaDB && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/packages/mariadb-server-10.4-mroonga/yum/centos-8/Dockerfile
+++ b/packages/mariadb-server-10.4-mroonga/yum/centos-8/Dockerfile
@@ -20,6 +20,13 @@ RUN \
   dnf install --enablerepo=powertools -y ${quiet} \
     'dnf-command(builddep)' \
     'dnf-command(download)' && \
+  # Install Judy-Devel directly.
+  # Because dnf --enablerepo=powertools install Judy-devel is fail.
+  # Probably, the metadata of the PowerTolls repository of CentOS8 has been broken.
+  # Therefore, we install Judy-Devel from RPM.
+  # We will remove this command when the metadata will be fixed.
+  yum install -y ${quiet} \
+    http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm && \
   dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
   dnf download -y ${quiet} --source MariaDB && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/packages/mariadb-server-10.5-mroonga/yum/centos-8/Dockerfile
+++ b/packages/mariadb-server-10.5-mroonga/yum/centos-8/Dockerfile
@@ -20,6 +20,13 @@ RUN \
   dnf install --enablerepo=powertools -y ${quiet} \
     'dnf-command(builddep)' \
     'dnf-command(download)' && \
+  # Install Judy-Devel directly.
+  # Because dnf --enablerepo=powertools install Judy-devel is fail.
+  # Probably, the metadata of the PowerTolls repository of CentOS8 has been broken.
+  # Therefore, we install Judy-Devel from RPM.
+  # We will remove this command when the metadata will be fixed.
+  yum install -y ${quiet} \
+    http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm && \
   dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
   dnf download -y ${quiet} --source MariaDB && \
   dnf install --enablerepo=powertools -y ${quiet} \


### PR DESCRIPTION
Judy-devel pacakge is installed by `dnf builddep --enablerepo=powertools -y MariaDB`.
However, currently,  the installation of the Judy-devel from PowerTools repository is fail.
(`dnf --enablerepo=powertools install Judy-devel` is also failing.)

Probably, the metadata of the PowerTolls repository of CentOS8 has been broken.
Therefore, we install Judy-Devel from RPM.
We will remove this patch when the metadata will be fixed.