### PR TITLE
package ubuntu: package name change to ubuntu's package name

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -89,6 +89,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     cache_key = [code_name, package_name]
     version = @ubuntu_package_versions[cache_key]
     return version if version
+    ubuntu_package_name = package_name.sub(/-/, "-server-")
     source_names = [code_name, "#{code_name}-updates"]
     source_names.each do |source_name|
       all_packages_url =
@@ -96,7 +97,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
       URI.open(all_packages_url) do |all_packages|
         all_packages.each_line do |line|
           case line
-          when /\A#{Regexp.escape(package_name.sub(/-/, "-server-"))} \((.+?)[\s)]/o
+          when /\A#{Regexp.escape(ubuntu_package_name)} \((.+?)[\s)]/o
             version = $1
           end
         end

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -84,17 +84,6 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     end
   end
 
-  def ubuntu_package_name(package_name)
-    ubuntu_package_names = {
-      "mariadb-10.2" => "mariadb-server-10.2",
-      "mariadb-10.3" => "mariadb-server-10.3",
-      "mariadb-10.4" => "mariadb-server-10.4",
-      "mariadb-10.5" => "mariadb-server-10.5",
-      "mysql-5.7" => "mysql-server-5.7",
-    }
-    ubuntu_package_names[package_name]
-  end
-
   def detect_ubuntu_package_version(code_name, package_name)
     @ubuntu_package_versions ||= {}
     cache_key = [code_name, package_name]
@@ -107,7 +96,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
       URI.open(all_packages_url) do |all_packages|
         all_packages.each_line do |line|
           case line
-          when /\A#{Regexp.escape(ubuntu_package_name(package_name))} \((.+?)[\s)]/o
+          when /\A#{Regexp.escape(package_name.sub(/-/, "-server-"))} \((.+?)[\s)]/o
             version = $1
           end
         end

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -84,6 +84,17 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     end
   end
 
+  def ubuntu_package_name(package_name)
+    ubuntu_package_names = {
+      "mariadb-10.2" => "mariadb-server-10.2",
+      "mariadb-10.3" => "mariadb-server-10.3",
+      "mariadb-10.4" => "mariadb-server-10.4",
+      "mariadb-10.5" => "mariadb-server-10.5",
+      "mysql-5.7" => "mysql-server-5.7",
+    }
+    ubuntu_package_names[package_name]
+  end
+
   def detect_ubuntu_package_version(code_name, package_name)
     @ubuntu_package_versions ||= {}
     cache_key = [code_name, package_name]
@@ -96,7 +107,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
       URI.open(all_packages_url) do |all_packages|
         all_packages.each_line do |line|
           case line
-          when /\A#{Regexp.escape(package_name)} \((.+?)[\s)]/o
+          when /\A#{Regexp.escape(ubuntu_package_name(package_name))} \((.+?)[\s)]/o
             version = $1
           end
         end

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -89,6 +89,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     cache_key = [code_name, package_name]
     version = @ubuntu_package_versions[cache_key]
     return version if version
+    # "mariadb-10.5" -> "mariadb-server-10.5"
+    # "mysql-5.7" -> "mysql-server-5.7"
     ubuntu_package_name = package_name.sub(/-/, "-server-")
     source_names = [code_name, "#{code_name}-updates"]
     source_names.each do |source_name|


### PR DESCRIPTION
Mroonga's package name is changed  by the following commit.
https://github.com/mroonga/mroonga/commit/6bd846f2136fd7c657f232212cfc4759f9dc7e59

However, Ubuntu's MySQL package is mariadb-server-10.x and mysql-server-5.x.
Therefore, we need to convert Mroonga's package name to Ubuntu's package name.
Otherwise, we can't get version for MySQL and MariaDB for Ubuntu.