### PR TITLE
package mariadb-10.3: rebuild against the latest MariaDB 10.3 package

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -138,12 +138,21 @@ jobs:
           restore-keys: package-${{ matrix.os }}-${{ matrix.package }}-ccache-
       - name: Build with Docker
         run: |
+          case ${{ matrix.os }} in
+            debian-*)
+              deb_release=$(head -n1 packages/${{ matrix.package }}-mroonga/debian/changelog | \
+                            awk '{print $2}' | \
+                            awk -F "-" '{print $2}' | \
+                            sed -e 's/[^0-9]//g')
+              ;;
+          esac
           cd packages/${{ matrix.package }}-mroonga
           rake ${{ matrix.package-type }}:build BUILD_DIR=build
         env:
           APT_TARGETS: ${{ matrix.os }}
           GROONGA_REPOSITORY: ../../../groonga
           YUM_TARGETS: ${{ matrix.os }}
+          DEB_RELEASE: ${deb_release}
 
       # Artifact
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -119,6 +119,8 @@ jobs:
         run: |
           make dist
       - name: Update version
+        if: |
+          github.ref == 'refs/heads/master'
         run: |
           case ${{ matrix.os }} in
             debian-*)
@@ -138,16 +140,8 @@ jobs:
           restore-keys: package-${{ matrix.os }}-${{ matrix.package }}-ccache-
       - name: Build with Docker
         run: |
-          case ${{ matrix.os }} in
-            debian-*)
-              deb_release=$(head -n1 packages/${{ matrix.package }}-mroonga/debian/changelog | \
-                            awk '{print $2}' | \
-                            awk -F "-" '{print $2}' | \
-                            sed -e 's/[^0-9]//g')
-              ;;
-          esac
           cd packages/${{ matrix.package }}-mroonga
-          rake ${{ matrix.package-type }}:build BUILD_DIR=build DEB_RELEASE=${deb_release}
+          rake ${{ matrix.package-type }}:build BUILD_DIR=build
         env:
           APT_TARGETS: ${{ matrix.os }}
           GROONGA_REPOSITORY: ../../../groonga

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -147,12 +147,11 @@ jobs:
               ;;
           esac
           cd packages/${{ matrix.package }}-mroonga
-          rake ${{ matrix.package-type }}:build BUILD_DIR=build
+          rake ${{ matrix.package-type }}:build BUILD_DIR=build DEB_RELEASE=${deb_release}
         env:
           APT_TARGETS: ${{ matrix.os }}
           GROONGA_REPOSITORY: ../../../groonga
           YUM_TARGETS: ${{ matrix.os }}
-          DEB_RELEASE: ${deb_release}
 
       # Artifact
       - uses: actions/upload-artifact@v2

--- a/packages/mariadb-10.3-mroonga/debian/changelog
+++ b/packages/mariadb-10.3-mroonga/debian/changelog
@@ -1,3 +1,9 @@
+mariadb-10.3-mroonga (11.03-2) unstable; urgency=low
+
+  * Rebuilt against MariaDB 10.3.29.
+
+ -- Horimoto Yasuhiro <horimoto@clear-code.com>  Mon, 21 Jun 2021 15:00:00 -0000
+
 mariadb-10.3-mroonga (11.03-1) unstable; urgency=low
 
   * New upstream release.


### PR DESCRIPTION
We need to increase minor version of Debian package for Mroonga when we update Debian package for Mroonga.