### PR TITLE
ci: add support for "maintenance/XX.XX" branch name

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,13 +1,8 @@
 name: Linux
 on:
   push:
-    branches:
-      - "**"
-    tags:
-      - "*"
   pull_request:
     branches:
-      - "*"
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: Linux
 on:
   push:
     branches:
-      - "*"
+      - "**"
     tags:
       - "*"
   pull_request:
@@ -120,7 +120,8 @@ jobs:
           make dist
       - name: Update version
         if: |
-          github.ref == 'refs/heads/master'
+          !startsWith(github.ref, 'refs/tags/') &&
+          !startsWith(github.ref, 'refs/heads/maintenance/')
         run: |
           case ${{ matrix.os }} in
             debian-*)


### PR DESCRIPTION
Because we will rename maintenance branch name to "maintenance/XX.XX" from "vXX.XX-maintenance".