### PR TITLE
packages mariadb: add a missing dependency package

### DIFF
--- a/packages/mariadb-10.3-mroonga/yum/centos-8/Dockerfile
+++ b/packages/mariadb-10.3-mroonga/yum/centos-8/Dockerfile
@@ -32,6 +32,7 @@ RUN \
     groonga-devel \
     groonga-normalizer-mysql-devel \
     intltool \
+    jemalloc-devel \
     make \
     pkgconfig \
     sudo \

--- a/packages/mariadb-10.4-mroonga/yum/centos-8/Dockerfile
+++ b/packages/mariadb-10.4-mroonga/yum/centos-8/Dockerfile
@@ -32,6 +32,7 @@ RUN \
     groonga-devel \
     groonga-normalizer-mysql-devel \
     intltool \
+    jemalloc-devel \
     make \
     pkgconfig \
     sudo \


### PR DESCRIPTION
Because forced jemalloc to be used by
https://github.com/MariaDB/server/commit/e1bf1aea5cd8f8b5a1b15fd2a8ca0b8205654431

However, MariaDB 10.5 doesn't apply this modification.
Because it doesn't use jemalloc.
See: https://github.com/MariaDB/server/commit/9bbedcdd590f2c25c79bd9f367a7f54c1fcefdcb