### PR TITLE
ci: add a test job for maintenance branch

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -292,6 +292,8 @@ jobs:
         run: |
           vagrant up ${{ matrix.os }}
       - name: Run test
+        if: |
+          !startsWith(github.ref, 'refs/heads/maintenance/')
         run: |
           repositories_dir=packages/${{ matrix.package }}-mroonga/${{ matrix.package-type }}/repositories/
           mkdir -p "${repositories_dir}"
@@ -302,3 +304,17 @@ jobs:
             -- \
             /vagrant/packages/${{ matrix.package-type }}/test.sh \
             ${{ matrix.package }}-mroonga
+      - name: Run test (Maintenance branch)
+        if: |
+          startsWith(github.ref, 'refs/heads/maintenance/')
+        run: |
+          repositories_dir=packages/${{ matrix.package }}-mroonga/${{ matrix.package-type }}/repositories/
+          mkdir -p "${repositories_dir}"
+          os_type=$(echo "${{ matrix.os }}" | grep -o '^[^-]*')
+          cp -a ${os_type} "${repositories_dir}"
+          vagrant \
+            ssh ${{ matrix.os }} \
+            -- \
+            /vagrant/packages/${{ matrix.package-type }}/test.sh \
+            ${{ matrix.package }}-mroonga \
+            maintenance

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -291,22 +291,12 @@ jobs:
       - name: Run VM
         run: |
           vagrant up ${{ matrix.os }}
-      - name: Run test
-        if: |
-          !startsWith(github.ref, 'refs/heads/maintenance/')
-        run: |
-          repositories_dir=packages/${{ matrix.package }}-mroonga/${{ matrix.package-type }}/repositories/
-          mkdir -p "${repositories_dir}"
-          os_type=$(echo "${{ matrix.os }}" | grep -o '^[^-]*')
-          cp -a ${os_type} "${repositories_dir}"
-          vagrant \
-            ssh ${{ matrix.os }} \
-            -- \
-            /vagrant/packages/${{ matrix.package-type }}/test.sh \
-            ${{ matrix.package }}-mroonga
-      - name: Run test (Maintenance branch)
+      - name: Set branch name
         if: |
           startsWith(github.ref, 'refs/heads/maintenance/')
+        run:
+          echo "BRANCH_NAME=maintenance" >> $GITHUB_ENV
+      - name: Run test
         run: |
           repositories_dir=packages/${{ matrix.package }}-mroonga/${{ matrix.package-type }}/repositories/
           mkdir -p "${repositories_dir}"
@@ -317,4 +307,4 @@ jobs:
             -- \
             /vagrant/packages/${{ matrix.package-type }}/test.sh \
             ${{ matrix.package }}-mroonga \
-            maintenance
+            ${BRANCH_NAME}

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -3,6 +3,9 @@
 set -exu
 
 package=$1
+if [ -n "$2" ]; then
+  branch=$2
+fi
 
 mysql_version=$(echo "${package}" | grep -o '[0-9]*\.[0-9]*')
 
@@ -155,22 +158,24 @@ case ${package} in
 esac
 
 # Upgrade
-sudo ${DNF} erase -y \
-  ${package} \
-  "${mysql_package_prefix}-*"
+if [ "${package}" != "maintenance" ]; then
+  sudo ${DNF} erase -y \
+    ${package} \
+    "${mysql_package_prefix}-*"
 
-# Currently, this check is always fails in mariadb 10.6.
-# The cause of failure is the Mroonga packages for
-# MariaDB10.6 don't exist in packages.groonga.org.
-# Because the Mroonga packages for MariaDB10.6 are made for the first time.
-# Therefore, this check disable temporarily in mariadb 10.6.
-# We enable this check again after we release the next release.
-case ${package} in
-  mariadb-10.6-*)
-    exit
-    ;;
-esac
+  # Currently, this check is always fails in mariadb 10.6.
+  # The cause of failure is the Mroonga packages for
+  # MariaDB10.6 don't exist in packages.groonga.org.
+  # Because the Mroonga packages for MariaDB10.6 are made for the first time.
+  # Therefore, this check disable temporarily in mariadb 10.6.
+  # We enable this check again after we release the next release.
+  case ${package} in
+    mariadb-10.6-*)
+      exit
+      ;;
+  esac
 
-sudo ${DNF} install -y ${old_package}
-sudo ${DNF} install -y \
-  ${repositories_dir}/${os}/${major_version}/*/Packages/*.rpm
+  sudo ${DNF} install -y ${old_package}
+  sudo ${DNF} install -y \
+    ${repositories_dir}/${os}/${major_version}/*/Packages/*.rpm
+fi


### PR DESCRIPTION
TODO: Probably I can be simpler it.

The maintenance branch makes the same version packages.
Therefore, an upgrade test always fails.

We execute the upgrade test on only master.