### PR TITLE
ci: enable almalinux 8

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,9 +76,12 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mysql-community-5.7
-          - os: almalinux-8
-            package-type: yum
-            package: mysql-community-8.0
+          # The build of MySQL 8.0.27 fail by gcc-toolset-10.
+          # The cause of this build error is the error of internal of gcc.
+          # We will enable MySQL 8.0 on AlmaLinux 8 when gcc will fix this error.
+          # - os: almalinux-8
+          #   package-type: yum
+          #   package: mysql-community-8.0
           - os: centos-7
             package-type: yum
             package: mysql-community-8.0
@@ -291,9 +294,12 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mysql-community-5.7
-          - os: almalinux-8
-            package-type: yum
-            package: mysql-community-8.0
+          # The build of MySQL 8.0.27 fail by gcc-toolset-10.
+          # The cause of this build error is the error of internal of gcc.
+          # We will enable MySQL 8.0 on AlmaLinux 8 when gcc will fix this error.
+          # - os: almalinux-8
+          #   package-type: yum
+          #   package: mysql-community-8.0
           - os: centos-7
             package-type: yum
             package: mysql-community-8.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,12 +76,9 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mysql-community-5.7
-          # The build of MySQL 8.0.27 fail by gcc-toolset-10.
-          # The cause of this build error is the error of internal of gcc.
-          # We will enable MySQL 8.0 on AlmaLinux 8 when gcc will fix this error.
-          # - os: almalinux-8
-          #   package-type: yum
-          #   package: mysql-community-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-8.0
           - os: centos-7
             package-type: yum
             package: mysql-community-8.0
@@ -294,12 +291,9 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mysql-community-5.7
-          # The build of MySQL 8.0.27 fail by gcc-toolset-10.
-          # The cause of this build error is the error of internal of gcc.
-          # We will enable MySQL 8.0 on AlmaLinux 8 when gcc will fix this error.
-          # - os: almalinux-8
-          #   package-type: yum
-          #   package: mysql-community-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-8.0
           - os: centos-7
             package-type: yum
             package: mysql-community-8.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,10 +64,9 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mysql-community-5.7
-          # TODO: Need groonga-normalizer-mysql package
-          # - os: almalinux-8
-          #   package-type: yum
-          #   package: mysql-community-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-8.0
           - os: centos-7
             package-type: yum
             package: mysql-community-8.0
@@ -77,10 +76,9 @@ jobs:
           - os: centos-7
             package-type: yum
             package: percona-server-5.7
-          # TODO: Need groonga-normalizer-mysql package
-          # - os: almalinux-8
-          #   package-type: yum
-          #   package: percona-server-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: percona-server-8.0
           - os: centos-7
             package-type: yum
             package: percona-server-8.0
@@ -269,10 +267,9 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mysql-community-5.7
-          # TODO: Need groonga-normalizer-mysql package
-          # - os: almalinux-8
-          #   package-type: yum
-          #   package: mysql-community-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-8.0
           - os: centos-7
             package-type: yum
             package: mysql-community-8.0
@@ -282,10 +279,9 @@ jobs:
           - os: centos-7
             package-type: yum
             package: percona-server-5.7
-          # TODO: Need groonga-normalizer-mysql package
-          # - os: almalinux-8
-          #   package-type: yum
-          #   package: percona-server-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: percona-server-8.0
           - os: centos-7
             package-type: yum
             package: percona-server-8.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -236,24 +236,36 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mariadb-10.2
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.3
           - os: centos-7
             package-type: yum
             package: mariadb-10.3
           - os: centos-8
             package-type: yum
             package: mariadb-10.3
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.4
           - os: centos-7
             package-type: yum
             package: mariadb-10.4
           - os: centos-8
             package-type: yum
             package: mariadb-10.4
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.5
           - os: centos-7
             package-type: yum
             package: mariadb-10.5
           - os: centos-8
             package-type: yum
             package: mariadb-10.5
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.6
           - os: centos-7
             package-type: yum
             package: mariadb-10.6

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,24 +34,36 @@ jobs:
           - os: centos-7
             package-type: yum
             package: mariadb-10.2
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.3
           - os: centos-7
             package-type: yum
             package: mariadb-10.3
           - os: centos-8
             package-type: yum
             package: mariadb-10.3
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.4
           - os: centos-7
             package-type: yum
             package: mariadb-10.4
           - os: centos-8
             package-type: yum
             package: mariadb-10.4
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.5
           - os: centos-7
             package-type: yum
             package: mariadb-10.5
           - os: centos-8
             package-type: yum
             package: mariadb-10.5
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.6
           - os: centos-7
             package-type: yum
             package: mariadb-10.6

--- a/packages/mariadb-10.3-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.3-mroonga/yum/almalinux-8/Dockerfile
@@ -1,0 +1,41 @@
+ARG FROM=almalinux:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  { \
+    echo "[mariadb]"; \
+    echo "name = MariaDB"; \
+    echo "baseurl = http://yum.mariadb.org/10.3/centos8-amd64"; \
+    echo "gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"; \
+    echo "gpgcheck = 1"; \
+  } | tee /etc/yum.repos.d/MariaDB.repo && \
+  dnf install -y \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+  dnf groupinstall -y ${quiet} "Development Tools" && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    'dnf-command(builddep)' \
+    'dnf-command(download)' && \
+  dnf module --enablerepo=powertools -y ${quiet} enable mariadb-devel && \
+  dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
+  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
+  dnf module -y ${quiet} disable mariadb && \
+  dnf module -y ${quiet} disable mysql && \
+  dnf download -y ${quiet} --source MariaDB && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    MariaDB-devel \
+    ccache \
+    gcc-c++ \
+    groonga-devel \
+    groonga-normalizer-mysql-devel \
+    intltool \
+    jemalloc-devel \
+    make \
+    pkgconfig \
+    sudo \
+    wget \
+    which && \
+  dnf clean ${quiet} all

--- a/packages/mariadb-10.4-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.4-mroonga/yum/almalinux-8/Dockerfile
@@ -1,0 +1,41 @@
+ARG FROM=almalinux:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  { \
+    echo "[mariadb]"; \
+    echo "name = MariaDB"; \
+    echo "baseurl = http://yum.mariadb.org/10.4/centos8-amd64"; \
+    echo "gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"; \
+    echo "gpgcheck = 1"; \
+  } | tee /etc/yum.repos.d/MariaDB.repo && \
+  dnf install -y \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+  dnf groupinstall -y ${quiet} "Development Tools" && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    'dnf-command(builddep)' \
+    'dnf-command(download)' && \
+  dnf module --enablerepo=powertools -y ${quiet} enable mariadb-devel && \
+  dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
+  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
+  dnf module -y ${quiet} disable mariadb && \
+  dnf module -y ${quiet} disable mysql && \
+  dnf download -y ${quiet} --source MariaDB && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    MariaDB-devel \
+    ccache \
+    gcc-c++ \
+    groonga-devel \
+    groonga-normalizer-mysql-devel \
+    intltool \
+    jemalloc-devel \
+    make \
+    pkgconfig \
+    sudo \
+    wget \
+    which && \
+  dnf clean ${quiet} all

--- a/packages/mariadb-10.5-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.5-mroonga/yum/almalinux-8/Dockerfile
@@ -21,9 +21,9 @@ RUN \
     'dnf-command(download)' && \
   dnf module --enablerepo=powertools -y ${quiet} enable mariadb-devel && \
   dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
+  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
   dnf module -y ${quiet} disable mariadb && \
   dnf module -y ${quiet} disable mysql && \
-  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
   dnf download -y ${quiet} --source MariaDB && \
   dnf install --enablerepo=powertools -y ${quiet} \
     MariaDB-devel \

--- a/packages/mariadb-10.5-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.5-mroonga/yum/almalinux-8/Dockerfile
@@ -1,0 +1,41 @@
+ARG FROM=almalinux:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  { \
+    echo "[mariadb]"; \
+    echo "name = MariaDB"; \
+    echo "baseurl = http://yum.mariadb.org/10.5/centos8-amd64"; \
+    echo "gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"; \
+    echo "gpgcheck = 1"; \
+  } | tee /etc/yum.repos.d/MariaDB.repo && \
+  dnf install -y \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+  dnf groupinstall -y ${quiet} "Development Tools" && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    'dnf-command(builddep)' \
+    'dnf-command(download)' && \
+  dnf module --enablerepo=powertools -y ${quiet} enable mariadb-devel && \
+  dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
+  dnf module -y ${quiet} disable mariadb && \
+  dnf module -y ${quiet} disable mysql && \
+  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
+  dnf download -y ${quiet} --source MariaDB && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    MariaDB-devel \
+    ccache \
+    gcc-c++ \
+    groonga-devel \
+    groonga-normalizer-mysql-devel \
+    intltool \
+    libtool \
+    make \
+    pkgconfig \
+    sudo \
+    wget \
+    which && \
+  dnf clean ${quiet} all

--- a/packages/mariadb-10.6-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.6-mroonga/yum/almalinux-8/Dockerfile
@@ -21,9 +21,9 @@ RUN \
     'dnf-command(download)' && \
   dnf module --enablerepo=powertools -y ${quiet} enable mariadb-devel && \
   dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
+  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
   dnf module -y ${quiet} disable mariadb && \
   dnf module -y ${quiet} disable mysql && \
-  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
   dnf download -y ${quiet} --source MariaDB && \
   dnf install --enablerepo=powertools -y ${quiet} \
     MariaDB-devel \

--- a/packages/mariadb-10.6-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.6-mroonga/yum/almalinux-8/Dockerfile
@@ -1,0 +1,41 @@
+ARG FROM=almalinux:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  { \
+    echo "[mariadb]"; \
+    echo "name = MariaDB"; \
+    echo "baseurl = http://yum.mariadb.org/10.6/centos8-amd64"; \
+    echo "gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"; \
+    echo "gpgcheck = 1"; \
+  } | tee /etc/yum.repos.d/MariaDB.repo && \
+  dnf install -y \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+  dnf groupinstall -y ${quiet} "Development Tools" && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    'dnf-command(builddep)' \
+    'dnf-command(download)' && \
+  dnf module --enablerepo=powertools -y ${quiet} enable mariadb-devel && \
+  dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
+  dnf module -y ${quiet} disable mariadb && \
+  dnf module -y ${quiet} disable mysql && \
+  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
+  dnf download -y ${quiet} --source MariaDB && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    MariaDB-devel \
+    ccache \
+    gcc-c++ \
+    groonga-devel \
+    groonga-normalizer-mysql-devel \
+    intltool \
+    libtool \
+    make \
+    pkgconfig \
+    sudo \
+    wget \
+    which && \
+  dnf clean ${quiet} all

--- a/packages/mysql-community-8.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/yum/almalinux-8/Dockerfile
@@ -17,8 +17,8 @@ RUN \
   dnf builddep --enablerepo=powertools -y ${quiet} mysql-community && \
   dnf download -y ${quiet} --source mysql-community && \
   dnf install --enablerepo=powertools -y ${quiet} \
+    ${SCL} \
     ccache \
-    ${SCL}-annobin \
     groonga-devel \
     groonga-normalizer-mysql-devel \
     intltool \

--- a/packages/mysql-community-8.0-mroonga/yum/centos-8/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/yum/centos-8/Dockerfile
@@ -17,8 +17,8 @@ RUN \
   dnf builddep --enablerepo=powertools -y ${quiet} mysql-community && \
   dnf download -y ${quiet} --source mysql-community && \
   dnf install --enablerepo=powertools -y ${quiet} \
+    ${SCL} \
     ccache \
-    ${SCL}-annobin \
     groonga-devel \
     groonga-normalizer-mysql-devel \
     intltool \

--- a/packages/mysql-community-8.0-mroonga/yum/mysql-community-8.0-mroonga.spec.in
+++ b/packages/mysql-community-8.0-mroonga/yum/mysql-community-8.0-mroonga.spec.in
@@ -1,5 +1,8 @@
 # -*- sh-shell: rpm -*-
 
+# Disable annobin because annobin causes SEGV.
+%undefine _annotated_build
+
 %define mysql_version_default 8.0.27
 %define mysql_release_default 1
 %define mysql_dist_default    el%{rhel}

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -160,14 +160,9 @@ sudo ${DNF} erase -y \
   ${package} \
   "${mysql_package_prefix}-*"
 
-# Currently, this check is always fails in mariadb 10.6.
-# The cause of failure is the Mroonga packages for
-# MariaDB10.6 don't exist in packages.groonga.org.
-# Because the Mroonga packages for MariaDB10.6 are made for the first time.
-# Therefore, this check disable temporarily in mariadb 10.6.
-# We enable this check again after we release the next release.
-case ${package} in
-  mariadb-10.6-*)
+# Disable upgrade test for first time packages.
+case ${os}-${package} in
+  almalinux-*) # TODO: Remove this after 11.10 release.
     exit
     ;;
 esac


### PR DESCRIPTION
Because groonga-normalizer-mysql for AlmaLinux 8 has been already released.