### PR TITLE
ci: use code name

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-bionic
             package: mysql
-          - os: ubuntu-20.04
+          - os: ubuntu-focal
             package: mariadb
-          - os: ubuntu-20.04
+          - os: ubuntu-focal
             package: mysql
     runs-on: macos-10.15
     steps:


### PR DESCRIPTION
Because vms id of Vagrantfile is changed at 7831130adaeb596e7946cb468d8700486f868d6f.