### PR TITLE
ci install: enable Ubuntu 21.10 (Impish)

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -21,9 +21,8 @@ jobs:
             package: mysql
           - os: ubuntu-hirsute
             package: mysql
-          # TODO: Ubuntu Impish isn't available on bento yet.
-          # - os: ubuntu-impish
-          #   package: mysql
+          - os: ubuntu-impish
+            package: mysql
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Because Ubuntu Impish has been already available on bento.