### PR TITLE
packages: use the latest mysql-apt-config

### DIFF
--- a/packages/mysql-community-5.7-mroonga/apt/debian-buster/Dockerfile
+++ b/packages/mysql-community-5.7-mroonga/apt/debian-buster/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     ca-certificates \
     wget && \
   wget https://packages.groonga.org/debian/groonga-apt-source-latest-buster.deb && \
-  wget https://repo.mysql.com/mysql-apt-config_0.8.17-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-5.7-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mysql-community-5.7-mroonga/yum/centos-7/Dockerfile
@@ -7,7 +7,9 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   yum update -y ${quiet} && \
   yum install -y ${quiet} \
-    https://repo.mysql.com/mysql57-community-release-el7.rpm && \
+    https://repo.mysql.com/mysql80-community-release-el7.rpm && \
+  yum-config-manager --disable mysql80-community && \
+  yum-config-manager --enable mysql57-community && \
   yum install -y \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm && \
   yum groupinstall -y ${quiet} "Development Tools" && \

--- a/packages/mysql-community-8.0-mroonga/apt/debian-bullseye/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/debian-bullseye/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     ca-certificates \
     wget && \
   wget https://packages.groonga.org/debian/groonga-apt-source-latest-bullseye.deb && \
-  wget https://repo.mysql.com/mysql-apt-config_0.8.17-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.0-mroonga/apt/debian-buster/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/debian-buster/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     ca-certificates \
     wget && \
   wget https://packages.groonga.org/debian/groonga-apt-source-latest-buster.deb && \
-  wget https://repo.mysql.com/mysql-apt-config_0.8.17-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \


### PR DESCRIPTION
Because the official MySQL YUM repository and MySQL APT repository updated public key for showing the validity of packages in these repositories.

In addition, mysql57-community-release-el7.rpm is already not being maintained in https://repo.mysql.com/.
Because mysql57-community-release-el7.rpm is not updated since 2017-4-27.

Therefore, we use mysql80-community-release-el7.rpm instead of mysql57-community-release-el7.rpm.
mysql80-community-release-el7.rpm includes information of mysql57-community-release-el7.rpm .

See: https://dev.mysql.com/doc/refman/8.0/en/linux-installation-yum-repo.html#yum-repo-select-series

However, if we use mysql80-community-release-el7.rpm, we need to select a release series by yum-config-manager.