### PR TITLE
mysql test: update the packages that set the repository of MySQL

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -30,7 +30,7 @@ case ${package} in
     ;;
   mysql-community-*)
     old_package=
-    wget https://repo.mysql.com/mysql-apt-config_0.8.17-1_all.deb
+    wget https://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb
     sudo \
       env DEBIAN_FRONTEND=noninteractive \
           MYSQL_SERVER_VERSION=mysql-${mysql_version} \

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -47,7 +47,11 @@ REPO
     mysql_package_version=$(echo ${mysql_version} | sed -e 's/\.//g')
     old_package=mysql${mysql_package_version}-community-mroonga
     sudo ${DNF} install -y \
-         https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${major_version}.rpm
+         https://repo.mysql.com/mysql80-community-release-el${major_version}.rpm
+    if [ "${major_version}" = "7" ] && [ "${mysql_version}" = "5.7" ]; then
+        sudo yum-config-manager --disable mysql80-community
+        sudo yum-config-manager --enable mysql57-community
+    fi
     ;;
   percona-*)
     service_name=mysqld


### PR DESCRIPTION
Because the official MySQL YUM repository and MySQL APT repository
updated public key for showing the validity of packages in these
repositories.

In addition, mysql57-community-release-el7.rpm is already not being
maintained in https://repo.mysql.com/.

Because mysql57-community-release-el7.rpm is not updated since
2017-4-27.

Therefore, we use mysql80-community-release-el7.rpm instead of
mysql57-community-release-el7.rpm.

mysql80-community-release-el7.rpm includes information of
mysql57-community-release-el7.rpm .

See: https://dev.mysql.com/doc/refman/8.0/en/linux-installation-yum-repo.html#yum-repo-select-series

However, if we use mysql80-community-release-el7.rpm, we need to
select a release series by yum-config-manager.