### PR TITLE
test: use ER_DUP_ENTRY instead of ER_DUP_UNIQUE

### DIFF
--- a/mysql-test/mroonga/include/mroonga/check_version.inc
+++ b/mysql-test/mroonga/include/mroonga/check_version.inc
@@ -39,4 +39,27 @@ let $version_10_2_or_later = `SELECT $version_major_minor >= 10.2`;
 let $version_10_3_or_later = `SELECT $version_major_minor >= 10.3`;
 let $version_10_4_or_later = `SELECT $version_major_minor >= 10.4`;
 let $version_10_5_or_later = `SELECT $version_major_minor >= 10.5`;
+
+let $version_major =
+  `SELECT CAST(SUBSTRING_INDEX(@@global.version, '.', 1) AS UNSIGNED);`;
+let $version_minor =
+  `SELECT CAST(
+    SUBSTRING_INDEX(
+      SUBSTRING_INDEX(@@global.version, '.', 2),
+      '.',
+      -1) AS UNSIGNED);`;
+let $version_micro =
+  `SELECT CAST(
+    SUBSTRING_INDEX(
+      SUBSTRING_INDEX(
+        SUBSTRING_INDEX(@@global.version, '.', 3),
+        '.',
+        -1),
+      '-',
+      1) AS UNSIGNED);`;
+
+let $version_10_5_14_or_later =
+  `SELECT (($version_major * 10000) +
+           ($version_minor * 100) +
+           ($version_micro)) >= 100514;`;
 --enable_query_log

--- a/mysql-test/mroonga/include/mroonga/have_mariadb_10_5_14_or_later.inc
+++ b/mysql-test/mroonga/include/mroonga/have_mariadb_10_5_14_or_later.inc
@@ -1,4 +1,4 @@
-# Copyright(C) 2014 Kouhei Sutou <kou@clear-code.com>
+# Copyright(C) 2022 Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,27 +14,12 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/not_embedded.inc
---source ../../../../../include/mroonga/skip_mariadb_10_5_14_or_later.inc
---source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../include/mroonga/check_version.inc
 
---disable_warnings
-DROP TABLE IF EXISTS ids;
---enable_warnings
+if (!$mariadb) {
+  --skip This test is for MariaDB version 10.5.14 or later
+}
 
-CREATE TABLE ids (
-  id INT
-) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-INSERT INTO ids (id) values (1), (1);
-
---error ER_DUP_UNIQUE
-ALTER TABLE ids ADD UNIQUE INDEX (id);
---replace_regex /\([0-9]+\)//
-SHOW CREATE TABLE ids;
-
-SELECT * FROM ids;
-
-DROP TABLE ids;
-
---source ../../../../../include/mroonga/have_mroonga_deinit.inc
+if (!$version_10_5_14_or_later) {
+  --skip This test is for MariaDB version 10.5.14 or later
+}

--- a/mysql-test/mroonga/include/mroonga/skip_mariadb_10_5_14_or_later.inc
+++ b/mysql-test/mroonga/include/mroonga/skip_mariadb_10_5_14_or_later.inc
@@ -1,4 +1,4 @@
-# Copyright(C) 2014 Kouhei Sutou <kou@clear-code.com>
+# Copyright(C) 2022 Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,27 +14,11 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/not_embedded.inc
---source ../../../../../include/mroonga/skip_mariadb_10_5_14_or_later.inc
---source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../include/mroonga/check_version.inc
+--source ../../include/mroonga/check_mariadb.inc
 
---disable_warnings
-DROP TABLE IF EXISTS ids;
---enable_warnings
-
-CREATE TABLE ids (
-  id INT
-) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-INSERT INTO ids (id) values (1), (1);
-
---error ER_DUP_UNIQUE
-ALTER TABLE ids ADD UNIQUE INDEX (id);
---replace_regex /\([0-9]+\)//
-SHOW CREATE TABLE ids;
-
-SELECT * FROM ids;
-
-DROP TABLE ids;
-
---source ../../../../../include/mroonga/have_mroonga_deinit.inc
+if ($mariadb) {
+  if ($version_10_5_14_or_later) {
+    --skip This test is not for MariaDB 10.5.14 or later
+  }
+}

--- a/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/multiple_column/r/duplicated.result
+++ b/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/multiple_column/r/duplicated.result
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS ids;
+CREATE TABLE ids (
+id1 INT,
+id2 INT
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+INSERT INTO ids (id1, id2) values (1, 2), (1, 2);
+ALTER TABLE ids ADD UNIQUE INDEX (id1, id2);
+ERROR 23000: Duplicate entry '1-2' for key 'id1'
+SHOW CREATE TABLE ids;
+Table	Create Table
+ids	CREATE TABLE `ids` (
+  `id1` int DEFAULT NULL,
+  `id2` int DEFAULT NULL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SELECT * FROM ids;
+id1	id2
+1	2
+1	2
+DROP TABLE ids;

--- a/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/multiple_column/t/duplicated.test
+++ b/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/multiple_column/t/duplicated.test
@@ -1,4 +1,4 @@
-# Copyright(C) 2014 Kouhei Sutou <kou@clear-code.com>
+# Copyright(C) 2022 Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,27 +14,28 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/not_embedded.inc
---source ../../../../../include/mroonga/skip_mariadb_10_5_14_or_later.inc
---source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../../../include/mroonga/not_embedded.inc
+--source ../../../../../../../include/mroonga/have_mariadb_10_5_14_or_later.inc
+--source ../../../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS ids;
 --enable_warnings
 
 CREATE TABLE ids (
-  id INT
+  id1 INT,
+  id2 INT
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-INSERT INTO ids (id) values (1), (1);
+INSERT INTO ids (id1, id2) values (1, 2), (1, 2);
 
---error ER_DUP_UNIQUE
-ALTER TABLE ids ADD UNIQUE INDEX (id);
---replace_regex /\([0-9]+\)//
+--error ER_DUP_ENTRY
+ALTER TABLE ids ADD UNIQUE INDEX (id1, id2);
+--replace_regex /int\([0-9]+\)/int/
 SHOW CREATE TABLE ids;
 
 SELECT * FROM ids;
 
 DROP TABLE ids;
 
---source ../../../../../include/mroonga/have_mroonga_deinit.inc
+--source ../../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/r/duplicated.result
+++ b/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/r/duplicated.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS ids;
+CREATE TABLE ids (
+id INT
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+INSERT INTO ids (id) values (1), (1);
+ALTER TABLE ids ADD UNIQUE INDEX (id);
+ERROR 23000: Duplicate entry '1' for key 'id'
+SHOW CREATE TABLE ids;
+Table	Create Table
+ids	CREATE TABLE `ids` (
+  `id` int DEFAULT NULL
+) ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SELECT * FROM ids;
+id
+1
+1
+DROP TABLE ids;

--- a/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/t/duplicated.test
+++ b/mysql-test/mroonga/storage/alter_table/add_index/unique/mariadb_10_5_14_or_later/t/duplicated.test
@@ -1,4 +1,4 @@
-# Copyright(C) 2014 Kouhei Sutou <kou@clear-code.com>
+# Copyright(C) 2022 Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,9 +14,9 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/not_embedded.inc
---source ../../../../../include/mroonga/skip_mariadb_10_5_14_or_later.inc
---source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../../include/mroonga/not_embedded.inc
+--source ../../../../../../include/mroonga/have_mariadb_10_5_14_or_later.inc
+--source ../../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS ids;
@@ -28,7 +28,7 @@ CREATE TABLE ids (
 
 INSERT INTO ids (id) values (1), (1);
 
---error ER_DUP_UNIQUE
+--error ER_DUP_ENTRY
 ALTER TABLE ids ADD UNIQUE INDEX (id);
 --replace_regex /\([0-9]+\)//
 SHOW CREATE TABLE ids;
@@ -37,4 +37,4 @@ SELECT * FROM ids;
 
 DROP TABLE ids;
 
---source ../../../../../include/mroonga/have_mroonga_deinit.inc
+--source ../../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/alter_table/add_index/unique/multiple_column/t/duplicated.test
+++ b/mysql-test/mroonga/storage/alter_table/add_index/unique/multiple_column/t/duplicated.test
@@ -15,6 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source ../../../../../../include/mroonga/not_embedded.inc
+--source ../../../../../../include/mroonga/skip_mariadb_10_5_14_or_later.inc
 --source ../../../../../../include/mroonga/have_mroonga.inc
 
 --disable_warnings


### PR DESCRIPTION
Because the error code is changed since MariaDB 10.5.14 or later.
In addition, this error case occurs "ER_DUP_ENTRY" on InnoDB.
Therefore, Mroonga occurs "ER_DUP_ENTRY" in this error case according to InnoDB's behavior.