### PR TITLE
ci linux: enable "Test" for Ubuntu Jammy

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -334,9 +334,8 @@ jobs:
             package: mariadb-10.8
 
           # MySQL 8.0
-          # TODO
-          # - os: ubuntu-jammy
-          #   package: mysql-8.0
+          - os: ubuntu-jammy
+            package: mysql-8.0
 
           # MySQL community 5.7
           - os: centos-7

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -335,6 +335,7 @@ jobs:
 
           # MySQL 8.0
           - os: ubuntu-jammy
+            package-type: apt
             package: mysql-8.0
 
           # MySQL community 5.7

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,8 +15,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       :box => "bento/ubuntu-20.04",
     },
     {
-      :id => "ubuntu-hirsute",
-      :box => "bento/ubuntu-21.04",
+      :id => "ubuntu-jammy",
+      :box => "bento/ubuntu-22.04",
     },
     {
       :id => "debian-bullseye",

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -127,25 +127,39 @@ for test_suite_name in $(find plugin/mroonga -type d '!' -name '[tr]'); do
 done
 set -x
 
-sudo \
-  ./mtr \
-  --force \
-  --no-check-testcases \
-  --parallel=${parallel} \
-  --retry=3 \
-  --suite="${test_suite_names}"
-
-case ${package} in
-  mariadb-*)
-    # Test with binary protocol
+case ${distribution} in
+  ubuntu)
     sudo \
       ./mtr \
       --force \
       --no-check-testcases \
       --parallel=${parallel} \
-      --ps-protocol \
+      --retry=3 \
+      --client-bindir="${mysql_test_dir}/bin" \
+      --suite="${test_suite_names}"
+    ;;
+  *)
+    sudo \
+      ./mtr \
+      --force \
+      --no-check-testcases \
+      --parallel=${parallel} \
       --retry=3 \
       --suite="${test_suite_names}"
+
+    case ${package} in
+      mariadb-*)
+        # Test with binary protocol
+        sudo \
+          ./mtr \
+          --force \
+          --no-check-testcases \
+          --parallel=${parallel} \
+          --ps-protocol \
+          --retry=3 \
+          --suite="${test_suite_names}"
+        ;;
+    esac
     ;;
 esac
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -55,6 +55,10 @@ case ${package} in
     ;;
   mysql-*)
     old_package=$(echo ${package} | sed -e 's/mysql-/mysql-server-/')
+    # TODO: Remove this after we release a new version.
+    if [ "${distribution}-${code_name}" = "ubuntu-jammy" ]; then
+      old_package=
+    fi
     mysql_package_prefix=mysql
     client_dev_package=libmysqlclient-dev
     test_package=mysql-testsuite
@@ -148,7 +152,7 @@ mtr_args+=(--no-check-testcases)
 mtr_args+=(--parallel=${parallel})
 mtr_args+=(--retry=3)
 mtr_args+=(--suite="${test_suite_names}")
-if -d "${mysql_test_dir}/bin" ; then
+if [ -d "${mysql_test_dir}/bin" ]; then
   mtr_args+=(--client-bindir="${mysql_test_dir}/bin")
 fi
 sudo ./mtr "${mtr_args[@]}"

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -10,6 +10,7 @@ echo "debconf debconf/frontend select Noninteractive" | \
   sudo debconf-set-selections
 
 sudo apt update
+sudo apt purge -V -y grub-pc
 sudo apt install -V -y apparmor lsb-release wget
 
 distribution=$(lsb_release --id --short | tr 'A-Z' 'a-z')
@@ -156,8 +157,6 @@ esac
 
 # Upgrade
 if [ -n "${old_package}" ]; then
-  sudo apt purge -V -y \
-    grub-pc
   sudo apt purge -V -y \
     ${package} \
     "${mysql_package_prefix}-*"

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -12,11 +12,12 @@ echo "debconf debconf/frontend select Noninteractive" | \
 sudo apt update
 sudo apt install -V -y apparmor lsb-release wget
 
+distribution=$(lsb_release --id --short)
 code_name=$(lsb_release --codename --short)
 architecture=$(dpkg --print-architecture)
 
 wget \
-  https://packages.groonga.org/debian/groonga-apt-source-latest-${code_name}.deb
+  https://packages.groonga.org/${distribution,}/groonga-apt-source-latest-${code_name}.deb
 sudo apt install -V -y ./groonga-apt-source-latest-${code_name}.deb
 sudo apt update
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -13,6 +13,14 @@ sudo apt update
 sudo apt install -V -y apparmor lsb-release wget
 
 distribution=$(lsb_release --id --short)
+case ${distribution} in
+  Debian)
+    repository=main
+    ;;
+  Ubuntu)
+    repository=universe
+  ;;
+esac
 code_name=$(lsb_release --codename --short)
 architecture=$(dpkg --print-architecture)
 
@@ -67,7 +75,7 @@ Architectures: amd64 source
 SignWith: ${GPG_KEY_ID}
 DISTRIBUTIONS
 reprepro includedeb ${code_name} \
-  ${repositories_dir}/debian/pool/${code_name}/main/*/*/*_{${architecture},all}.deb
+  ${repositories_dir}/${distribution,}/pool/${code_name}/${repository}/*/*/*_{${architecture},all}.deb
 
 cat <<APT_SOURCES | sudo tee /etc/apt/sources.list.d/${package}.list
 deb [signed-by=/usr/share/keyrings/${package}.gpg] file://${PWD} ${code_name} main

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -50,6 +50,13 @@ case ${package} in
     test_package=mysql-testsuite
     mysql_test_dir=/usr/lib/mysql-test
     ;;
+  mysql-*)
+    old_package=$(echo ${package} | sed -e 's/mysql-/mysql-server-/')
+    mysql_package_prefix=mysql
+    client_dev_package=libmysqlclient-dev
+    test_package=mysql-testsuite
+    mysql_test_dir=/usr/lib/mysql-test
+    ;;
 esac
 
 (echo "Key-Type: RSA"; \

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -12,12 +12,12 @@ echo "debconf debconf/frontend select Noninteractive" | \
 sudo apt update
 sudo apt install -V -y apparmor lsb-release wget
 
-distribution=$(lsb_release --id --short)
+distribution=$(lsb_release --id --short | tr 'A-Z' 'a-z')
 case ${distribution} in
-  Debian)
+  debian)
     repository=main
     ;;
-  Ubuntu)
+  ubuntu)
     repository=universe
   ;;
 esac
@@ -25,7 +25,7 @@ code_name=$(lsb_release --codename --short)
 architecture=$(dpkg --print-architecture)
 
 wget \
-  https://packages.groonga.org/${distribution,}/groonga-apt-source-latest-${code_name}.deb
+  https://packages.groonga.org/${distribution}/groonga-apt-source-latest-${code_name}.deb
 sudo apt install -V -y ./groonga-apt-source-latest-${code_name}.deb
 sudo apt update
 
@@ -82,7 +82,7 @@ Architectures: amd64 source
 SignWith: ${GPG_KEY_ID}
 DISTRIBUTIONS
 reprepro includedeb ${code_name} \
-  ${repositories_dir}/${distribution,}/pool/${code_name}/${repository}/*/*/*_{${architecture},all}.deb
+  ${repositories_dir}/${distribution}/pool/${code_name}/${repository}/*/*/*_{${architecture},all}.deb
 
 cat <<APT_SOURCES | sudo tee /etc/apt/sources.list.d/${package}.list
 deb [signed-by=/usr/share/keyrings/${package}.gpg] file://${PWD} ${code_name} main

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -9,6 +9,8 @@ mysql_version=$(echo "${package}" | grep -o '[0-9]*\.[0-9]*')
 echo "debconf debconf/frontend select Noninteractive" | \
   sudo debconf-set-selections
 
+sudo sed -i'' -e 's/in\.archive/archive/g' /etc/apt/sources.list
+
 sudo apt update
 sudo apt purge -V -y grub-pc
 sudo apt install -V -y apparmor lsb-release wget

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -75,6 +75,7 @@ sudo gpg \
 
 sudo apt install -V -y reprepro
 repositories_dir=/vagrant/packages/${package}/apt/repositories
+pushd /tmp/
 mkdir -p conf/
 cat <<DISTRIBUTIONS > conf/distributions
 Codename: ${code_name}
@@ -84,10 +85,11 @@ SignWith: ${GPG_KEY_ID}
 DISTRIBUTIONS
 reprepro includedeb ${code_name} \
   ${repositories_dir}/${distribution}/pool/${code_name}/${repository}/*/*/*_{${architecture},all}.deb
-
 cat <<APT_SOURCES | sudo tee /etc/apt/sources.list.d/${package}.list
 deb [signed-by=/usr/share/keyrings/${package}.gpg] file://${PWD} ${code_name} main
 APT_SOURCES
+popd
+
 sudo apt update
 sudo apt install -V -y ${package}
 


### PR DESCRIPTION
Because Ubuntu Jammy has already available on bento.