### PR TITLE
package: don't require to run update.sql when the execution install.sql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /configure
 /configure.lineno
 /data/install.sql
+/data/install_plugin.sql
 /data/update.sql
 /depcomp
 /doc/locale/*/*-build-stamp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,6 +522,10 @@ configure_file(
   "${PROJECT_BINARY_DIR}/data/install.sql"
   @ONLY)
 configure_file(
+  "${PROJECT_SOURCE_DIR}/data/install_plugin.sql.in"
+  "${PROJECT_BINARY_DIR}/data/install_plugin.sql"
+  @ONLY)
+configure_file(
   "${PROJECT_SOURCE_DIR}/data/update.sql.in"
   "${PROJECT_BINARY_DIR}/data/update.sql"
   @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,7 @@ install(FILES
   "${PROJECT_SOURCE_DIR}/AUTHORS"
   "${PROJECT_SOURCE_DIR}/COPYING"
   "${PROJECT_BINARY_DIR}/data/install.sql"
+  "${PROJECT_BINARY_DIR}/data/install_plugin.sql"
   "${PROJECT_SOURCE_DIR}/data/uninstall.sql"
   "${PROJECT_BINARY_DIR}/data/update.sql"
   DESTINATION "${MRN_DATA_DIR}/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,6 +517,11 @@ configure_file(
   "${MRN_TEST_SUITE_DIR}/storage/variable/r/version.result"
   NEWLINE_STYLE LF)
 
+if(MRN_BUNDLED)
+  set(MRN_DATA_DIR "${INSTALL_MYSQLSHAREDIR}/${PROJECT_NAME}")
+else()
+  set(MRN_DATA_DIR "share/${PROJECT_NAME}")
+endif()
 configure_file(
   "${PROJECT_SOURCE_DIR}/data/install.sql.in"
   "${PROJECT_BINARY_DIR}/data/install.sql"
@@ -530,11 +535,6 @@ configure_file(
   "${PROJECT_BINARY_DIR}/data/update.sql"
   @ONLY)
 
-if(MRN_BUNDLED)
-  set(MRN_DATA_DIR "${INSTALL_MYSQLSHAREDIR}/${PROJECT_NAME}")
-else()
-  set(MRN_DATA_DIR "share/${PROJECT_NAME}")
-endif()
 install(FILES
   "${PROJECT_SOURCE_DIR}/AUTHORS"
   "${PROJECT_SOURCE_DIR}/COPYING"

--- a/configure.ac
+++ b/configure.ac
@@ -606,5 +606,6 @@ AC_OUTPUT([
   mysql-test/mroonga/storage/information_schema/r/plugins.result
   mysql-test/mroonga/storage/variable/r/version.result
   data/install.sql
+  data/install_plugin.sql
   data/update.sql
 ])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -5,5 +5,6 @@ SUBDIRS =					\
 sqldir = $(pkgdatadir)
 dist_sql_DATA =					\
 	install.sql				\
+	install_plugin.sql				\
 	uninstall.sql				\
 	update.sql

--- a/data/deb/postinst.sh
+++ b/data/deb/postinst.sh
@@ -70,7 +70,7 @@ install_mroonga() {
     need_manual_update=yes
   fi
 
-  install_sql=/usr/share/mroonga/install.sql
+  install_sql=/usr/share/mroonga/install_plugin.sql
   uninstall_sql=/usr/share/mroonga/uninstall.sql
   update_sql=/usr/share/mroonga/update.sql
 

--- a/data/install.sql.in
+++ b/data/install.sql.in
@@ -1,1 +1,2 @@
-INSTALL PLUGIN mroonga SONAME 'ha_mroonga@MRN_PLUGIN_SUFFIX@';
+source ${DATA_DIR}/mroonga/install_plugin.sql
+source ${DATA_DIR}/mroonga/update.sql

--- a/data/install.sql.in
+++ b/data/install.sql.in
@@ -1,2 +1,2 @@
-source '@MRN_DATA_DIR@/mroonga/install_plugin.sql'
-source '@MRN_DATA_DIR@/mroonga/update.sql'
+source install_plugin.sql
+source update.sql

--- a/data/install.sql.in
+++ b/data/install.sql.in
@@ -1,2 +1,2 @@
-source ${DATA_DIR}/mroonga/install_plugin.sql
-source ${DATA_DIR}/mroonga/update.sql
+source @DATA_DIR@/mroonga/install_plugin.sql
+source @DATA_DIR@/mroonga/update.sql

--- a/data/install.sql.in
+++ b/data/install.sql.in
@@ -1,2 +1,2 @@
-source @DATA_DIR@/mroonga/install_plugin.sql
-source @DATA_DIR@/mroonga/update.sql
+source @MRN_DATA_DIR@/mroonga/install_plugin.sql
+source @MRN_DATA_DIR@/mroonga/update.sql

--- a/data/install.sql.in
+++ b/data/install.sql.in
@@ -1,2 +1,2 @@
-source install_plugin.sql
-source update.sql
+source @MRN_DATA_DIR@/install_plugin.sql
+source @MRN_DATA_DIR@/update.sql

--- a/data/install.sql.in
+++ b/data/install.sql.in
@@ -1,2 +1,2 @@
-source @MRN_DATA_DIR@/mroonga/install_plugin.sql
-source @MRN_DATA_DIR@/mroonga/update.sql
+source '@MRN_DATA_DIR@/mroonga/install_plugin.sql'
+source '@MRN_DATA_DIR@/mroonga/update.sql'

--- a/data/install_plugin.sql.in
+++ b/data/install_plugin.sql.in
@@ -1,0 +1,1 @@
+INSTALL PLUGIN mroonga SONAME 'ha_mroonga@MRN_PLUGIN_SUFFIX@';

--- a/data/rpm/post.sh
+++ b/data/rpm/post.sh
@@ -63,7 +63,7 @@ case "${action}" in
     ;;
 esac
 
-install_sql=${data_dir}/mroonga/install.sql
+install_sql=${data_dir}/mroonga/install_plugin.sql
 uninstall_sql=${data_dir}/mroonga/uninstall.sql
 update_sql=${data_dir}/mroonga/update.sql
 


### PR DESCRIPTION
This is testing now.


GitHub: fix #509 Reported by Jérome Perrin. Thanks!!!