### PR TITLE
doc release: Remove needless --watch option

### DIFF
--- a/doc/source/developer/release.rst
+++ b/doc/source/developer/release.rst
@@ -228,7 +228,7 @@ We update the below files.
 
 We can confirm contents of blog on Web browser by using Jekyll.::
 
-  % jekyll serve --watch
+  % jekyll serve
 
 We access http://localhost:4000 on our web browser for confirming contents.
 


### PR DESCRIPTION
`--watch` is needless because it's enabled by default.