### PR TITLE
doc: add announcement script

### DIFF
--- a/build/makefiles/gettext.am
+++ b/build/makefiles/gettext.am
@@ -61,6 +61,9 @@ endif
 html: build
 man: build
 pdf: build
+markdown: build
+text: build
+
 
 gettext:
 	rm *.pot || true

--- a/build/makefiles/sphinx.am
+++ b/build/makefiles/sphinx.am
@@ -56,7 +56,11 @@ generated_files =				\
 	changes-build-stamp			\
 	linkcheck				\
 	linkcheck-build-stamp			\
-	doctest
+	doctest					\
+	markdown				\
+	markdown-build-stamp			\
+	text					\
+	text-build-stamp
 
 $(mo_files_relative_from_locale_dir): mo-build-stamp
 
@@ -77,6 +81,8 @@ endif
 .PHONY: help
 .PHONY: man clean-man
 .PHONY: html clean-html
+.PHONY: markdown clean-markdown
+.PHONY: text clean-text
 .PHONY: pdf
 .PHONY: dirhtml
 .PHONY: pickle
@@ -107,6 +113,8 @@ help:
 
 man: man-build-stamp
 html: html-recursive html-build-stamp
+markdown: markdown-recursive markdown-build-stamp
+text: text-recursive text-build-stamp
 dirhtml: dirhtml-build-stamp
 pickle: pickle-build-stamp
 json: json-build-stamp
@@ -132,7 +140,9 @@ clean_targets =					\
 	clean-textile				\
 	clean-changes				\
 	clean-linkcheck				\
-	clean-doctest
+	clean-doctest				\
+	clean-markdown				\
+	clean-text
 
 $(clean_targets):
 	target=`echo $@ | sed -e 's/^clean-//'`;	\
@@ -151,7 +161,9 @@ build_stamps =					\
 	textile-build-stamp			\
 	changes-build-stamp			\
 	linkcheck-build-stamp			\
-	doctest-build-stamp
+	doctest-build-stamp			\
+	markdown-build-stamp			\
+	text-build-stamp
 
 $(build_stamps): $(document_source_files)
 	target=`echo $@ | sed -e 's/-build-stamp$$//'`;	\

--- a/configure.ac
+++ b/configure.ac
@@ -542,6 +542,7 @@ if test x"$enable_document" != x"no"; then
     if test -n "$SPHINX_BUILD"; then
       document_available=yes
       document_buildable=yes
+      AM_EXTRA_RECURSIVE_TARGETS([markdown text])
     else
       AC_MSG_ERROR([
 No sphinx-build found.

--- a/doc/create-announcement-article.rb
+++ b/doc/create-announcement-article.rb
@@ -1,0 +1,283 @@
+require 'optparse'
+require 'fileutils'
+
+option = {}
+OptionParser.new do |opt|
+  opt.on('--release-date=DATE', "YYYY-MM-DD") { |v| option[:release_date] = v }
+  opt.on('--version=VERSION', "e.g. 12.1.1") { |v| option[:version] = v }
+  opt.on('--previous-version=VERSION', "e.g. 12.1.0") { |v| option[:previous_version] = v }
+  opt.on('--groonga-repository=PATH', "e.g. $HOME/work/groonga") { |v| option[:groonga_repository] = v }
+  opt.on('--mroonga-org-repository=PATH', "e.g. $HOME/work/mroonga.org") { |v| option[:mroonga_org_repository] = v }
+  opt.parse!(ARGV)
+end
+
+require "#{option[:groonga_repository]}/doc/announcement-article-generator"
+
+class MroongaArticleGenerator < ArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version)
+  end
+end
+
+class MarkdownEnArticleGenerator < MroongaArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @input_file_path = "./locale/en/markdown/news.md"
+    @release_headline_regexp_pattern = /^## Release.+$/
+  end
+
+  def generate_article
+    <<-ARTICLE
+## Mroonga #{@version} has been released!
+
+Mroonga is a MySQL storage engine that supports fast fulltext search
+and geolocation search. It is CJK ready. It uses Groonga as a storage
+and fulltext search engine.
+
+[Mroonga #{@version}](#{@link_prefix}/news.html#release-#{@version_in_link}) has been released!
+
+* How to install: [Install](#{@link_prefix}/install.html)
+* How to upgrade: [Upgrade guide](#{@link_prefix}/upgrade.html)
+
+### Changes
+
+Here are important changes in this release:
+
+#{extract_latest_release_note}
+
+### Conclusion
+
+Please refer to [release note](#{@link_prefix}/news.html#release-#{@version_in_link}) about the detail of changes in this release.
+
+Let's search by Mroonga!
+    ARTICLE
+  end
+end
+
+class MarkdownJaArticleGenerator < MroongaArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @input_file_path = "./locale/ja/markdown/news.md"
+    @release_headline_regexp_pattern = /^## .*リリース.+$/
+  end
+
+  def generate_article
+    <<-ARTICLE
+## Mroonga #{@version} リリース
+
+[Mroonga #{@version}](#{@link_prefix}/news.html#release-#{@version_in_link})をリリースしました！
+
+* インストール方法: [インストール](#{@link_prefix}/install.html)
+* アップグレード方法: [アップグレードガイド](#{@link_prefix}/upgrade.html)
+
+### 変更点
+    
+主な変更点は以下の通りです。
+
+#{extract_latest_release_note}
+
+### おわりに
+
+今回のリリースの詳細については、 [リリースノート](#{@link_prefix}/news.html#release-#{@version_in_link}) または、 [リリース自慢会](https://www.youtube.com/watch?v=ov33wL5HBZg) を参照してください。
+
+それでは、Mroongaでガンガン検索してください！
+    ARTICLE
+  end
+end
+
+class BlogEnArticleGenerator < MarkdownEnArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @output_file_path = "#{mroonga_org_repository}/en/_posts/#{release_date}-mroonga-#{version}.md"
+    @link_prefix = "/docs"
+  end
+
+  def generate_article
+    article_base = super
+    prefix = <<-ARTICLE
+---
+layout: post.en
+title: Mroonga #{@version} has been released!
+description: Mroonga #{@version} has been released!
+---
+
+#{super}
+    ARTICLE
+  end
+end
+
+class BlogJaArticleGenerator < MarkdownJaArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @output_file_path = "#{mroonga_org_repository}/ja/_posts/#{release_date}-mroonga-#{version}.md"
+    @link_prefix = "/ja/docs"
+  end
+
+  def generate_article
+    article_base = super
+    prefix = <<-ARTICLE
+---
+layout: post.ja
+title: Mroonga #{@version}リリース！
+description: Mroonga #{@version}をリリースしました！
+---
+
+#{super}
+    ARTICLE
+  end
+end
+
+class DiscussionsEnArticleGenerator < MarkdownEnArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @output_file_path = "./tmp/discussions-en-#{release_date}-mroonga-#{version}.md"
+    @link_prefix = "https://mroonga.org/docs"
+  end
+
+  def generate
+    FileUtils.mkdir_p("tmp")
+    super
+  end
+end
+
+class DiscussionsJaArticleGenerator < MarkdownJaArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @output_file_path = "./tmp/discussions-ja-#{release_date}-mroonga-#{version}.md"
+    @link_prefix = "https://mroonga.org/ja/docs"
+  end
+
+  def generate
+    FileUtils.mkdir_p("tmp")
+    super
+  end
+end
+
+class FacebookArticleGenerator < MroongaArticleGenerator
+  def generate
+    FileUtils.mkdir_p("tmp")
+    super
+  end
+end
+
+class FacebookEnArticleGenerator < FacebookArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @input_file_path = "./locale/en/text/news.txt"
+    @output_file_path = "./tmp/facebook-en-#{release_date}-mroonga-#{version}.txt"
+    @release_headline_regexp_pattern = /^Release.*\n=.+$/
+    @link_prefix = "https://mroonga.org/docs"
+  end
+
+  def generate_article
+    <<-ARTICLE
+Hi,
+Mroonga #{@version} has been released!
+
+Mroonga is a MySQL storage engine that supports fast fulltext search
+and geolocation search. It is CJK ready. It uses Groonga as a storage
+and fulltext search engine.
+
+Mroonga #{@version} has been released!
+
+* Release note: #{@link_prefix}/news.html#release-#{@version_in_link}
+* How to install: #{@link_prefix}/install.html
+* How to upgrade: #{@link_prefix}/upgrade.html
+
+Changes
+=======
+
+The main changes are as follows.
+
+#{extract_latest_release_note}
+
+Conclusion
+==========
+
+Please refer to release note ( #{@link_prefix}/news.html#release-#{@version_in_link} ) about the detail of changes in this release.
+
+Let's search by Mroonga!
+    ARTICLE
+  end
+end
+
+class FacebookJaArticleGenerator < FacebookArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @input_file_path = "./locale/ja/text/news.txt"
+    @output_file_path = "./tmp/facebook-ja-#{release_date}-mroonga-#{version}.txt"
+    @release_headline_regexp_pattern = /^.*リリース.+\n=.+/
+    @link_prefix = "https://mroonga.org/ja/docs"
+  end
+
+  def generate_article
+    <<-ARTICLE
+Mroonga #{@version} をリリースしました！
+
+* リリースノート: #{@link_prefix}/news.html#release-#{@version_in_link}
+
+* インストール方法: #{@link_prefix}/install.html
+
+* アップグレード方法: #{@link_prefix}/upgrade.html
+
+主な変更内容
+============
+
+主な変更点は以下の通りです。
+
+#{extract_latest_release_note}
+
+おわりに
+========
+
+今回のリリースの詳細については、 リリースノート( #{@link_prefix}/news.html#release-#{@version_in_link} ) または、リリース自慢会( https://www.youtube.com/playlist?list=PLLwHraQ4jf7PnA3GjI9v90DZq8ikLk0iN ) を参照してください。
+
+それでは、Mroongaでガンガン検索してください！
+    ARTICLE
+  end
+end
+
+class TwitterEnArticleBaseGenerator < MroongaArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @output_file_path = "./tmp/twitter-en-#{release_date}-mroonga-#{version}-base.txt"
+  end
+
+  def generate_article
+    "Mroonga #{@version} has been released!(#{@release_date}) " + 
+    "https://mroonga.org/en/blog/#{@release_date_in_link}/groonga-#{@version}.html"
+  end
+end
+
+class TwitterJaArticleBaseGenerator < MroongaArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @output_file_path = "./tmp/twitter-ja-#{release_date}-mroonga-#{version}-base.txt"
+  end
+
+  def generate_article
+    "Mroonga #{@version}をリリースしました！(#{@release_date}) " +
+    "https://mroonga.org/ja/blog/#{@release_date_in_link}/groonga-#{@version}.html"
+  end
+end
+
+generator_classes = [
+  BlogEnArticleGenerator,
+  BlogJaArticleGenerator,
+  DiscussionsEnArticleGenerator,
+  DiscussionsJaArticleGenerator,
+  FacebookEnArticleGenerator,
+  FacebookJaArticleGenerator,
+  TwitterEnArticleBaseGenerator,
+  TwitterJaArticleBaseGenerator
+]
+
+generator_classes.each do |generator_class|
+  generator = generator_class.new(option[:release_date],
+                                  option[:version], 
+                                  option[:previous_version],
+                                  option[:mroonga_org_repository])
+  generator.generate
+  puts generator.output_file_path
+end
+

--- a/doc/create-announcement-article.rb
+++ b/doc/create-announcement-article.rb
@@ -245,7 +245,7 @@ class TwitterEnArticleBaseGenerator < MroongaArticleGenerator
 
   def generate_article
     "Mroonga #{@version} has been released!(#{@release_date}) " + 
-    "https://mroonga.org/en/blog/#{@release_date_in_link}/groonga-#{@version}.html"
+    "https://mroonga.org/en/blog/#{@release_date_in_link}/mroonga-#{@version}.html"
   end
 end
 
@@ -257,7 +257,7 @@ class TwitterJaArticleBaseGenerator < MroongaArticleGenerator
 
   def generate_article
     "Mroonga #{@version}をリリースしました！(#{@release_date}) " +
-    "https://mroonga.org/ja/blog/#{@release_date_in_link}/groonga-#{@version}.html"
+    "https://mroonga.org/ja/blog/#{@release_date_in_link}/mroonga-#{@version}.html"
   end
 end
 

--- a/doc/create-announcement-article.rb
+++ b/doc/create-announcement-article.rb
@@ -261,6 +261,47 @@ class TwitterJaArticleBaseGenerator < MroongaArticleGenerator
   end
 end
 
+class MySQLMailingListJaArticleGenerator < MroongaArticleGenerator
+  def initialize(release_date, version, previous_version, mroonga_org_repository)
+    super(release_date, version, previous_version, mroonga_org_repository)
+    @input_file_path = "./locale/ja/text/news.txt"
+    @output_file_path = "./tmp/mysql-mailinglist-ja-#{release_date}-mroonga-#{version}.txt"
+    @release_headline_regexp_pattern = /^.*リリース.+\n=.+/
+  end
+  
+  def generate
+    FileUtils.mkdir_p("tmp")
+    super
+  end
+
+  def generate_article
+    <<-ARTICLE
+こんにちは。
+
+リリースアナウンス:
+  https://mroonga.org/ja/blog/#{@release_date_in_link}/mroonga-#{@version_in_link}.html
+    
+MroongaはMySQLで日本語全文検索を実現するストレージエンジンです。高速で
+あることや位置情報検索をサポートしていることなどが特徴です。詳細につい
+はドキュメントをご覧ください。
+    
+  * Mroongaの特徴 ― Mroonga v#{@version} documentation
+    https://mroonga.org/ja/docs/characteristic.html#what-is-mroonga
+
+主な変更内容
+============
+
+主な変更点は以下の通りです。
+
+https://mroonga.org/ja/docs/news.html#release-#{@version}
+
+#{extract_latest_release_note}
+
+以上です！ 
+    ARTICLE
+  end
+end
+
 generator_classes = [
   BlogEnArticleGenerator,
   BlogJaArticleGenerator,
@@ -269,7 +310,8 @@ generator_classes = [
   FacebookEnArticleGenerator,
   FacebookJaArticleGenerator,
   TwitterEnArticleBaseGenerator,
-  TwitterJaArticleBaseGenerator
+  TwitterJaArticleBaseGenerator,
+  MySQLMailingListJaArticleGenerator
 ]
 
 generator_classes.each do |generator_class|

--- a/doc/create-announcement-article.rb
+++ b/doc/create-announcement-article.rb
@@ -22,7 +22,7 @@ end
 class MarkdownEnArticleGenerator < MroongaArticleGenerator
   def initialize(release_date, version, previous_version, mroonga_org_repository)
     super(release_date, version, previous_version, mroonga_org_repository)
-    @input_file_path = "./locale/en/markdown/news.md"
+    @input_file_path = "./locale/en/markdown/news/#{version.split(".")[0]}.md"
     @release_headline_regexp_pattern = /^## Release.+$/
   end
 
@@ -57,7 +57,7 @@ end
 class MarkdownJaArticleGenerator < MroongaArticleGenerator
   def initialize(release_date, version, previous_version, mroonga_org_repository)
     super(release_date, version, previous_version, mroonga_org_repository)
-    @input_file_path = "./locale/ja/markdown/news.md"
+    @input_file_path = "./locale/ja/markdown/news/#{version.split(".")[0]}.md"
     @release_headline_regexp_pattern = /^## .*リリース.+$/
   end
 
@@ -163,7 +163,7 @@ end
 class FacebookEnArticleGenerator < FacebookArticleGenerator
   def initialize(release_date, version, previous_version, mroonga_org_repository)
     super(release_date, version, previous_version, mroonga_org_repository)
-    @input_file_path = "./locale/en/text/news.txt"
+    @input_file_path = "./locale/en/text/news/#{version.split(".")[0]}.txt"
     @output_file_path = "./tmp/facebook-en-#{release_date}-mroonga-#{version}.txt"
     @release_headline_regexp_pattern = /^Release.*\n=.+$/
     @link_prefix = "https://mroonga.org/docs"
@@ -204,7 +204,7 @@ end
 class FacebookJaArticleGenerator < FacebookArticleGenerator
   def initialize(release_date, version, previous_version, mroonga_org_repository)
     super(release_date, version, previous_version, mroonga_org_repository)
-    @input_file_path = "./locale/ja/text/news.txt"
+    @input_file_path = "./locale/ja/text/news/#{version.split(".")[0]}.txt"
     @output_file_path = "./tmp/facebook-ja-#{release_date}-mroonga-#{version}.txt"
     @release_headline_regexp_pattern = /^.*リリース.+\n=.+/
     @link_prefix = "https://mroonga.org/ja/docs"
@@ -264,7 +264,7 @@ end
 class MySQLMailingListJaArticleGenerator < MroongaArticleGenerator
   def initialize(release_date, version, previous_version, mroonga_org_repository)
     super(release_date, version, previous_version, mroonga_org_repository)
-    @input_file_path = "./locale/ja/text/news.txt"
+    @input_file_path = "./locale/ja/text/news/#{version.split(".")[0]}.txt"
     @output_file_path = "./tmp/mysql-mailinglist-ja-#{release_date}-mroonga-#{version}.txt"
     @release_headline_regexp_pattern = /^.*リリース.+\n=.+/
   end


### PR DESCRIPTION
Added a script to create bases of Blog/Discussions/Facebook/Twitter/Mailing List articles.

`create-announcement-article.rb`: This script creates bases of Blog/Discussions/Facebook/Twitter/Mailing List articles from the results of `make markdown text`.

Usage:

```
cd doc
make markdown text
ruby create-announcement-article.rb --release-date 2023-01-07 --version 12.11 --previous_version 12.10 --groonga_repository $HOME/gitdir/groonga --mroonga_org_repository $HOME/gitdir/mroonga.org
```

As `create-announcement-article.rb` executed, the files as below are created.

```
$HOME/gitdir/mroonga.org/en/_posts/2023-01-07-mroonga-12.11.md
$HOME/gitdir/mroonga.org/ja/_posts/2023-01-07-mroonga-12.11.md
./tmp/discussions-en-2023-01-07-mroonga-12.11.md
./tmp/discussions-ja-2023-01-07-mroonga-12.11.md
./tmp/facebook-en-2023-01-07-mroonga-12.11.txt
./tmp/facebook-ja-2023-01-07-mroonga-12.11.txt
./tmp/twitter-en-2023-01-07-mroonga-12.11-base.txt
./tmp/twitter-ja-2023-01-07-groonga-12.11-base.txt
./tmp/mysql-mailinglist-ja-2023-01-07-groonga-12.11.txt
```

TODO:

* [ ] Separate changes about `.ac` and `.am` files into another pull request
* [ ] Use variables that already used in release procedure like `NEW_RELEASE_DATE`.