### PR TITLE
packages percona-server: disable build of packages for Percona Server

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -206,11 +206,13 @@ jobs:
           #   package-type: apt
           #   package: mysql-community-8.0
 
+          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 5.7
           #- os: centos-7
           #  package-type: yum
           #  package: percona-server-5.7
 
+          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 8.0
           #- os: almalinux-8
           #  package-type: yum
@@ -449,11 +451,13 @@ jobs:
             package-type: apt
             package: mysql-community-8.0
 
+          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 5.7
           #- os: centos-7
           #  package-type: yum
           #  package: percona-server-5.7
 
+          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 8.0
           #- os: almalinux-8
           #  package-type: yum

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -210,8 +210,8 @@ jobs:
           #- os: centos-7
           #  package-type: yum
           #  package: percona-server-5.7
-          #
-          ## Percona Server 8.0
+
+          # Percona Server 8.0
           #- os: almalinux-8
           #  package-type: yum
           #  package: percona-server-8.0
@@ -450,20 +450,20 @@ jobs:
             package: mysql-community-8.0
 
           # Percona Server 5.7
-          - os: centos-7
-            package-type: yum
-            package: percona-server-5.7
+          #- os: centos-7
+          #  package-type: yum
+          #  package: percona-server-5.7
 
           # Percona Server 8.0
-          - os: almalinux-8
-            package-type: yum
-            package: percona-server-8.0
-          - os: almalinux-9
-            package-type: yum
-            package: percona-server-8.0
-          - os: centos-7
-            package-type: yum
-            package: percona-server-8.0
+          #- os: almalinux-8
+          #  package-type: yum
+          #  package: percona-server-8.0
+          #- os: almalinux-9
+          #  package-type: yum
+          #  package: percona-server-8.0
+          #- os: centos-7
+          #  package-type: yum
+          #  package: percona-server-8.0
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -207,20 +207,20 @@ jobs:
           #   package: mysql-community-8.0
 
           # Percona Server 5.7
-          - os: centos-7
-            package-type: yum
-            package: percona-server-5.7
-
-          # Percona Server 8.0
-          - os: almalinux-8
-            package-type: yum
-            package: percona-server-8.0
-          - os: almalinux-9
-            package-type: yum
-            package: percona-server-8.0
-          - os: centos-7
-            package-type: yum
-            package: percona-server-8.0
+          #- os: centos-7
+          #  package-type: yum
+          #  package: percona-server-5.7
+          #
+          ## Percona Server 8.0
+          #- os: almalinux-8
+          #  package-type: yum
+          #  package: percona-server-8.0
+          #- os: almalinux-9
+          #  package-type: yum
+          #  package: percona-server-8.0
+          #- os: centos-7
+          #  package-type: yum
+          #  package: percona-server-8.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Because Currently we can't build the RPM of Percona-Server from SPEC. Probabry the cause of this problem by Percna Server.

See: https://jira.percona.com/browse/PS-8623

We can't build of packages for Percona Server until resolved this problem.