### PR TITLE
Add support for building with MariaDB 10.11.2

### DIFF
--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -694,7 +694,8 @@ typedef uint mrn_srid;
 #endif
 
 #ifdef MRN_MARIADB_P
-#  if (((MYSQL_VERSION_ID >= 101002) && (MYSQL_VERSION_ID < 101100)) || \
+#  if (((MYSQL_VERSION_ID >= 101102) && (MYSQL_VERSION_ID < 101200)) || \
+       ((MYSQL_VERSION_ID >= 101002) && (MYSQL_VERSION_ID < 101100)) || \
        ((MYSQL_VERSION_ID >= 100904) && (MYSQL_VERSION_ID < 101000)) || \
        ((MYSQL_VERSION_ID >= 100806) && (MYSQL_VERSION_ID < 100900)) || \
        ((MYSQL_VERSION_ID >= 100707) && (MYSQL_VERSION_ID < 100800)) || \

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -694,8 +694,7 @@ typedef uint mrn_srid;
 #endif
 
 #ifdef MRN_MARIADB_P
-#  if (((MYSQL_VERSION_ID >= 101102) && (MYSQL_VERSION_ID < 101200)) || \
-       ((MYSQL_VERSION_ID >= 101002) && (MYSQL_VERSION_ID < 101100)) || \
+#  if ((MYSQL_VERSION_ID >= 101002) || \
        ((MYSQL_VERSION_ID >= 100904) && (MYSQL_VERSION_ID < 101000)) || \
        ((MYSQL_VERSION_ID >= 100806) && (MYSQL_VERSION_ID < 100900)) || \
        ((MYSQL_VERSION_ID >= 100707) && (MYSQL_VERSION_ID < 100800)) || \


### PR DESCRIPTION
GitHub: fix GH-605 

Error compiling the Mroonga plugin 13.00 with MariaDB 10.11.2 in Debian 11.6.