### PR TITLE
packages percona-server: enable build of packages for Percona Server

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -228,23 +228,21 @@ jobs:
           #   package-type: apt
           #   package: mysql-community-8.0
 
-          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 5.7
-          #- os: centos-7
-          #  package-type: yum
-          #  package: percona-server-5.7
+          - os: centos-7
+            package-type: yum
+            package: percona-server-5.7
 
-          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 8.0
-          #- os: almalinux-8
-          #  package-type: yum
-          #  package: percona-server-8.0
-          #- os: almalinux-9
-          #  package-type: yum
-          #  package: percona-server-8.0
-          #- os: centos-7
-          #  package-type: yum
-          #  package: percona-server-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: percona-server-8.0
+          - os: almalinux-9
+            package-type: yum
+            package: percona-server-8.0
+          - os: centos-7
+            package-type: yum
+            package: percona-server-8.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -479,23 +477,21 @@ jobs:
             package-type: apt
             package: mysql-community-8.0
 
-          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 5.7
-          #- os: centos-7
-          #  package-type: yum
-          #  package: percona-server-5.7
+          - os: centos-7
+            package-type: yum
+            package: percona-server-5.7
 
-          # We will enable this when https://jira.percona.com/browse/PS-8623 resolved.
           # Percona Server 8.0
-          #- os: almalinux-8
-          #  package-type: yum
-          #  package: percona-server-8.0
-          #- os: almalinux-9
-          #  package-type: yum
-          #  package: percona-server-8.0
-          #- os: centos-7
-          #  package-type: yum
-          #  package: percona-server-8.0
+          - os: almalinux-8
+            package-type: yum
+            package: percona-server-8.0
+          - os: almalinux-9
+            package-type: yum
+            package: percona-server-8.0
+          - os: centos-7
+            package-type: yum
+            package: percona-server-8.0
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Because the library to need build the RPM package of Percona Server already has been able to aveirable for download.