### PR TITLE
ci : Sepcify "DEBIAN_FRONTEND=noninteractive" when we install or upgrade "mysql-apt-config"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,155 +103,155 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # MariaDB 10.3
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.3
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.3
-#
-#          # MariaDB 10.4
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.4
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.4
-#
-#          # MariaDB 10.5
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: amazon-linux-2
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: debian-bullseye
-#            package-type: apt
-#            package: mariadb-10.5
-#
-#          # MariaDB 10.6
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.6
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.6
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.6
-#          - os: ubuntu-jammy
-#            package-type: apt
-#            package: mariadb-10.6
-#
-#          # MariaDB 10.7
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.7
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.7
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.7
-#
-#          # MariaDB 10.8
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.8
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.8
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.8
-#
-#          # MariaDB 10.9
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.9
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.9
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.9
-#
-#          # MariaDB 10.10
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.10
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.10
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.10
-#
-#          # MariaDB 10.11
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.11
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.11
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.11
-#
-#          # MySQL 8.0
-#          - os: ubuntu-jammy
-#            package-type: apt
-#            package: mysql-8.0
-#
-#          # MySQL community 5.7
-#          - os: centos-7
-#            package-type: yum
-#            package: mysql-community-5.7
-#
-#          # MySQL community 8.0
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mysql-community-8.0
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mysql-community-8.0
-#          - os: centos-7
-#            package-type: yum
-#            package: mysql-community-8.0
+          # MariaDB 10.3
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.3
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.3
+
+          # MariaDB 10.4
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.4
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.4
+
+          # MariaDB 10.5
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.5
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.5
+          - os: amazon-linux-2
+            package-type: yum
+            package: mariadb-10.5
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.5
+          - os: debian-bullseye
+            package-type: apt
+            package: mariadb-10.5
+
+          # MariaDB 10.6
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.6
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.6
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.6
+          - os: ubuntu-jammy
+            package-type: apt
+            package: mariadb-10.6
+
+          # MariaDB 10.7
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.7
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.7
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.7
+
+          # MariaDB 10.8
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.8
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.8
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.8
+
+          # MariaDB 10.9
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.9
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.9
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.9
+
+          # MariaDB 10.10
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.10
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.10
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.10
+
+          # MariaDB 10.11
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.11
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.11
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.11
+
+          # MySQL 8.0
+          - os: ubuntu-jammy
+            package-type: apt
+            package: mysql-8.0
+
+          # MySQL community 5.7
+          - os: centos-7
+            package-type: yum
+            package: mysql-community-5.7
+
+          # MySQL community 8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-8.0
+          - os: almalinux-9
+            package-type: yum
+            package: mysql-community-8.0
+          - os: centos-7
+            package-type: yum
+            package: mysql-community-8.0
           - os: debian-bullseye
             package-type: apt
             package: mysql-community-8.0
-#          - os: ubuntu-jammy
-#            package-type: apt
-#            package: mysql-community-8.0
-#
-#          # MySQL community minimal 8.0
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mysql-community-minimal-8.0
-#
-#          # Percona Server 5.7
-#          - os: centos-7
-#            package-type: yum
-#            package: percona-server-5.7
-#
-#          # Percona Server 8.0
-#          - os: almalinux-8
-#            package-type: yum
-#            package: percona-server-8.0
-#          - os: almalinux-9
-#            package-type: yum
-#            package: percona-server-8.0
-#          - os: centos-7
-#            package-type: yum
-#            package: percona-server-8.0
+          - os: ubuntu-jammy
+            package-type: apt
+            package: mysql-community-8.0
+
+          # MySQL community minimal 8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-minimal-8.0
+
+          # Percona Server 5.7
+          - os: centos-7
+            package-type: yum
+            package: percona-server-5.7
+
+          # Percona Server 8.0
+          - os: almalinux-8
+            package-type: yum
+            package: percona-server-8.0
+          - os: almalinux-9
+            package-type: yum
+            package: percona-server-8.0
+          - os: centos-7
+            package-type: yum
+            package: percona-server-8.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -365,153 +365,153 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # MariaDB 10.3
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.3
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.3
-#
-#          # MariaDB 10.4
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.4
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.4
-#
-#          # MariaDB 10.5
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: amazon-linux-2
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.5
-#          - os: debian-bullseye
-#            package-type: apt
-#            package: mariadb-10.5
-#
-#          # MariaDB 10.6
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.6
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.6
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.6
-#          - os: ubuntu-jammy
-#            package-type: apt
-#            package: mariadb-10.6
-#
-#          # MariaDB 10.7
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.7
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.7
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.7
-#
-#          # MariaDB 10.8
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.8
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.8
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.8
-#
-#          # MariaDB 10.9
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.9
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.9
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.9
-#
-#          # MariaDB 10.10
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.10
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.10
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.10
-#
-#          # MariaDB 10.11
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mariadb-10.11
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mariadb-10.11
-#          - os: centos-7
-#            package-type: yum
-#            package: mariadb-10.11
-#
-#          # MySQL 8.0
-#          - os: ubuntu-jammy
-#            package-type: apt
-#            package: mysql-8.0
-#
-#          # MySQL community 5.7
-#          - os: centos-7
-#            package-type: yum
-#            package: mysql-community-5.7
-#
-#          # MySQL community 8.0
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mysql-community-8.0
-#          - os: almalinux-9
-#            package-type: yum
-#            package: mysql-community-8.0
-#          - os: centos-7
-#            package-type: yum
-#            package: mysql-community-8.0
+          # MariaDB 10.3
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.3
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.3
+
+          # MariaDB 10.4
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.4
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.4
+
+          # MariaDB 10.5
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.5
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.5
+          - os: amazon-linux-2
+            package-type: yum
+            package: mariadb-10.5
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.5
+          - os: debian-bullseye
+            package-type: apt
+            package: mariadb-10.5
+
+          # MariaDB 10.6
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.6
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.6
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.6
+          - os: ubuntu-jammy
+            package-type: apt
+            package: mariadb-10.6
+
+          # MariaDB 10.7
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.7
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.7
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.7
+
+          # MariaDB 10.8
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.8
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.8
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.8
+
+          # MariaDB 10.9
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.9
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.9
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.9
+
+          # MariaDB 10.10
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.10
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.10
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.10
+
+          # MariaDB 10.11
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-10.11
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-10.11
+          - os: centos-7
+            package-type: yum
+            package: mariadb-10.11
+
+          # MySQL 8.0
+          - os: ubuntu-jammy
+            package-type: apt
+            package: mysql-8.0
+
+          # MySQL community 5.7
+          - os: centos-7
+            package-type: yum
+            package: mysql-community-5.7
+
+          # MySQL community 8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-8.0
+          - os: almalinux-9
+            package-type: yum
+            package: mysql-community-8.0
+          - os: centos-7
+            package-type: yum
+            package: mysql-community-8.0
           - os: debian-bullseye
             package-type: apt
             package: mysql-community-8.0
 
-#          # MySQL community minimal 8.0
-#          - os: almalinux-8
-#            package-type: yum
-#            package: mysql-community-minimal-8.0
-#            target-os: oracle-linux-8
-#
-#          # Percona Server 5.7
-#          - os: centos-7
-#            package-type: yum
-#            package: percona-server-5.7
-#
-#          # Percona Server 8.0
-#          - os: almalinux-8
-#            package-type: yum
-#            package: percona-server-8.0
-#          - os: almalinux-9
-#            package-type: yum
-#            package: percona-server-8.0
-#          - os: centos-7
-#            package-type: yum
-#            package: percona-server-8.0
+          # MySQL community minimal 8.0
+          - os: almalinux-8
+            package-type: yum
+            package: mysql-community-minimal-8.0
+            target-os: oracle-linux-8
+
+          # Percona Server 5.7
+          - os: centos-7
+            package-type: yum
+            package: percona-server-5.7
+
+          # Percona Server 8.0
+          - os: almalinux-8
+            package-type: yum
+            package: percona-server-8.0
+          - os: almalinux-9
+            package-type: yum
+            package: percona-server-8.0
+          - os: centos-7
+            package-type: yum
+            package: percona-server-8.0
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,155 +103,155 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # MariaDB 10.3
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.3
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.3
-
-          # MariaDB 10.4
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.4
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.4
-
-          # MariaDB 10.5
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.5
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.5
-          - os: amazon-linux-2
-            package-type: yum
-            package: mariadb-10.5
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.5
+#          # MariaDB 10.3
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.3
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.3
+#
+#          # MariaDB 10.4
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.4
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.4
+#
+#          # MariaDB 10.5
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: amazon-linux-2
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: debian-bullseye
+#            package-type: apt
+#            package: mariadb-10.5
+#
+#          # MariaDB 10.6
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.6
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.6
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.6
+#          - os: ubuntu-jammy
+#            package-type: apt
+#            package: mariadb-10.6
+#
+#          # MariaDB 10.7
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.7
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.7
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.7
+#
+#          # MariaDB 10.8
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.8
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.8
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.8
+#
+#          # MariaDB 10.9
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.9
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.9
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.9
+#
+#          # MariaDB 10.10
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.10
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.10
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.10
+#
+#          # MariaDB 10.11
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.11
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.11
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.11
+#
+#          # MySQL 8.0
+#          - os: ubuntu-jammy
+#            package-type: apt
+#            package: mysql-8.0
+#
+#          # MySQL community 5.7
+#          - os: centos-7
+#            package-type: yum
+#            package: mysql-community-5.7
+#
+#          # MySQL community 8.0
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mysql-community-8.0
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mysql-community-8.0
+#          - os: centos-7
+#            package-type: yum
+#            package: mysql-community-8.0
           - os: debian-bullseye
             package-type: apt
-            package: mariadb-10.5
-
-          # MariaDB 10.6
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.6
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.6
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.6
-          - os: ubuntu-jammy
-            package-type: apt
-            package: mariadb-10.6
-
-          # MariaDB 10.7
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.7
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.7
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.7
-
-          # MariaDB 10.8
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.8
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.8
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.8
-
-          # MariaDB 10.9
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.9
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.9
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.9
-
-          # MariaDB 10.10
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.10
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.10
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.10
-
-          # MariaDB 10.11
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.11
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.11
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.11
-
-          # MySQL 8.0
-          - os: ubuntu-jammy
-            package-type: apt
-            package: mysql-8.0
-
-          # MySQL community 5.7
-          - os: centos-7
-            package-type: yum
-            package: mysql-community-5.7
-
-          # MySQL community 8.0
-          - os: almalinux-8
-            package-type: yum
             package: mysql-community-8.0
-          - os: almalinux-9
-            package-type: yum
-            package: mysql-community-8.0
-          - os: centos-7
-            package-type: yum
-            package: mysql-community-8.0
-          - os: debian-bullseye
-            package-type: apt
-            package: mysql-community-8.0
-          - os: ubuntu-jammy
-            package-type: apt
-            package: mysql-community-8.0
-
-          # MySQL community minimal 8.0
-          - os: almalinux-8
-            package-type: yum
-            package: mysql-community-minimal-8.0
-
-          # Percona Server 5.7
-          - os: centos-7
-            package-type: yum
-            package: percona-server-5.7
-
-          # Percona Server 8.0
-          - os: almalinux-8
-            package-type: yum
-            package: percona-server-8.0
-          - os: almalinux-9
-            package-type: yum
-            package: percona-server-8.0
-          - os: centos-7
-            package-type: yum
-            package: percona-server-8.0
+#          - os: ubuntu-jammy
+#            package-type: apt
+#            package: mysql-community-8.0
+#
+#          # MySQL community minimal 8.0
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mysql-community-minimal-8.0
+#
+#          # Percona Server 5.7
+#          - os: centos-7
+#            package-type: yum
+#            package: percona-server-5.7
+#
+#          # Percona Server 8.0
+#          - os: almalinux-8
+#            package-type: yum
+#            package: percona-server-8.0
+#          - os: almalinux-9
+#            package-type: yum
+#            package: percona-server-8.0
+#          - os: centos-7
+#            package-type: yum
+#            package: percona-server-8.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -365,153 +365,153 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # MariaDB 10.3
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.3
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.3
-
-          # MariaDB 10.4
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.4
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.4
-
-          # MariaDB 10.5
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.5
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.5
-          - os: amazon-linux-2
-            package-type: yum
-            package: mariadb-10.5
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.5
+#          # MariaDB 10.3
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.3
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.3
+#
+#          # MariaDB 10.4
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.4
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.4
+#
+#          # MariaDB 10.5
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: amazon-linux-2
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.5
+#          - os: debian-bullseye
+#            package-type: apt
+#            package: mariadb-10.5
+#
+#          # MariaDB 10.6
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.6
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.6
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.6
+#          - os: ubuntu-jammy
+#            package-type: apt
+#            package: mariadb-10.6
+#
+#          # MariaDB 10.7
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.7
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.7
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.7
+#
+#          # MariaDB 10.8
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.8
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.8
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.8
+#
+#          # MariaDB 10.9
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.9
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.9
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.9
+#
+#          # MariaDB 10.10
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.10
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.10
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.10
+#
+#          # MariaDB 10.11
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mariadb-10.11
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mariadb-10.11
+#          - os: centos-7
+#            package-type: yum
+#            package: mariadb-10.11
+#
+#          # MySQL 8.0
+#          - os: ubuntu-jammy
+#            package-type: apt
+#            package: mysql-8.0
+#
+#          # MySQL community 5.7
+#          - os: centos-7
+#            package-type: yum
+#            package: mysql-community-5.7
+#
+#          # MySQL community 8.0
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mysql-community-8.0
+#          - os: almalinux-9
+#            package-type: yum
+#            package: mysql-community-8.0
+#          - os: centos-7
+#            package-type: yum
+#            package: mysql-community-8.0
           - os: debian-bullseye
             package-type: apt
-            package: mariadb-10.5
-
-          # MariaDB 10.6
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.6
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.6
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.6
-          - os: ubuntu-jammy
-            package-type: apt
-            package: mariadb-10.6
-
-          # MariaDB 10.7
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.7
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.7
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.7
-
-          # MariaDB 10.8
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.8
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.8
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.8
-
-          # MariaDB 10.9
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.9
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.9
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.9
-
-          # MariaDB 10.10
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.10
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.10
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.10
-
-          # MariaDB 10.11
-          - os: almalinux-8
-            package-type: yum
-            package: mariadb-10.11
-          - os: almalinux-9
-            package-type: yum
-            package: mariadb-10.11
-          - os: centos-7
-            package-type: yum
-            package: mariadb-10.11
-
-          # MySQL 8.0
-          - os: ubuntu-jammy
-            package-type: apt
-            package: mysql-8.0
-
-          # MySQL community 5.7
-          - os: centos-7
-            package-type: yum
-            package: mysql-community-5.7
-
-          # MySQL community 8.0
-          - os: almalinux-8
-            package-type: yum
-            package: mysql-community-8.0
-          - os: almalinux-9
-            package-type: yum
-            package: mysql-community-8.0
-          - os: centos-7
-            package-type: yum
-            package: mysql-community-8.0
-          - os: debian-bullseye
-            package-type: apt
             package: mysql-community-8.0
 
-          # MySQL community minimal 8.0
-          - os: almalinux-8
-            package-type: yum
-            package: mysql-community-minimal-8.0
-            target-os: oracle-linux-8
-
-          # Percona Server 5.7
-          - os: centos-7
-            package-type: yum
-            package: percona-server-5.7
-
-          # Percona Server 8.0
-          - os: almalinux-8
-            package-type: yum
-            package: percona-server-8.0
-          - os: almalinux-9
-            package-type: yum
-            package: percona-server-8.0
-          - os: centos-7
-            package-type: yum
-            package: percona-server-8.0
+#          # MySQL community minimal 8.0
+#          - os: almalinux-8
+#            package-type: yum
+#            package: mysql-community-minimal-8.0
+#            target-os: oracle-linux-8
+#
+#          # Percona Server 5.7
+#          - os: centos-7
+#            package-type: yum
+#            package: percona-server-5.7
+#
+#          # Percona Server 8.0
+#          - os: almalinux-8
+#            package-type: yum
+#            package: percona-server-8.0
+#          - os: almalinux-9
+#            package-type: yum
+#            package: percona-server-8.0
+#          - os: centos-7
+#            package-type: yum
+#            package: percona-server-8.0
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -190,6 +190,6 @@ if [ -n "${old_package}" ]; then
   sudo apt install -V -y ${old_package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/
   sudo apt update
-  sudo env DEBIAN_FRONTEND=noninteractive apt upgrade -V -y
+  sudo apt upgrade -V -y
   sudo mysql -e "SHOW ENGINES" | grep Mroonga
 fi

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -35,6 +35,22 @@ wget \
 sudo apt install -V -y ./groonga-apt-source-latest-${code_name}.deb
 sudo apt update
 
+mysql_community_install_mysql_apt_config() {
+  # We need to specify DEBIAN_FRONTEND=noninteractive explicitly
+  # because the mysql-apt-config's config script refers the
+  # DEBIAN_FRONTEND environment variable directly. :<
+  sudo \
+    env DEBIAN_FRONTEND=noninteractive \
+        MYSQL_SERVER_VERSION=mysql-${mysql_version} \
+      apt install -V -y ./mysql-apt-config_*_all.deb
+  sudo apt update
+  # Ensure using the latest mysql-apt-config
+  sudo \
+    env DEBIAN_FRONTEND=noninteractive \
+        MYSQL_SERVER_VERSION=mysql-${mysql_version} \
+      apt upgrade -V -y
+}
+
 case ${package} in
   mariadb-*)
     old_package=$(echo ${package} | sed -e 's/mariadb-/mariadb-server-/')
@@ -50,11 +66,7 @@ case ${package} in
   mysql-community-*)
     old_package=${package}
     wget https://repo.mysql.com/mysql-apt-config_0.8.24-1_all.deb
-    sudo \
-      env DEBIAN_FRONTEND=noninteractive \
-          MYSQL_SERVER_VERSION=mysql-${mysql_version} \
-        apt install -y ./mysql-apt-config_*_all.deb
-    sudo apt update
+    mysql_community_install_mysql_apt_config
     mysql_package_prefix=mysql
     client_dev_package=libmysqlclient-dev
     test_package=mysql-testsuite
@@ -180,10 +192,7 @@ if [ -n "${old_package}" ]; then
   sudo mv /etc/apt/sources.list.d/${package}.list /tmp/
   case ${package} in
     mysql-community-8.*)
-      sudo \
-        env DEBIAN_FRONTEND=noninteractive \
-            MYSQL_SERVER_VERSION=mysql-${mysql_version} \
-          apt install -y ./mysql-apt-config_*_all.deb
+      mysql_community_install_mysql_apt_config
       ;;
   esac
   sudo apt update

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -49,7 +49,7 @@ case ${package} in
     ;;
   mysql-community-*)
     old_package=${package}
-    wget https://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb
+    wget https://repo.mysql.com/mysql-apt-config_0.8.24-1_all.deb
     sudo \
       env DEBIAN_FRONTEND=noninteractive \
           MYSQL_SERVER_VERSION=mysql-${mysql_version} \

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -190,6 +190,6 @@ if [ -n "${old_package}" ]; then
   sudo apt install -V -y ${old_package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/
   sudo apt update
-  sudo apt upgrade -V -y
+  sudo env DEBIAN_FRONTEND=noninteractive apt upgrade -V -y
   sudo mysql -e "SHOW ENGINES" | grep Mroonga
 fi


### PR DESCRIPTION
Because the mysql-apt-config's config script refers the DEBIAN_FRONTEND environment variable directly.
It doesn't refer the debconf setting.