### PR TITLE
packages mariadb: add a newly support for MariaDB 11.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -230,6 +230,17 @@ jobs:
             package-type: apt
             package: mariadb-10.11
 
+          # MariaDB 11.0
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-11.0
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-11.0
+          - os: centos-7
+            package-type: yum
+            package: mariadb-11.0
+
           # MySQL 8.0
           - os: ubuntu-jammy
             package-type: apt
@@ -475,6 +486,17 @@ jobs:
           - os: debian-bookworm
             package-type: apt
             package: mariadb-10.11
+
+          # MariaDB 11.0
+          - os: almalinux-8
+            package-type: yum
+            package: mariadb-11.0
+          - os: almalinux-9
+            package-type: yum
+            package: mariadb-11.0
+          - os: centos-7
+            package-type: yum
+            package: mariadb-11.0
 
           # MySQL 8.0
           - os: ubuntu-jammy

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,9 +38,10 @@ jobs:
           - mariadb-release: "10.9"
           - mariadb-release: "10.10"
           - mariadb-release: "10.11"
-          - mariadb-release: "10.11"
+          - mariadb-release: "11.0"
+          - mariadb-release: "11.0"
             use-master: "yes"
-          - mariadb-release: "10.11"
+          - mariadb-release: "11.0"
             use-master: "yes"
             embed: "ON"
     env:
@@ -120,7 +121,7 @@ jobs:
           ridk exec tar xzf "${mariadbTarGz}"
           Move-Item mariadb-${Env:MARIADB_VERSION} ..\source
           cd ..\source
-          if ("${Env:MARIADB_VERSION}" -match "^10\.5|^10\.6|^10\.7|^10\.8|^10\.9|^10\.10|^10\.11") {
+          if ("${Env:MARIADB_VERSION}" -match "^10\.5|^10\.6|^10\.7|^10\.8|^10\.9|^10\.10|^10\.11|^11\.0") {
             ridk exec patch -p1 -i `
               ..\mroonga\packages\source\patches\mariadb-10.5.5-add-a-missing-export-symbol.diff
           }

--- a/data/rpm/post.sh
+++ b/data/rpm/post.sh
@@ -19,15 +19,18 @@ case "${variant}" in
     service_name=mysqld
     variant_label=MySQL
     may_have_auto_generated_password=yes
+    mysql_command=$(which mysql)
     ;;
   mariadb)
     service_name=mariadb
     variant_label=MariaDB
+    mysql_command=$(which mariadb)
     ;;
   percona)
     service_name=mysqld
     variant_label="Percona Server"
     may_have_auto_generated_password=yes
+    mysql_command=$(which mysql)
     ;;
 esac
 
@@ -69,7 +72,6 @@ update_sql=${data_dir}/mroonga/update.sql
 
 need_password_expire=no
 if [ "${try_auto_prepare}" = "yes" ]; then
-  mysql_command=$(which mysql)
   password_option=""
   if [ "${have_auto_generated_password}" = "yes" ]; then
     if "${mysql_command}" \

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14167,7 +14167,9 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
                                                         ha_rows limit,
+#endif
                                                         Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14175,7 +14177,10 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
   KEY *key_info = &(table->key_info[keyno]);
   if (mrn_is_geo_key(key_info)) {
     rows = handler::multi_range_read_info_const(keyno, seq, seq_init_param,
-                                                n_ranges, bufsz, flags, limit,
+                                                n_ranges, bufsz, flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+                                                limit,
+#endif
                                                 cost);
     DBUG_RETURN(rows);
   }
@@ -14184,7 +14189,10 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
   if (fulltext_searching)
     set_pk_bitmap();
   rows = wrap_handler->multi_range_read_info_const(keyno, seq, seq_init_param,
-                                                   n_ranges, bufsz, flags, limit,
+                                                   n_ranges, bufsz, flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+                                                   limit,
+#endif
                                                    cost);
   MRN_SET_BASE_SHARE_KEY(share, table->s);
   MRN_SET_BASE_TABLE_KEY(this, table);
@@ -14198,21 +14206,29 @@ ha_rows ha_mroonga::storage_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
                                                         ha_rows limit,
+#endif
                                                         Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
   ha_rows rows = handler::multi_range_read_info_const(keyno, seq,
                                                       seq_init_param,
                                                       n_ranges, bufsz, flags,
-                                                      limit, cost);
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+                                                      limit,
+#endif
+                                                      cost);
   DBUG_RETURN(rows);
 }
 
 ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                                 void *seq_init_param,
                                                 uint n_ranges, uint *bufsz,
-                                                uint *flags, ha_rows limit,
+                                                uint *flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+                                                ha_rows limit,
+#endif
                                                 Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14222,12 +14238,20 @@ ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   {
     rows = wrapper_multi_range_read_info_const(keyno, seq, seq_init_param,
                                                n_ranges, bufsz,
-                                               flags, limit, cost);
+                                               flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+                                               limit,
+#endif
+                                               cost);
   } else {
 #endif
     rows = storage_multi_range_read_info_const(keyno, seq, seq_init_param,
                                                n_ranges, bufsz,
-                                               flags, limit, cost);
+                                               flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+                                               limit,
+#endif
+                                               cost);
 #ifdef MRN_ENABLE_WRAPPER_MODE
   }
 #endif

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15012,9 +15012,14 @@ IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
   if (share->wrapper_mode)
   {
     time = wrapper_keyread_time(index, ranges, rows, blocks);
-  } else {
+  }
+#  else
+  time = storage_keyread_time(index, ranges, rows, blocks);
+# endif
+  DBUG_RETURN(time);
+}
+
 #  endif
-    time = storage_keyread_time(index, ranges, rows, blocks);
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   }
 #  endif

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14963,9 +14963,9 @@ double ha_mroonga::scan_time()
 #if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
-                                                  uint ranges,
-                                                  ha_rows rows,
-                                                  ulonglong blocks)
+                                                 uint ranges,
+                                                 ha_rows rows,
+                                                 ulonglong blocks)
 {
   IO_AND_CPU_COST res;
   MRN_DBUG_ENTER_METHOD();
@@ -14992,9 +14992,9 @@ IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
 #  endif
 
 IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,
-                                        uint ranges,
-                                        ha_rows rows,
-                                        ulonglong blocks)
+                                                 uint ranges,
+                                                 ha_rows rows,
+                                                 ulonglong blocks)
 {
   MRN_DBUG_ENTER_METHOD();
   IO_AND_CPU_COST time = handler::keyread_time(index, ranges, rows, blocks);

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15019,9 +15019,36 @@ IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
   DBUG_RETURN(time);
 }
 
-#  endif
 #  ifdef MRN_ENABLE_WRAPPER_MODE
+IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  MRN_SET_WRAP_SHARE_KEY(share, table->s);
+  MRN_SET_WRAP_TABLE_KEY(this, table);
+  IO_AND_CPU_COST time = wrap_handler->rnd_pos_time(rows);
+  MRN_SET_BASE_SHARE_KEY(share, table->s);
+  MRN_SET_BASE_TABLE_KEY(this, table);
+  DBUG_RETURN(time);
+}
+#  endif
+IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST time = handler::rnd_pos_time(rows);
+  DBUG_RETURN(time);
+}
+
+IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST time;
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+  if (share->wrapper_mode)
+  {
+    time = wrapper_rnd_pos_time(rows);
   }
+#  else
+  time = storage_rnd_pos_time(rows);
 #  endif
   DBUG_RETURN(time);
 }

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15002,7 +15002,7 @@ IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,
 }
 
 IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
-                                         uint ranges,
+                                         ulong ranges,
                                          ha_rows rows,
                                          ulonglong blocks)
 {

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14167,6 +14167,7 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+                                                        ha_rows limit,
                                                         Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14174,7 +14175,8 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
   KEY *key_info = &(table->key_info[keyno]);
   if (mrn_is_geo_key(key_info)) {
     rows = handler::multi_range_read_info_const(keyno, seq, seq_init_param,
-                                                n_ranges, bufsz, flags, cost);
+                                                n_ranges, bufsz, flags, limit,
+                                                cost);
     DBUG_RETURN(rows);
   }
   MRN_SET_WRAP_SHARE_KEY(share, table->s);
@@ -14182,7 +14184,7 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
   if (fulltext_searching)
     set_pk_bitmap();
   rows = wrap_handler->multi_range_read_info_const(keyno, seq, seq_init_param,
-                                                   n_ranges, bufsz, flags,
+                                                   n_ranges, bufsz, flags, limit,
                                                    cost);
   MRN_SET_BASE_SHARE_KEY(share, table->s);
   MRN_SET_BASE_TABLE_KEY(this, table);
@@ -14196,20 +14198,21 @@ ha_rows ha_mroonga::storage_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+                                                        ha_rows limit,
                                                         Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
   ha_rows rows = handler::multi_range_read_info_const(keyno, seq,
                                                       seq_init_param,
                                                       n_ranges, bufsz, flags,
-                                                      cost);
+                                                      limit, cost);
   DBUG_RETURN(rows);
 }
 
 ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                                 void *seq_init_param,
                                                 uint n_ranges, uint *bufsz,
-                                                uint *flags,
+                                                uint *flags, ha_rows limit,
                                                 Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14219,12 +14222,12 @@ ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   {
     rows = wrapper_multi_range_read_info_const(keyno, seq, seq_init_param,
                                                n_ranges, bufsz,
-                                               flags, cost);
+                                               flags, limit, cost);
   } else {
 #endif
     rows = storage_multi_range_read_info_const(keyno, seq, seq_init_param,
                                                n_ranges, bufsz,
-                                               flags, cost);
+                                               flags, limit, cost);
 #ifdef MRN_ENABLE_WRAPPER_MODE
   }
 #endif

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14963,7 +14963,7 @@ double ha_mroonga::scan_time()
 #if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
-                                                 uint ranges,
+                                                 ulong ranges,
                                                  ha_rows rows,
                                                  ulonglong blocks)
 {
@@ -14992,7 +14992,7 @@ IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
 #  endif
 
 IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,
-                                                 uint ranges,
+                                                 ulong ranges,
                                                  ha_rows rows,
                                                  ulonglong blocks)
 {

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -657,7 +657,10 @@ public:
   double scan_time() mrn_override;
 #endif
 #if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
-  IO_AND_CPU_COST keyread_time(uint index, ulong ranges, ha_rows rows, ulonglong blocks) mrn_override;
+  IO_AND_CPU_COST keyread_time(uint index,
+                               ulong ranges,
+                               ha_rows rows,
+                               ulonglong blocks) mrn_override;
 #else
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -677,6 +677,7 @@ public:
                                       uint n_ranges,
                                       uint *bufsz,
                                       uint *flags,
+                                      ha_rows limit,
                                       Cost_estimate *cost) mrn_override;
   ha_rows multi_range_read_info(uint keyno,
                                 uint n_ranges,
@@ -1528,6 +1529,7 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+                                              ha_rows limit,
                                               Cost_estimate *cost);
 #endif
   ha_rows storage_multi_range_read_info_const(uint keyno,
@@ -1536,6 +1538,7 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+                                              ha_rows limit,
                                               Cost_estimate *cost);
 #ifdef MRN_ENABLE_WRAPPER_MODE
   ha_rows wrapper_multi_range_read_info(uint keyno, uint n_ranges, uint keys,

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -677,7 +677,9 @@ public:
                                       uint n_ranges,
                                       uint *bufsz,
                                       uint *flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
                                       ha_rows limit,
+#endif
                                       Cost_estimate *cost) mrn_override;
   ha_rows multi_range_read_info(uint keyno,
                                 uint n_ranges,
@@ -1529,7 +1531,9 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+#  if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
                                               ha_rows limit,
+#  endif
                                               Cost_estimate *cost);
 #endif
   ha_rows storage_multi_range_read_info_const(uint keyno,
@@ -1538,7 +1542,9 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
                                               ha_rows limit,
+#endif
                                               Cost_estimate *cost);
 #ifdef MRN_ENABLE_WRAPPER_MODE
   ha_rows wrapper_multi_range_read_info(uint keyno, uint n_ranges, uint keys,

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -661,6 +661,7 @@ public:
                                ulong ranges,
                                ha_rows rows,
                                ulonglong blocks) mrn_override;
+  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
 #else
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #endif
@@ -1490,12 +1491,14 @@ private:
                                        ulong ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
+  IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);
 #  endif
   IO_AND_CPU_COST storage_scan_time();
   IO_AND_CPU_COST storage_keyread_time(uint index,
                                        ulong ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
+  IO_AND_CPU_COST storage_rnd_pos_time(ha_rows rows);
 #else
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   double wrapper_scan_time();

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -656,7 +656,11 @@ public:
 #else
   double scan_time() mrn_override;
 #endif
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+  IO_AND_CPU_COST keyread_time(uint index, ulong ranges, ha_rows rows, ulonglong blocks) mrn_override;
+#else
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
+#endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
   longlong get_memory_buffer_size() const mrn_override;
 #endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -651,7 +651,11 @@ public:
                            uint child_key_name_len) mrn_override;
 #endif
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg) mrn_override;
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+  IO_AND_CPU_COST scan_time() mrn_override;
+#else
   double scan_time() mrn_override;
+#endif
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
   longlong get_memory_buffer_size() const mrn_override;
@@ -1472,10 +1476,17 @@ private:
   void wrapper_change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg);
 #endif
   void storage_change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg);
-#ifdef MRN_ENABLE_WRAPPER_MODE
+#if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+  IO_AND_CPU_COST wrapper_scan_time();
+#  endif
+  IO_AND_CPU_COST storage_scan_time();
+#else
+#  ifdef MRN_ENABLE_WRAPPER_MODE
   double wrapper_scan_time();
-#endif
+#  endif
   double storage_scan_time();
+#endif
 #ifdef MRN_ENABLE_WRAPPER_MODE
   double wrapper_read_time(uint index, uint ranges, ha_rows rows);
 #endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -1486,8 +1486,16 @@ private:
 #if MYSQL_VERSION_ID >= 110002 && defined(MRN_MARIADB_P)
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   IO_AND_CPU_COST wrapper_scan_time();
+  IO_AND_CPU_COST wrapper_keyread_time(uint index,
+                                       ulong ranges,
+                                       ha_rows rows,
+                                       ulonglong blocks);
 #  endif
   IO_AND_CPU_COST storage_scan_time();
+  IO_AND_CPU_COST storage_keyread_time(uint index,
+                                       ulong ranges,
+                                       ha_rows rows,
+                                       ulonglong blocks);
 #else
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   double wrapper_scan_time();

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -7,6 +7,7 @@ packages = [
   "mariadb-10.9-mroonga",
   "mariadb-10.10-mroonga",
   "mariadb-10.11-mroonga",
+  "mariadb-11.0-mroonga",
   "mysql-8.0-mroonga",
   "mysql-community-5.7-mroonga",
   "mysql-community-8.0-mroonga",

--- a/packages/mariadb-11.0-mroonga/Rakefile
+++ b/packages/mariadb-11.0-mroonga/Rakefile
@@ -2,7 +2,7 @@ require_relative "../mroonga-package-task"
 
 class MariaDB110MroongaPackageTask < MroongaPackageTask
   def initialize
-    super("mariadb-11.0")
+    super("mariadb-11.0-mroonga")
   end
 
   def enable_apt?

--- a/packages/mariadb-11.0-mroonga/Rakefile
+++ b/packages/mariadb-11.0-mroonga/Rakefile
@@ -1,0 +1,26 @@
+require_relative "../mroonga-package-task"
+
+class MariaDB110MroongaPackageTask < MroongaPackageTask
+  def initialize
+    super("mariadb-11.0")
+  end
+
+  def enable_apt?
+    false
+  end
+
+  def enable_ubuntu?
+    false
+  end
+
+  def yum_targets_default
+    [
+      "almalinux-8",
+      "almalinux-9",
+      "centos-7",
+    ]
+  end
+end
+
+task = MariaDB110MroongaPackageTask.new
+task.define

--- a/packages/mariadb-11.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-11.0-mroonga/yum/almalinux-8/Dockerfile
@@ -1,0 +1,41 @@
+ARG FROM=almalinux:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  { \
+    echo "[mariadb]"; \
+    echo "name = MariaDB"; \
+    echo "baseurl = https://yum.mariadb.org/11.0/rhel/8/x86_64/"; \
+    echo "gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"; \
+    echo "gpgcheck = 1"; \
+  } | tee /etc/yum.repos.d/MariaDB.repo && \
+  dnf install -y \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+  dnf groupinstall -y ${quiet} "Development Tools" && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    'dnf-command(builddep)' \
+    'dnf-command(download)' && \
+  dnf module --enablerepo=powertools -y ${quiet} enable mariadb-devel && \
+  dnf builddep --enablerepo=powertools -y ${quiet} MariaDB && \
+  dnf module --enablerepo=powertools -y ${quiet} disable mariadb-devel && \
+  dnf module -y ${quiet} disable mariadb && \
+  dnf module -y ${quiet} disable mysql && \
+  dnf download -y ${quiet} --source MariaDB && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    MariaDB-devel \
+    ccache \
+    gcc-c++ \
+    groonga-devel \
+    groonga-normalizer-mysql-devel \
+    intltool \
+    libtool \
+    make \
+    pkgconfig \
+    sudo \
+    wget \
+    which && \
+  dnf clean ${quiet} all

--- a/packages/mariadb-11.0-mroonga/yum/almalinux-9/Dockerfile
+++ b/packages/mariadb-11.0-mroonga/yum/almalinux-9/Dockerfile
@@ -1,0 +1,42 @@
+ARG FROM=almalinux:9
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  { \
+    echo "[mariadb]"; \
+    echo "name = MariaDB"; \
+    echo "baseurl = https://yum.mariadb.org/11.0/rhel9-amd64"; \
+    echo "gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"; \
+    echo "gpgcheck = 1"; \
+  } | tee /etc/yum.repos.d/MariaDB.repo && \
+  dnf install -y \
+    https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm && \
+  dnf install -y epel-release && \
+  dnf install -y https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
+  dnf config-manager --set-enabled epel|| : && \
+  dnf config-manager --set-enabled crb || : && \
+  dnf groupinstall -y ${quiet} "Development Tools" && \
+  dnf install --enablerepo=crb -y ${quiet} \
+    'dnf-command(builddep)' \
+    'dnf-command(download)' && \
+  dnf builddep --enablerepo=crb -y ${quiet} MariaDB && \
+  dnf download -y ${quiet} --source MariaDB && \
+  dnf install --enablerepo=crb -y ${quiet} \
+    arrow-devel \
+    MariaDB-devel \
+    ccache \
+    gcc-c++ \
+    groonga-devel \
+    groonga-normalizer-mysql-devel \
+    intltool \
+    libtool \
+    make \
+    pkgconfig \
+    sudo \
+    wget \
+    which && \
+  dnf clean ${quiet} all

--- a/packages/mariadb-11.0-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mariadb-11.0-mroonga/yum/centos-7/Dockerfile
@@ -1,0 +1,34 @@
+ARG FROM=centos:7
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  yum update -y ${quiet} && \
+  { \
+    echo "[mariadb]"; \
+    echo "name = MariaDB"; \
+    echo "baseurl = https://yum.mariadb.org/11.0/rhel/7/x86_64/"; \
+    echo "gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"; \
+    echo "gpgcheck = 1"; \
+  } | tee /etc/yum.repos.d/MariaDB.repo && \
+  yum install -y \
+    https://packages.groonga.org/centos/7/groonga-release-latest.noarch.rpm && \
+  yum groupinstall -y ${quiet} "Development Tools" && \
+  yum-builddep -y ${quiet} MariaDB && \
+  yumdownloader -y ${quiet} --source MariaDB && \
+  yum install -y ${quiet} \
+    MariaDB-devel \
+    ccache \
+    gcc-c++ \
+    groonga-devel \
+    groonga-normalizer-mysql-devel \
+    intltool \
+    libtool \
+    make \
+    pkgconfig \
+    sudo \
+    wget \
+    which && \
+  yum clean ${quiet} all

--- a/packages/mariadb-11.0-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mariadb-11.0-mroonga/yum/centos-7/Dockerfile
@@ -3,6 +3,9 @@ FROM ${FROM}
 
 ARG DEBUG
 
+ENV \
+  SCL=devtoolset-11
+
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   yum update -y ${quiet} && \
@@ -14,14 +17,15 @@ RUN \
     echo "gpgcheck = 1"; \
   } | tee /etc/yum.repos.d/MariaDB.repo && \
   yum install -y \
+    centos-release-scl-rh \
     https://packages.groonga.org/centos/7/groonga-release-latest.noarch.rpm && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum-builddep -y ${quiet} MariaDB && \
   yumdownloader -y ${quiet} --source MariaDB && \
   yum install -y ${quiet} \
+    ${SCL} \
     MariaDB-devel \
     ccache \
-    gcc-c++ \
     groonga-devel \
     groonga-normalizer-mysql-devel \
     intltool \

--- a/packages/mariadb-11.0-mroonga/yum/mariadb-11.0-mroonga.spec.in
+++ b/packages/mariadb-11.0-mroonga/yum/mariadb-11.0-mroonga.spec.in
@@ -1,0 +1,132 @@
+# -*- sh-shell: rpm -*-
+
+%define mariadb_version_default 11.0.2
+%define mariadb_release_default 1
+%if %{rhel} == 7
+%define mariadb_dist_default    el%{rhel}.centos
+%else
+%define mariadb_dist_default    el%{rhel}
+%endif
+
+%define _mariadb_version %{?mariadb_version:%{mariadb_version}}%{!?mariadb_version:%{mariadb_version_default}}
+%define _mariadb_release %{?mariadb_release:%{mariadb_release}}%{!?mariadb_release:%{mariadb_release_default}}
+%define _mariadb_dist %{?mariadb_dist:%{mariadb_dist}}%{!?mariadb_dist:%{mariadb_dist_default}}
+
+%define use_dnf (%{rhel} >= 8)
+
+%if %{use_dnf}
+%define dnf_download dnf download
+%else
+%define dnf_download yumdownloader
+%endif
+
+%define groonga_required_version @REQUIRED_GROONGA_VERSION@
+
+Name:		mariadb-11.0-mroonga
+Version:	@VERSION@
+Release:	1%{?dist}
+Summary:	A fast fulltext searchable storage engine for MariaDB
+
+Group:		Applications/Databases
+License:	LGPLv2.1
+URL:		https://mroonga.org/
+Source0:	https://packages.groonga.org/source/mroonga/mroonga-%{version}.tar.gz
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
+BuildRequires:	MariaDB-devel = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+BuildRequires:	gcc-c++
+BuildRequires:	groonga-devel >= %{groonga_required_version}
+BuildRequires:	groonga-normalizer-mysql-devel
+BuildRequires:	rpm
+BuildRequires:	sed
+BuildRequires:	which
+%if %{use_dnf}
+BuildRequires:	dnf-command(download)
+%else
+BuildRequires:	yum-utils
+%endif
+Requires:	MariaDB-server = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+Requires:	MariaDB-client = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+Requires:	groonga-libs >= %{groonga_required_version}
+Requires:	groonga-normalizer-mysql
+
+%description
+Mroonga is a fast fulltext searchable storage plugin for MariaDB.
+It is based on Groonga that is a fast fulltext search engine and
+column store. Groonga is good at real-time update.
+
+%package doc
+Summary:	Documentation for Mroonga
+Group:		Documentation
+License:	LGPLv2.1
+
+%description doc
+Documentation for Mroonga
+
+
+%prep
+%setup -q -n mroonga-%{version}
+
+if ! cp /MariaDB-*.src.rpm ./; then
+  %{dnf_download} -y ${quiet} --source MariaDB
+fi
+rpm -Uvh MariaDB-*.src.rpm
+sed -i'' -e 's/^make /make perfschema /' ~/rpmbuild/SPECS/MariaDB.spec
+
+%build
+rpmbuild -bc ~/rpmbuild/SPECS/MariaDB.spec
+mariadb_source=$HOME/rpmbuild/BUILD/MariaDB-%{_mariadb_version}/mariadb-%{_mariadb_version}
+mariadb_build=$HOME/rpmbuild/BUILD/MariaDB-%{_mariadb_version}/cpack_rpm_build_dir
+%configure \
+    --disable-static \
+    --with-mysql-source=${mariadb_source} \
+    --with-mysql-build=${mariadb_build} \
+    --with-mysql-config=${mariadb_build}/scripts/mysql_config \
+    %{?mroonga_configure_options}
+make %{?_smp_mflags}
+
+%install
+rm -rf $RPM_BUILD_ROOT
+make install DESTDIR=$RPM_BUILD_ROOT
+rm $RPM_BUILD_ROOT%{_libdir}/mysql/plugin/*.la
+rm $RPM_BUILD_ROOT%{_libdir}/mysql/plugin/ha_mroonga.so
+rm $RPM_BUILD_ROOT%{_libdir}/mysql/plugin/ha_mroonga.so.?
+mv $RPM_BUILD_ROOT%{_libdir}/mysql/plugin/ha_mroonga.so.?.?.? \
+   $RPM_BUILD_ROOT%{_libdir}/mysql/plugin/ha_mroonga_official.so
+mv $RPM_BUILD_ROOT%{_datadir}/doc/mroonga/ mroonga-doc/
+sed -i'' -e 's/ha_mroonga/ha_mroonga_official/g' \
+  $RPM_BUILD_ROOT%{_datadir}/mroonga/*.sql
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%post
+# Ensure returning success status for manual Mroonga preparation.
+%{_datadir}/mroonga/rpm/post.sh \
+  "$1" \
+  mariadb \
+  %{_datadir} \
+  %{groonga_required_version} || :
+
+%preun
+# Ensure returning success status for manual Mroonga preparation.
+%{_datadir}/mroonga/rpm/preun.sh \
+  "$1" \
+  mariadb \
+  %{_datadir} || :
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/mysql/plugin/
+%{_datadir}/mroonga/*
+%{_datadir}/man/man1/*
+%{_datadir}/man/*/man1/*
+
+%files doc
+%defattr(-,root,root,-)
+%doc README COPYING
+%doc mroonga-doc/*
+
+%changelog
+* Thu Jun 15 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.02-1
+- New upstream release.

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -143,6 +143,15 @@ esac
 function mroonga_is_registered() {
   sudo systemctl start ${service_name}
   mysql="mysql -u root"
+  case ${package} in
+    mariadb-*)
+      case ${mysql_version} in
+        11.0)
+          mysql="mariadb -u root"
+          ;;
+      esac
+      ;;
+  esac
   if [ "${have_auto_generated_password}" = "yes" ]; then
     auto_generated_password=$(sudo awk '/root@localhost/{print $NF}' /var/log/mysqld.log | tail -n 1)
     mysql="${mysql} -p${auto_generated_password}"

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -64,7 +64,7 @@ case ${package} in
       ha_mroonga_so=ha_mroonga_official.so
       test_package_name=MariaDB-test
       case ${mysql_version} in
-        10.5|10.6|10.7|10.8|10.9|10.10|10.11)
+        10.5|10.6|10.7|10.8|10.9|10.10|10.11|11.0)
           baseurl=https://yum.mariadb.org/${mysql_version}/rhel${major_version}-amd64
           ;;
         *)


### PR DESCRIPTION
Fix: #632

* Use `keyread_time()` + `rnd_pos_time()` instead of `read_time()`.
  Because `read_time()` is removed since MariaDB 11.0.2.

* Change the type of return value to `IO_AND_CPU_COST` for `scan_time()`.
  Because the return value of type of `scan_time()` is changed `IO_AND_CPU_COST` since MariaDB 11.0.2.

See:
* https://github.com/MariaDB/server/commit/b66cdbd1eaeed7e96317a03a190c496fd062ec71

---

* Add a newly argument of range optimizer.
  Because the argument of `multi_range_read_info_const()` is added since MariaDB11.0.2.

See:
* https://github.com/MariaDB/server/commit/009db2288ba8d22c5e8e5e047d8f8694f7097923