### PR TITLE
 packages percona-server-8.0: add support for MySQL 8.0.33

### DIFF
--- a/packages/percona-server-8.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/percona-server-8.0-mroonga/yum/almalinux-8/Dockerfile
@@ -4,7 +4,7 @@ FROM ${FROM}
 ARG DEBUG
 
 ENV \
-  SCL=gcc-toolset-11
+  SCL=gcc-toolset-12
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \


### PR DESCRIPTION
* Use GCC 12
  Because MySQL 8.0.33 use GCC 12 instead of GCC 11.

  See:
  https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-33.html