### PR TITLE
ci install: use LXD instead of Vagrant

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -25,6 +25,7 @@ jobs:
             package: mysql
     steps:
       - uses: actions/checkout@v4
+      - uses: canonical/setup-lxd@v0.1.1
       - name: Install Mroonga
         run: |
           set -x

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,8 +1,9 @@
 name: Install to Ubuntu
 on:
-  schedule:
-    - cron: |
-        0 0 * * *
+  - push
+#  schedule:
+#    - cron: |
+#        0 0 * * *
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,9 +1,8 @@
 name: Install to Ubuntu
 on:
-  - push
-#  schedule:
-#    - cron: |
-#        0 0 * * *
+  schedule:
+    - cron: |
+        0 0 * * *
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -9,28 +9,26 @@ concurrency:
 jobs:
   install:
     name: Install to Ubuntu
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-focal
+          - image: "ubuntu:20.04"
             package: mariadb
-          - os: ubuntu-focal
+          - image: "ubuntu:20.04"
             package: mysql
-          - os: ubuntu-jammy
+          - image: "ubuntu:22.04"
             package: mariadb
-          - os: ubuntu-jammy
+          - image: "ubuntu:22.04"
             package: mysql
-    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
-      - name: Run VM
-        run: |
-          vagrant up ${{ matrix.os }}
       - name: Install Mroonga
         run: |
-          vagrant \
-            ssh ${{ matrix.os }} \
-            -- \
-            /vagrant/packages/apt/install_test.sh \
-            ${{ matrix.package }}-mroonga
+          set -x
+          lxc launch ${{ matrix.image }} target
+          lxc config device add target host disk source=$PWD path=/host
+          lxc exec target -- /host/packages/apt/install_test.sh ${{ matrix.package }}-mroonga
+          lxc stop target
+          lxc delete target


### PR DESCRIPTION
Because Vagrant isn't OSS.