### PR TITLE
ci linux: use LXD instead of Vagrant

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -437,7 +437,7 @@ jobs:
             image: "images:centos/7"
             package-type: yum
             package: percona-server-8.0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: canonical/setup-lxd@v0.1.1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -454,6 +454,7 @@ jobs:
           os=${{ matrix.target-os }}
           : ${os:=${{ matrix.os }}}
           lxc launch ${{ matrix.image }} target
+          sleep 5
           lxc config device add target host disk source=$PWD path=/host
           lxc exec target -- /host/packages/${{ matrix.package-type }}/test.sh \
           ${{ matrix.package }}-mroonga

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -324,70 +324,89 @@ jobs:
         include:
           # MariaDB 10.4
           - os: almalinux-8
+            image: "images:almalinux/8"
             package-type: yum
             package: mariadb-10.4
           - os: centos-7
+            image: "images:centos/7"
             package-type: yum
             package: mariadb-10.4
 
           # MariaDB 10.5
           - os: almalinux-8
+            image: "images:almalinux/8"
             package-type: yum
             package: mariadb-10.5
           - os: almalinux-9
+            image: "images:almalinux/9"
             package-type: yum
             package: mariadb-10.5
           - os: centos-7
+            image: "images:centos/7"
             package-type: yum
             package: mariadb-10.5
           - os: debian-bullseye
+            image: "images:debian/11"
             package-type: apt
             package: mariadb-10.5
 
           # MariaDB 10.6
           - os: almalinux-8
+            image: "images:almalinux/8"
             package-type: yum
             package: mariadb-10.6
           - os: almalinux-9
+            image: "images:almalinux/9"
             package-type: yum
             package: mariadb-10.6
           - os: centos-7
+            image: "images:centos/7"
             package-type: yum
             package: mariadb-10.6
           - os: ubuntu-jammy
+            image: "ubuntu:22.04"
             package-type: apt
             package: mariadb-10.6
 
           # MariaDB 10.11
           - os: almalinux-8
+            image: "images:almalinux/8"
             package-type: yum
             package: mariadb-10.11
           - os: almalinux-9
+            image: "images:almalinux/9"
             package-type: yum
             package: mariadb-10.11
           - os: centos-7
+            image: "images:centos/7"
             package-type: yum
             package: mariadb-10.11
           - os: debian-bookworm
+            image: "images:debian/12"
             package-type: apt
             package: mariadb-10.11
 
           # MySQL 8.0
           - os: ubuntu-jammy
+            image: "ubuntu:22.04"
             package-type: apt
             package: mysql-8.0
 
           # MySQL community 8.0
           - os: almalinux-8
+            image: "images:almalinux/8"
             package-type: yum
             package: mysql-community-8.0
           - os: almalinux-9
+            image: "images:almalinux/9"
             package-type: yum
             package: mysql-community-8.0
           - os: centos-7
+            image: "images:centos/7"
             package-type: yum
             package: mysql-community-8.0
           - os: debian-bullseye
+            image: "images:debian/11"
             package-type: apt
             package: mysql-community-8.0
 # Currently, the source of MySQL Community Server for Debian 12 doesn't exist
@@ -400,42 +419,47 @@ jobs:
 
           # MySQL community minimal 8.0
           - os: almalinux-8
+            image: "images:almalinux/8"
             package-type: yum
             package: mysql-community-minimal-8.0
             target-os: oracle-linux-8
 
           # Percona Server 8.0
           - os: almalinux-8
+            image: "images:almalinux/8"
             package-type: yum
             package: percona-server-8.0
           - os: almalinux-9
+            image: "images:almalinux/9"
             package-type: yum
             package: percona-server-8.0
           - os: centos-7
+            image: "images:centos/7"
             package-type: yum
             package: percona-server-8.0
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: canonical/setup-lxd@v0.1.1
       - uses: actions/download-artifact@v3
         with:
           name: packages-${{ matrix.package }}-${{ matrix.os }}
-      - name: Run VM
-        run: |
-          os=${{ matrix.target-os }}
-          : ${os:=${{ matrix.os }}}
-          vagrant up ${os}
       - name: Run test
         run: |
+          set -x
+
           repositories_dir=packages/${{ matrix.package }}-mroonga/${{ matrix.package-type }}/repositories/
           mkdir -p "${repositories_dir}"
           os_type=$(echo "${{ matrix.os }}" | grep -o '^[^-]*')
           cp -a ${os_type} "${repositories_dir}"
           os=${{ matrix.target-os }}
           : ${os:=${{ matrix.os }}}
-          vagrant \
-            ssh ${os} \
-            -- \
-            /vagrant/packages/${{ matrix.package-type }}/test.sh \
-            ${{ matrix.package }}-mroonga
+
+          lxc launch ${{ matrix.image }} target
+          lxc config device add target host disk source=$PWD path=/host
+          lxc exec target -- /host/packages/${{ matrix.package-type }}/test.sh \
+          ${{ matrix.package }}-mroonga
+
+          lxc stop target
+          lxc delete target
         timeout-minutes: 20

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -447,19 +447,16 @@ jobs:
       - name: Run test
         run: |
           set -x
-
           repositories_dir=packages/${{ matrix.package }}-mroonga/${{ matrix.package-type }}/repositories/
           mkdir -p "${repositories_dir}"
           os_type=$(echo "${{ matrix.os }}" | grep -o '^[^-]*')
           cp -a ${os_type} "${repositories_dir}"
           os=${{ matrix.target-os }}
           : ${os:=${{ matrix.os }}}
-
           lxc launch ${{ matrix.image }} target
           lxc config device add target host disk source=$PWD path=/host
           lxc exec target -- /host/packages/${{ matrix.package-type }}/test.sh \
           ${{ matrix.package }}-mroonga
-
           lxc stop target
           lxc delete target
         timeout-minutes: 20

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -112,7 +112,7 @@ sudo gpg \
   --import keys
 
 sudo apt install -V -y reprepro
-repositories_dir=/vagrant/packages/${package}/apt/repositories
+repositories_dir=/host/packages/${package}/apt/repositories
 pushd /tmp/
 mkdir -p conf/
 cat <<DISTRIBUTIONS > conf/distributions
@@ -142,7 +142,7 @@ sudo apt install -V -y \
 pushd ${mysql_test_dir}
 sudo rm -rf plugin/mroonga
 sudo mkdir -p plugin
-sudo cp -a /vagrant/mysql-test/mroonga/ plugin/
+sudo cp -a /host/mysql-test/mroonga/ plugin/
 
 case ${package} in
   mysql-8.*)

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -27,6 +27,7 @@ case ${major_version} in
     else
       DNF="dnf --enablerepo=powertools"
     fi
+    sudo ${DNF} update -y
     sudo dnf module -y disable mariadb
     sudo dnf module -y disable mysql
     ;;

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -143,7 +143,7 @@ function mroonga_can_be_registered_for_mysql_community_minimal() {
   mysqladmin -u root -p${auto_generated_password} shutdown
 }
 
-repositories_dir=/vagrant/packages/${package}/yum/repositories
+repositories_dir=/host/packages/${package}/yum/repositories
 sudo ${DNF} install -y \
   ${repositories_dir}/${os}/${major_version}/*/Packages/*.rpm
 
@@ -181,7 +181,7 @@ else
   sudo rm -rf plugin
 fi
 sudo mkdir -p plugin
-sudo cp -a /vagrant/mysql-test/mroonga/ plugin/
+sudo cp -a /host/mysql-test/mroonga/ plugin/
 sed -i'' -e "s/ha_mroonga\\.so/${ha_mroonga_so}/g" \
   plugin/mroonga/include/mroonga/check_ha_mroonga_so.inc
 sed -i'' -e "s/\$HA_MROONGA_SO/${ha_mroonga_so}/g" \


### PR DESCRIPTION
Because Vagrant isn't OSS.


We use LXC on Ubuntu 20.04 in test of Mroonga packages for Linux.
Because CentOS 7 requires CGroupV1.

If we use LXC on Ubuntu 22.04, CentOS 7 image can not start.
Because LXC on Ubuntu 22.04 use CGroupV2 normally. 