### PR TITLE
ci windows: display Groonga revision

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -156,7 +156,8 @@ jobs:
           cd ..\source
           if ("${{ matrix.use-main }}" -eq "yes") {
             pushd extra\groonga
-            git describe --abbrev=7 HEAD
+            $groonga_revision = git describe --abbrev=7 HEAD
+            Write-Output $groonga_revision
             popd
           }
       - name: Prepare groonga-normalizer-mysql

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,9 +55,6 @@ jobs:
         run: |
           Set-TimeZone -Id "Tokyo Standard Time"
       - uses: actions/setup-ruby@v1
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Set environment variables
         run: |
           $releasesResponse = `
@@ -103,7 +100,7 @@ jobs:
         with:
           path: download/
           key: download-mariadb-${{ env.MARIADB_VERSION }}
-      - name: Prepare MariaDB
+      - name: Download MariaDB
         run: |
           $mariadbTarGz = "download\mariadb-${Env:MARIADB_VERSION}.tar.gz"
           if (-not(Test-Path -Path ${mariadbTarGz})) {
@@ -114,25 +111,30 @@ jobs:
               -Verbose
           }
           ridk exec tar xzf "${mariadbTarGz}"
-          Move-Item mariadb-${Env:MARIADB_VERSION} ..\source
-          cd ..\source
+          Move-Item mariadb-${Env:MARIADB_VERSION} mariadb
+          Remove-Item mariadb\storage\mroonga -Recurse -Force
+      - uses: actions/checkout@v4
+        with:
+          path: mariadb/storage/mroonga
+          submodules: recursive
+      - name: Prepare MariaDB
+        run: |
+          cd mariadb
           if ("${Env:MARIADB_VERSION}" -match "^10\.5|^10\.6|^10\.11") {
             ridk exec patch -p1 -i `
-              ..\mroonga\packages\source\patches\mariadb-10.5.5-add-a-missing-export-symbol.diff
+              storage\mroonga\packages\source\patches\mariadb-10.5.5-add-a-missing-export-symbol.diff
           }
-          Remove-Item storage\mroonga -Recurse -Force
-          Copy-Item ..\mroonga storage\mroonga -Recurse
-          Copy-Item ..\mroonga\build\mroonga_windows.cmake cmake\build_configurations\
+          Copy-Item storage\mroonga\build\mroonga_windows.cmake cmake\build_configurations\
       - uses: actions/checkout@v4
         if: |
           matrix.use-main == 'yes'
         with:
-          path: ../source/extra/groonga
+          path: mariadb/extra/groonga
           repository: groonga/groonga
           submodules: recursive
       - name: Prepare Groonga
         run: |
-          cd ..\source
+          cd mariadb
           if ("${{ matrix.use-main }}" -eq "yes") {
             pushd extra\groonga\vendor
             ruby download_lz4.rb
@@ -151,33 +153,30 @@ jobs:
             Move-Item groonga-* extra\groonga
           }
           Remove-Item extra\groonga\test -Recurse -Force
-      - name: Display Groonga revision
+      - uses: actions/checkout@v4
+        # TODO: Remove " || true" when we release
+        # groonga-normalizer-mysql 1.2.3.
+        if: |
+          matrix.use-main == 'yes' || true
+        with:
+          path: mariadb/extra/groonga-normalizer-mysql
+          repository: groonga/groonga-normalizer-mysql
+          submodules: recursive
+      - name: Download groonga-normalizer-mysql latest
+        # TODO: Remove " -Or $true" when we release
+        # groonga-normalizer-mysql 1.2.3.
+        if: |
+          !(matrix.use-main == 'yes' || true)
         run: |
-          cd ..\source
-          if ("${{ matrix.use-main }}" -eq "yes") {
-            pushd extra\groonga
-            git rev-parse HEAD
-            popd
-          }
-      - name: Prepare groonga-normalizer-mysql
-        run: |
-          cd ..\source
-          # TODO: Remove " -Or $true" when we release
-          # groonga-normalizer-mysql 1.2.2.
-          if ("${{ matrix.use-main }}" -eq "yes" -Or $true) {
-            git clone --quiet --depth 1 --recursive `
-              https://github.com/groonga/groonga-normalizer-mysql.git `
-              extra\groonga-normalizer-mysql
-          } else {
-            Invoke-WebRequest `
-              -Uri "https://packages.groonga.org/source/groonga-normalizer-mysql/groonga-normalizer-mysql-latest.zip" `
-              -OutFile groonga-normalizer-mysql-latest.zip
-            Expand-Archive groonga-normalizer-mysql-latest.zip .
-            Remove-Item groonga-normalizer-mysql-latest.zip
-            Move-Item `
-              groonga-normalizer-mysql-* `
-              extra\groonga-normalizer-mysql
-          }
+          cd mariadb
+          Invoke-WebRequest `
+            -Uri "https://packages.groonga.org/source/groonga-normalizer-mysql/groonga-normalizer-mysql-latest.zip" `
+            -OutFile groonga-normalizer-mysql-latest.zip
+          Expand-Archive groonga-normalizer-mysql-latest.zip .
+          Remove-Item groonga-normalizer-mysql-latest.zip
+          Move-Item `
+            groonga-normalizer-mysql-* `
+            extra\groonga-normalizer-mysql
       - name: Run CMake
         shell: cmd
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           Set-TimeZone -Id "Tokyo Standard Time"
       - uses: actions/setup-ruby@v1
-      - name: Set environment variables
+      - name: Detect MariaDB version
         run: |
           $releasesResponse = `
             Invoke-WebRequest `
@@ -67,33 +67,6 @@ jobs:
                               Sort-Object -Property {[Version]$_})[-1]
           $mariaDBVersion = $latestRelease
           Write-Output "MARIADB_VERSION=${mariaDBVersion}" | `
-            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
-          $mroongaVersion = "$(Get-Content version_full)"
-          $artifactName = "mariadb-${mariaDBVersion}-with-mroonga-${mroongaVersion}"
-          if ("${{ matrix.use-main }}" -eq "yes") {
-            $artifactName += "-with-groonga-main"
-          }
-          if ("${{ matrix.embed }}" -eq "ON") {
-            $artifactName += "-embed"
-          }
-          $artifactName += "-${Env:PACKAGE_PLATFORM}"
-          Write-Output "MROONGA_VERSION=${mroongaVersion}" | `
-            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
-          Write-Output "ARTIFACT_NAME=${artifactName}" | `
-            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Roaming\ccache
-          key: source-${{ env.MARIADB_VERSION }}-${{ env.VC_ARCHITECTURE }}-ccache-${{ hashFiles('*.cpp', '*.hpp', '*.h', 'lib/*.cpp', 'lib/*.hpp') }}
-          restore-keys: source-${{ env.MARIADB_VERSION }}-${{ env.VC_ARCHITECTURE }}-ccache-
-      - name: Prepare ccache
-        run: |
-          choco install ccache
-          ccache --show-stats --verbose
-          Write-Output "CMAKE_C_COMPILER_LAUNCHER=ccache" | `
-            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
-          Write-Output "CMAKE_CXX_COMPILER_LAUNCHER=ccache" | `
             Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
       - name: Cache MariaDB archive
         uses: actions/cache@v3
@@ -117,6 +90,35 @@ jobs:
         with:
           path: mariadb/storage/mroonga
           submodules: recursive
+      - name: Set environment variables
+        run: |
+          $mroongaVersion = "$(Get-Content mariadb\storage\mroonga\version_full)"
+          $artifactName = "mariadb-${mariaDBVersion}-with-mroonga-${mroongaVersion}"
+          if ("${{ matrix.use-main }}" -eq "yes") {
+            $artifactName += "-with-groonga-main"
+          }
+          if ("${{ matrix.embed }}" -eq "ON") {
+            $artifactName += "-embed"
+          }
+          $artifactName += "-${Env:PACKAGE_PLATFORM}"
+          Write-Output "MROONGA_VERSION=${mroongaVersion}" | `
+            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
+          Write-Output "ARTIFACT_NAME=${artifactName}" | `
+            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Roaming\ccache
+          key: source-${{ env.MARIADB_VERSION }}-${{ env.VC_ARCHITECTURE }}-ccache-${{ hashFiles('mariadb/storage/mroonga/**.{cpp,hpp,h}') }}
+          restore-keys: source-${{ env.MARIADB_VERSION }}-${{ env.VC_ARCHITECTURE }}-ccache-
+      - name: Prepare ccache
+        run: |
+          choco install ccache
+          ccache --show-stats --verbose
+          Write-Output "CMAKE_C_COMPILER_LAUNCHER=ccache" | `
+            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
+          Write-Output "CMAKE_CXX_COMPILER_LAUNCHER=ccache" | `
+            Out-File -FilePath ${Env:GITHUB_ENV} -Encoding utf8 -Append
       - name: Prepare MariaDB
         run: |
           cd mariadb

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -147,6 +147,14 @@ jobs:
             Move-Item groonga-* extra\groonga
           }
           Remove-Item extra\groonga\test -Recurse -Force
+      - name: Display Groonga revision
+        run: |
+          cd ..\source
+          if ("${{ matrix.use-main }}" -eq "yes") {
+            pushd extra\groonga
+            git describe --abbrev=7 HEAD
+            popd
+          }
       - name: Prepare groonga-normalizer-mysql
         run: |
           cd ..\source

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -125,7 +125,7 @@ jobs:
           Copy-Item ..\mroonga\build\mroonga_windows.cmake cmake\build_configurations\
       - uses: actions/checkout@v4
         if: |
-          matrix.use-main == "yes"
+          matrix.use-main == 'yes'
         with:
           path: ../source/extra/groonga
           repository: groonga/groonga

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -123,13 +123,16 @@ jobs:
           Remove-Item storage\mroonga -Recurse -Force
           Copy-Item ..\mroonga storage\mroonga -Recurse
           Copy-Item ..\mroonga\build\mroonga_windows.cmake cmake\build_configurations\
+      - uses: actions/checkout@v4
+        if: |
+          matrix.use-main == "yes"
+        with:
+          path: ../source/extra/groonga
+          repository: groonga/groonga
+          submodules: recursive
       - name: Prepare Groonga
         run: |
           cd ..\source
-          if ("${{ matrix.use-main }}" -eq "yes") {
-            git clone --quiet --depth 1 --recursive `
-              https://github.com/groonga/groonga.git `
-              extra\groonga
             pushd extra\groonga\vendor
             ruby download_lz4.rb
             ruby download_mecab.rb

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -184,11 +184,11 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VC_ARCHITECTURE% || exit /B
           cmake ^
-            -S ..\source ^
-            -B ..\build ^
+            -S mariadb ^
+            -B build ^
             -G "Ninja" ^
             -DBUILD_CONFIG=mroonga_windows ^
-            -DCMAKE_INSTALL_PREFIX=..\install ^
+            -DCMAKE_INSTALL_PREFIX=install ^
             -DCONNECT_WITH_LIBXML2=OFF ^
             -DMRN_GROONGA_EMBED=${{ matrix.embed || 'OFF' }} ^
             -DMRN_GROONGA_NORMALIZER_MYSQL_EMBED=${{ matrix.embed || 'OFF' }} ^
@@ -200,7 +200,7 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VC_ARCHITECTURE% || exit /B
           set CMAKE_BUILD_PARALLEL_LEVEL=%NUMBER_OF_PROCESSORS%
           cmake ^
-            --build ..\build ^
+            --build build ^
             --config RelWithDebInfo ^
             --target install ^
             --verbose || exit /B
@@ -211,14 +211,14 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VC_ARCHITECTURE% || exit /B
           set CMAKE_BUILD_PARALLEL_LEVEL=%NUMBER_OF_PROCESSORS%
           cmake ^
-            --build ..\build ^
+            --build build ^
             --config RelWithDebInfo ^
             --target package ^
             --verbose || exit /B
           ccache --show-stats --verbose
       - name: Prepare package
         run: |
-          pushd ..\build
+          pushd build
           Expand-Archive `
             mariadb-${Env:MARIADB_VERSION}-${Env:PACKAGE_PLATFORM}.zip `
             .
@@ -227,7 +227,7 @@ jobs:
           popd
           Move-Item `
             mariadb-${Env:MARIADB_VERSION}-${Env:PACKAGE_PLATFORM} `
-            ..\mroonga\
+            ..\
           popd
           Compress-Archive `
             -Path mariadb-${Env:MARIADB_VERSION}-${Env:PACKAGE_PLATFORM} `
@@ -251,7 +251,7 @@ jobs:
 
       - name: Test
         run: |
-          cd ..\install\mysql-test
+          cd install\mysql-test
           $suites = `
             Get-ChildItem -Recurse -Directory -Name t plugin\mroonga | `
               Split-Path -Parent | `
@@ -265,7 +265,7 @@ jobs:
 
       - name: "Test: reference count"
         run: |
-          cd ..\install\mysql-test
+          cd install\mysql-test
           $suites = `
             Get-ChildItem -Recurse -Directory -Name t plugin\mroonga | `
               Split-Path -Parent | `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -156,8 +156,7 @@ jobs:
           cd ..\source
           if ("${{ matrix.use-main }}" -eq "yes") {
             pushd extra\groonga
-            $groonga_revision = git describe --abbrev=7 HEAD
-            Write-Output $groonga_revision
+            git rev-parse HEAD
             popd
           }
       - name: Prepare groonga-normalizer-mysql

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Prepare Groonga
         run: |
           cd ..\source
+          if ("${{ matrix.use-main }}" -eq "yes") {
             pushd extra\groonga\vendor
             ruby download_lz4.rb
             ruby download_mecab.rb


### PR DESCRIPTION
We can show Groonga revision by using `actions/checkout`.

We can't use parent directory with `actions/checkout`. So we need to change directory structure:

Before:

```text
$PWD: Mroonga source
$PWD/../source: MariaDB with Mroonga/Groonga/groonga-normalizer-mysql
$PWD/../build: Build directory
$PWD/../install: Install destination
```

After:

```text
$PWD/mariadb: MariaDB with Mroonga/Groonga/groonga-normalizer-mysql
$PWD/build: Build directory
$PWD/install: Install destination
```
