### PR TITLE
rpm: don't use "which" command

### DIFF
--- a/data/rpm/post.sh
+++ b/data/rpm/post.sh
@@ -69,7 +69,7 @@ update_sql=${data_dir}/mroonga/update.sql
 
 need_password_expire=no
 if [ "${try_auto_prepare}" = "yes" ]; then
-  mysql_command=$(which mysql)
+  mysql_command=mysql
   password_option=""
   if [ "${have_auto_generated_password}" = "yes" ]; then
     if "${mysql_command}" \

--- a/data/rpm/preun.sh
+++ b/data/rpm/preun.sh
@@ -64,7 +64,7 @@ uninstall_sql=${data_dir}/mroonga/uninstall.sql
 
 need_password_expire=no
 if [ "${try_auto_uninstall}" = "yes" ]; then
-  mysql_command=$(which mysql)
+  mysql_command=mysql
   password_option=""
   if [ "${have_auto_generated_password}" = "yes" ]; then
     if "${mysql_command}" \

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -33,6 +33,7 @@ case ${major_version} in
     ;;
 esac
 
+sudo ${DNF} install -y which
 sudo ${DNF} install -y \
   https://packages.groonga.org/${os}/${major_version}/groonga-release-latest.noarch.rpm
 

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -33,7 +33,6 @@ case ${major_version} in
     ;;
 esac
 
-sudo ${DNF} install -y which
 sudo ${DNF} install -y \
   https://packages.groonga.org/${os}/${major_version}/groonga-release-latest.noarch.rpm
 


### PR DESCRIPTION
Because LXD images of Almalinux 8,9 and CentOS 7 have not "which" command in default.