### PR TITLE
packages mysql-community-8.0: use the latest settings of MySQL's YUM repository

### DIFF
--- a/packages/mysql-community-8.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/yum/almalinux-8/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     'dnf-command(builddep)' \
     'dnf-command(download)' \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
-    https://repo.mysql.com/mysql80-community-release-el8-3.noarch.rpm && \
+    https://repo.mysql.com/mysql80-community-release-el8.rpm && \
   dnf builddep --enablerepo=powertools -y ${quiet} mysql-community && \
   dnf download -y ${quiet} --source mysql-community && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/packages/mysql-community-8.0-mroonga/yum/almalinux-9/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/yum/almalinux-9/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     'dnf-command(builddep)' \
     'dnf-command(download)' \
     https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm \
-    https://repo.mysql.com/mysql80-community-release-el9-1.noarch.rpm \
+    https://repo.mysql.com/mysql80-community-release-el9.rpm \
     https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
   dnf builddep --enablerepo=crb -y ${quiet} mysql-community && \
   dnf download -y ${quiet} --source mysql-community && \


### PR DESCRIPTION
Because GPG keys of MYSQL's YUM repository were updated.

This PR resolve GPG check error when we install mysql-community-devel packages as below.

https://github.com/mroonga/mroonga/actions/runs/7577804071/job/20639333567#step:9:7064

I think if we resolve the above error, CI for Mroonga with MySQL Community 8.0 fail yet.
Because  the new version of MySQL Community 8.0 had been released.

So, I will fix it in the other PR after we merge this PR. 