### PR TITLE
packages percona-server-8.0: use the latest Percona Server

### DIFF
--- a/packages/percona-server-8.0-mroonga/yum/percona-server-8.0-mroonga.spec.in
+++ b/packages/percona-server-8.0-mroonga/yum/percona-server-8.0-mroonga.spec.in
@@ -2,8 +2,8 @@
 
 %define _centos_ver %{?centos_ver:%{centos_ver}}%{!?centos_ver:7}
 
-%define mysql_version_default 8.0.34
-%define percona_server_version_default 26
+%define mysql_version_default 8.0.35
+%define percona_server_version_default 27
 %define rpm_release_default 1
 %define mysql_dist_default    %{?dist}
 %define mysql_spec_file_default percona-server.spec
@@ -29,7 +29,7 @@
 
 Name:           percona-server-8.0-mroonga
 Version:        @VERSION@
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A fast fulltext searchable storage engine for MySQL
 
 Group:          Applications/Databases
@@ -149,6 +149,9 @@ Documentation for Mroonga
 %doc mysql-mroonga-doc/*
 
 %changelog
+* Fri Jan 13 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
+- build against Percona Server 8.0.35-27.1.
+
 * Fri Oct 13 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-2
 - build against Percona Server 8.0.34-26.1.
 


### PR DESCRIPTION
Because Percona Server for MySQL 8.0.35-27( https://docs.percona.com/percona-server/8.0/release-notes/8.0.35-27.html ) had been released.

This PR resolve "error: Failed build dependencies:" when we install "percona-server-8.0-mroonga" as below.

* https://github.com/mroonga/mroonga/actions/runs/7577804071/job/20639334523#step:9:3220
* https://github.com/mroonga/mroonga/actions/runs/7577804071/job/20639334696#step:9:4046
* https://github.com/mroonga/mroonga/actions/runs/7577804071/job/20639334830#step:9:3944
