### PR TITLE
packages mysql-community-8.0: use the latest MySQL Community Server

### DIFF
--- a/packages/mysql-community-8.0-mroonga/yum/mysql-community-8.0-mroonga.spec.in
+++ b/packages/mysql-community-8.0-mroonga/yum/mysql-community-8.0-mroonga.spec.in
@@ -1,6 +1,6 @@
 # -*- sh-shell: rpm -*-
 
-%define mysql_version_default 8.0.35
+%define mysql_version_default 8.0.36
 %define mysql_release_default 1
 %define mysql_dist_default    el%{rhel}
 %define mysql_spec_file_default mysql.spec
@@ -23,7 +23,7 @@
 
 Name:		mysql-community-8.0-mroonga
 Version:	@VERSION@
-Release:	2%{?dist}
+Release:	3%{?dist}
 Summary:	A fast fulltext searchable storage engine for MySQL
 
 Group:		Applications/Databases
@@ -144,6 +144,9 @@ Documentation for Mroonga
 %doc mysql-mroonga-doc/*
 
 %changelog
+* Fri Jan 19 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
+- build against MySQL 8.0.36.
+
 * Wed Oct 25 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-2
 - build against MySQL 8.0.35.
 

--- a/packages/mysql-community-minimal-8.0-mroonga/yum/mysql-community-minimal-8.0-mroonga.spec.in
+++ b/packages/mysql-community-minimal-8.0-mroonga/yum/mysql-community-minimal-8.0-mroonga.spec.in
@@ -1,6 +1,6 @@
 # -*- sh-shell: rpm -*-
 
-%define mysql_version_default 8.0.35
+%define mysql_version_default 8.0.36
 %define mysql_release_default 1
 %define mysql_dist_default    el%{rhel}
 %define mysql_spec_file_default mysql.spec
@@ -16,7 +16,7 @@
 
 Name:		mysql-community-minimal-8.0-mroonga
 Version:	@VERSION@
-Release:	2%{?dist}
+Release:	3%{?dist}
 Summary:	A fast fulltext searchable storage engine for MySQL
 
 Group:		Applications/Databases
@@ -98,6 +98,9 @@ This is a trnsitional package. This can safely be removed.
 %doc README COPYING
 
 %changelog
+* Fri Jan 19 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
+- build against MySQL 8.0.36.
+
 * Wed Oct 25 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-2
 - build against MySQL 8.0.35.
 


### PR DESCRIPTION
Because MySQL 8.0.36( https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-36.html ) had been released.

This PR resolve "error: Failed build dependencies:" when we install "mysql-community-minimal-8.0-mroonga" and "mysql-community-8.0-mroonga".