### PR TITLE
packages mysql-community-8.0: use the latest settings of MySQL's repositories for CentOS7, Debian bullseye, Debian bookworm, and Ubuntu jammy

### DIFF
--- a/packages/mysql-community-8.0-mroonga/apt/debian-bookworm/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/debian-bookworm/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  wget https://repo.mysql.com/mysql-apt-config_0.8.25-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.0-mroonga/apt/debian-bullseye/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/debian-bullseye/Dockerfile
@@ -19,7 +19,7 @@ RUN \
     lsb-release \
     wget && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  wget https://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
@@ -19,7 +19,7 @@ RUN \
     lsb-release \
     wget && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  wget https://repo.mysql.com/mysql-apt-config_0.8.22-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.0-mroonga/yum/centos-7/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/yum/centos-7/Dockerfile
@@ -12,7 +12,7 @@ RUN \
   yum install -y ${quiet} \
     centos-release-scl-rh \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
-    https://repo.mysql.com/mysql80-community-release-el7-5.noarch.rpm && \
+    https://repo.mysql.com/mysql80-community-release-el7.rpm && \
   yum-config-manager --enable centos-sclo-rh-testing && \
   yum-builddep -y ${quiet} mysql-community && \
   yumdownloader -y ${quiet} --source mysql-community && \


### PR DESCRIPTION
These modifications same as #663.

I forgot modification for CentOS7, Debian bullseye, Debian bookworm, and Ubuntu jammy.