### PR TITLE
packages mariadb: bump MariaDB version

### DIFF
--- a/packages/mariadb-10.11-mroonga/yum/mariadb-10.11-mroonga.spec.in
+++ b/packages/mariadb-10.11-mroonga/yum/mariadb-10.11-mroonga.spec.in
@@ -1,6 +1,6 @@
 # -*- sh-shell: rpm -*-
 
-%define mariadb_version_default 10.11.6
+%define mariadb_version_default 10.11.7
 %define mariadb_release_default 1
 %if %{rhel} == 7
 %define mariadb_dist_default    el%{rhel}.centos
@@ -24,7 +24,7 @@
 
 Name:		mariadb-10.11-mroonga
 Version:	@VERSION@
-Release:	3%{?dist}
+Release:	4%{?dist}
 Summary:	A fast fulltext searchable storage engine for MariaDB
 
 Group:		Applications/Databases
@@ -128,6 +128,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc mroonga-doc/*
 
 %changelog
+* Tue Feb 20 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-4
+- Rebuild against MariaDB 10.11.7.
+
 * Fri Nov 24 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
 - Rebuild against MariaDB 10.11.6.
 

--- a/packages/mariadb-10.4-mroonga/yum/mariadb-10.4-mroonga.spec.in
+++ b/packages/mariadb-10.4-mroonga/yum/mariadb-10.4-mroonga.spec.in
@@ -2,7 +2,7 @@
 
 %define _centos_ver %{?centos_ver:%{centos_ver}}%{!?centos_ver:7}
 
-%define mariadb_version_default 10.4.32
+%define mariadb_version_default 10.4.33
 %define mariadb_release_default 1
 %if %{_centos_ver} == 7
 %define mariadb_dist_default    el%{_centos_ver}.centos
@@ -26,7 +26,7 @@
 
 Name:		mariadb-10.4-mroonga
 Version:	@VERSION@
-Release:	3%{?dist}
+Release:	4%{?dist}
 Summary:	A fast fulltext searchable storage engine for MariaDB
 
 Group:		Applications/Databases
@@ -130,6 +130,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc mroonga-doc/*
 
 %changelog
+* Tue Feb 20 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-4
+- Rebuild against MariaDB 10.4.33.
+
 * Fri Nov 24 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
 - Rebuild against MariaDB 10.4.32.
 

--- a/packages/mariadb-10.5-mroonga/yum/mariadb-10.5-mroonga.spec.in
+++ b/packages/mariadb-10.5-mroonga/yum/mariadb-10.5-mroonga.spec.in
@@ -3,7 +3,7 @@
 %define mariadb_package MariaDB
 %define mariadb_client_package %{mariadb_package}-client
 #%%define mariadb_epoch_default
-%define mariadb_version_default 10.5.23
+%define mariadb_version_default 10.5.24
 %define mariadb_release_default 1
 %if %{rhel} == 7
   %define mariadb_dist_default    el%{rhel}.centos
@@ -29,7 +29,7 @@
 
 Name:		mariadb-10.5-mroonga
 Version:	@VERSION@
-Release:	3%{?dist}
+Release:	4%{?dist}
 Summary:	A fast fulltext searchable storage engine for MariaDB
 
 Group:		Applications/Databases
@@ -146,6 +146,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc mroonga-doc/*
 
 %changelog
+* Tue Feb 20 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-4
+- Rebuild against MariaDB 10.5.24.
+
 * Fri Nov 24 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
 - Rebuild against MariaDB 10.5.23.
 

--- a/packages/mariadb-10.6-mroonga/yum/mariadb-10.6-mroonga.spec.in
+++ b/packages/mariadb-10.6-mroonga/yum/mariadb-10.6-mroonga.spec.in
@@ -2,7 +2,7 @@
 
 %define _centos_ver %{?centos_ver:%{centos_ver}}%{!?centos_ver:7}
 
-%define mariadb_version_default 10.6.16
+%define mariadb_version_default 10.6.17
 %define mariadb_release_default 1
 %if %{_centos_ver} == 7
 %define mariadb_dist_default    el%{_centos_ver}.centos
@@ -26,7 +26,7 @@
 
 Name:		mariadb-10.6-mroonga
 Version:	@VERSION@
-Release:	3%{?dist}
+Release:	4%{?dist}
 Summary:	A fast fulltext searchable storage engine for MariaDB
 
 Group:		Applications/Databases
@@ -130,6 +130,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc mroonga-doc/*
 
 %changelog
+* Tue Feb 20 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-4
+- Rebuild against MariaDB 10.6.17.
+
 * Fri Nov 24 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
 - Rebuild against MariaDB 10.6.16.
 


### PR DESCRIPTION
Because MariaDB released new version.

See: https://mariadb.org/mariadb/all-releases/

This PR only fix failure of build Mroonga with MariaDB.
So, tests for Mroonga still fail even if this PR merge.