### PR TITLE
mariadb: unuse HA_EXTRA_IGNORE_INSERT

### DIFF
--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -100,7 +100,9 @@ extern "C" {
 #  define MRN_HAVE_HA_EXTRA_NO_READ_LOCKING
 #endif
 
-#if (defined(MRN_MARIADB_P) && MYSQL_VERSION_ID >= 100600)
+#if (defined(MRN_MARIADB_P) &&                                      \
+     ((MYSQL_VERSION_ID >= 100600 && MYSQL_VERSION_ID < 100616)     \
+      || (MYSQL_VERSION_ID >= 101100 && MYSQL_VERSION_ID < 101106))
 #  define MRN_HAVE_HA_EXTRA_IGNORE_INSERT
 #endif
 

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -102,7 +102,7 @@ extern "C" {
 
 #if (defined(MRN_MARIADB_P) &&                                      \
      ((MYSQL_VERSION_ID >= 100600 && MYSQL_VERSION_ID < 100616)     \
-      || (MYSQL_VERSION_ID >= 101100 && MYSQL_VERSION_ID < 101106))
+      || (MYSQL_VERSION_ID >= 101100 && MYSQL_VERSION_ID < 101106)))
 #  define MRN_HAVE_HA_EXTRA_IGNORE_INSERT
 #endif
 


### PR DESCRIPTION
Because HA_EXTRA_IGNORE_INSERT was removed in MariaDB 10.6.16 or later and MariaDB 10.11.06 or later.

See: https://github.com/MariaDB/server/commit/c438284863db2ccba8a04437c941a5c8a2d9225b