### PR TITLE
mariadb10.5 10.6: follow bitmap_init() and bitmap_free() API change

### DIFF
--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -883,16 +883,11 @@ typedef uint mrn_srid;
     bitmap_init((map), (buf), (n_bits))
 #  define mrn_bitmap_free(map) \
     bitmap_free((map))
-#elif defined(MRN_MARIADB_P) && MYSQL_VERSION_ID >= 100700
+#elif defined(MRN_MARIADB_P)
 #  define mrn_bitmap_init(map, buf, n_bits) \
     my_bitmap_init((map), (buf), (n_bits))
 #  define mrn_bitmap_free(map) \
     my_bitmap_free((map))
-#else
-#  define mrn_bitmap_init(map, buf, n_bits) \
-    bitmap_init((map), (buf), (n_bits), false)
-#  define mrn_bitmap_free(map) \
-    bitmap_free((map))
 #endif
 
 #ifdef MRN_MARIADB_P


### PR DESCRIPTION
This API change enabled in all mariadb that we support currently. So, we can add "my_" prefix if build target is mariadb. a limit is not need by mariadb version.

See: https://github.com/MariaDB/server/commit/273078c5faa19b60e2cc93330d18534fae221487