### PR TITLE
mariadb 10.5 10.6: add a missing argument for my_bitmap_init()

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -5894,7 +5894,7 @@ int ha_mroonga::open(const char *name,
     DBUG_RETURN(error);
   thr_lock_data_init(&share->lock,&thr_lock_data,NULL);
 
-  if (mrn_bitmap_init(&multiple_column_key_bitmap, NULL, table->s->fields))
+  if (mrn_bitmap_init(&multiple_column_key_bitmap, NULL, table->s->fields, false))
   {
     mrn_free_share(share);
     share = NULL;
@@ -17314,7 +17314,8 @@ bool ha_mroonga::storage_inplace_alter_table_add_column(
       MY_BITMAP generated_column_bitmap;
       if (mrn_bitmap_init(&generated_column_bitmap,
                           NULL,
-                          altered_table->s->fields)) {
+                          altered_table->s->fields,
+                          false)) {
         error = HA_ERR_OUT_OF_MEM;
         my_message(ER_OUTOFMEMORY,
                    "mroonga: storage: "

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -5894,7 +5894,7 @@ int ha_mroonga::open(const char *name,
     DBUG_RETURN(error);
   thr_lock_data_init(&share->lock,&thr_lock_data,NULL);
 
-  if (mrn_bitmap_init(&multiple_column_key_bitmap, NULL, table->s->fields, false))
+  if (mrn_bitmap_init(&multiple_column_key_bitmap, NULL, table->s->fields))
   {
     mrn_free_share(share);
     share = NULL;
@@ -17314,8 +17314,7 @@ bool ha_mroonga::storage_inplace_alter_table_add_column(
       MY_BITMAP generated_column_bitmap;
       if (mrn_bitmap_init(&generated_column_bitmap,
                           NULL,
-                          altered_table->s->fields,
-                          false)) {
+                          altered_table->s->fields)) {
         error = HA_ERR_OUT_OF_MEM;
         my_message(ER_OUTOFMEMORY,
                    "mroonga: storage: "

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -878,14 +878,19 @@ typedef uint mrn_srid;
   (memset((table_share), 0, sizeof(TABLE_SHARE)))
 #endif
 
-#if !defined(MRN_MARIADB_P) && MYSQL_VERSION_ID >= 80019
-#  define mrn_bitmap_init(map, buf, n_bits) \
+#if !defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 80019)
+#  define mrn_bitmap_init(map, buf, n_bits, thread_safe) \
     bitmap_init((map), (buf), (n_bits))
 #  define mrn_bitmap_free(map) \
     bitmap_free((map))
-#elif defined(MRN_MARIADB_P)
-#  define mrn_bitmap_init(map, buf, n_bits) \
+#elif defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 100700)
+#  define mrn_bitmap_init(map, buf, n_bits, thread_safe) \
     my_bitmap_init((map), (buf), (n_bits))
+#  define mrn_bitmap_free(map) \
+    my_bitmap_free((map))
+#else
+#  define mrn_bitmap_init(map, buf, n_bits, thread_safe)    \
+  my_bitmap_init((map), (buf), (n_bits), (thread_safe))
 #  define mrn_bitmap_free(map) \
     my_bitmap_free((map))
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -878,21 +878,23 @@ typedef uint mrn_srid;
   (memset((table_share), 0, sizeof(TABLE_SHARE)))
 #endif
 
-#if !defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 80019)
-#  define mrn_bitmap_init(map, buf, n_bits, thread_safe) \
+#ifdef MRN_MARIADB_P
+#  if MYSQL_VERSION_ID >= 100700
+#    define mrn_bitmap_init(map, buf, n_bits) \
+      my_bitmap_init((map), (buf), (n_bits))
+#    define mrn_bitmap_free(map) \
+      my_bitmap_free((map))
+#  else
+#    define mrn_bitmap_init(map, buf, n_bits) \
+      my_bitmap_init((map), (buf), (n_bits), false)
+#    define mrn_bitmap_free(map) \
+      my_bitmap_free((map))
+#   endif
+#else
+#  define mrn_bitmap_init(map, buf, n_bits) \
     bitmap_init((map), (buf), (n_bits))
 #  define mrn_bitmap_free(map) \
     bitmap_free((map))
-#elif defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 100700)
-#  define mrn_bitmap_init(map, buf, n_bits, thread_safe) \
-    my_bitmap_init((map), (buf), (n_bits))
-#  define mrn_bitmap_free(map) \
-    my_bitmap_free((map))
-#else
-#  define mrn_bitmap_init(map, buf, n_bits, thread_safe)    \
-  my_bitmap_init((map), (buf), (n_bits), (thread_safe))
-#  define mrn_bitmap_free(map) \
-    my_bitmap_free((map))
 #endif
 
 #ifdef MRN_MARIADB_P


### PR DESCRIPTION
`my_bitmap_init()` doesn't have the fourth argument (`thread_safe`) since MariaDB 10.7 or later.
However, `my_bitmap_init()` has the fourth argument in MariaDB 10.5 and 10.6.

The following change exists in MariaDB 10.7 or later.
See: https://github.com/MariaDB/server/commit/0299ec29d4af3230741a62d5443c0562269b05b2