### PR TITLE
packages mysql-community-minimal-8.0: install mysql-community-release before mysql-community-minimal-release

### DIFF
--- a/packages/mysql-community-minimal-8.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mysql-community-minimal-8.0-mroonga/yum/almalinux-8/Dockerfile
@@ -12,7 +12,11 @@ RUN \
   dnf install --enablerepo=powertools -y ${quiet} \
     'dnf-command(builddep)' \
     'dnf-command(download)' \
-    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+  dnf install -y ${quiet} https://repo.mysql.com/mysql80-community-release-el8.rpm && \
+  dnf install --disablerepo=appstream -y ${quiet} \
+    mysql-community-devel && \
+  dnf install --enablerepo=powertools -y ${quiet} \
     https://repo.mysql.com/mysql-community-minimal-release-el8.rpm && \
   dnf builddep --enablerepo=mysql80-community-minimal-source,powertools -y ${quiet} mysql-community-minimal && \
   dnf download --enablerepo=mysql80-community-minimal-source -y ${quiet} --source mysql-community-minimal && \
@@ -30,9 +34,6 @@ RUN \
     rpm-build \
     wget \
     which && \
-  dnf install -y ${quiet} https://repo.mysql.com/mysql80-community-release-el8.rpm && \
-  dnf install --disablerepo=appstream -y ${quiet} \
-    mysql-community-devel && \
   dnf clean ${quiet} all
 
 # Workaround: We can remove this once redhat-rpm-config uses "annobin"


### PR DESCRIPTION
TODO: Test

If we install mysql-community-release after mysql-community-minimal-release, we can't install mysql-community-minimal-release.

Because mysql-community-minimal-release and mysql80-community-release are conflicting. 
See: https://github.com/mroonga/mroonga/actions/runs/9265261501/job/25487027793#step:9:5291

However, if we install mysql-community-release firstly, we can replace mysql80-community-release to mysql-community-minimal-release.

Currently, We install mysql-community-release only to install mysql-community-devel in this job. So, no problem that mysql-community-release replace to mysql-community-minimal-release, anytime after we install mysql-community-devel.