### PR TITLE
ci test: use the latest mysql-apt-config

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -78,7 +78,7 @@ case ${package} in
     ;;
   mysql-community-*)
     old_package=${package}
-    wget https://repo.mysql.com/mysql-apt-config_0.8.24-1_all.deb
+    wget https://repo.mysql.com/mysql-apt-config_0.8.30-1_all.deb
     mysql_community_install_mysql_apt_config
     mysql_package_prefix=mysql
     client_dev_package=libmysqlclient-dev

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -78,7 +78,7 @@ case ${package} in
     ;;
   mysql-community-*)
     old_package=${package}
-    wget https://repo.mysql.com/mysql-apt-config_0.8.30-1_all.deb
+    wget https://repo.mysql.com/mysql-apt-config.deb
     mysql_community_install_mysql_apt_config
     mysql_package_prefix=mysql
     client_dev_package=libmysqlclient-dev

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -101,11 +101,6 @@ mysql_community_install_mysql_apt_config() {
         MYSQL_SERVER_VERSION=mysql-${mysql_version} \
       apt install -V -y ./mysql-apt-config.deb
   sudo apt update
-  # Ensure using the latest mysql-apt-config
-  sudo \
-    env DEBIAN_FRONTEND=noninteractive \
-        MYSQL_SERVER_VERSION=mysql-${mysql_version} \
-      apt upgrade -V -y
 }
 
 case ${package} in


### PR DESCRIPTION
Currently, we couldn't be verified signatures of 'http://repo.mysql.com/apt/debian bookworm InRelease' as below.
https://github.com/mroonga/mroonga/actions/runs/9309443050/job/25625429475#step:6:781

Because we use old public key.