### PR TITLE
ci install: migrate LXD to Incus

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -39,6 +39,11 @@ jobs:
 
           sudo apt update
           sudo apt install -y -V incus
+      - name: Allow egress network traffic flows for Incus
+        # https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-incus-and-docker
+        run: |
+          sudo iptables -I DOCKER-USER -i incusbr0 -j ACCEPT
+          sudo iptables -I DOCKER-USER -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
       - name: Prepare container
         run: |
           set -x

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,20 +14,44 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: "ubuntu:20.04"
+          - image: "images:ubuntu/20.04"
             package: mysql
-          - image: "ubuntu:22.04"
+          - image: "images:ubuntu/22.04"
             package: mariadb
-          - image: "ubuntu:22.04"
+          - image: "images:ubuntu/22.04"
             package: mysql
     steps:
       - uses: actions/checkout@v4
-      - uses: canonical/setup-lxd@v0.1.1
-      - name: Install Mroonga
+      - name: Install Incus
+        run: |
+          # We can use the official Ubuntu APT repository when
+          # ubuntu-latest is Ubuntu 24.04.
+          sudo curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
+          cat <<SOURCES | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.sources
+          Enabled: yes
+          Types: deb
+          URIs: https://pkgs.zabbly.com/incus/stable
+          Suites: $(. /etc/os-release && echo ${VERSION_CODENAME})
+          Components: main
+          Architectures: $(dpkg --print-architecture)
+          Signed-By: /etc/apt/keyrings/zabbly.asc
+          SOURCES
+
+          sudo apt update
+          sudo apt install -y -V incus
+      - name: Prepare container
         run: |
           set -x
-          lxc launch ${{ matrix.image }} target
-          lxc config device add target host disk source=$PWD path=/host
-          lxc exec target -- /host/packages/apt/install_test.sh ${{ matrix.package }}-mroonga
-          lxc stop target
-          lxc delete target
+          sudo incus admin init --auto
+          sudo incus launch ${{ matrix.image }} target
+          sudo incus config device add target host disk source=$PWD path=/host
+      - name: Install Mroonga
+        run: |
+          sudo incus exec target \
+            -- \
+            /host/packages/apt/install_test.sh \
+              ${{ matrix.package }}-mroonga
+      - name: Delete container
+        run: |
+          sudo incus stop target
+          sudo incus delete target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   install:
     name: Install to Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -24,19 +24,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Incus
         run: |
-          # We can use the official Ubuntu APT repository when
-          # ubuntu-latest is Ubuntu 24.04.
-          sudo curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
-          cat <<SOURCES | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.sources
-          Enabled: yes
-          Types: deb
-          URIs: https://pkgs.zabbly.com/incus/stable
-          Suites: $(. /etc/os-release && echo ${VERSION_CODENAME})
-          Components: main
-          Architectures: $(dpkg --print-architecture)
-          Signed-By: /etc/apt/keyrings/zabbly.asc
-          SOURCES
-
           sudo apt update
           sudo apt install -y -V incus
       - name: Allow egress network traffic flows for Incus

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,9 @@
 name: Install to Ubuntu
 on:
+  # TODO: Added to verify that the CI works. We will delete it after verification.
+  pull_request:
+    paths:
+      - ".github/workflows/install.yml"
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,9 +1,5 @@
 name: Install to Ubuntu
 on:
-  # TODO: Added to verify that the CI works. We will delete it after verification.
-  pull_request:
-    paths:
-      - ".github/workflows/install.yml"
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -41,6 +41,9 @@ jobs:
           sudo incus admin init --auto
           sudo incus launch ${{ matrix.image }} target
           sudo incus config device add target host disk source=$PWD path=/host
+          # Wait for network services stabilizing
+          sleep 1 # Wait for systemd ready
+          sudo incus exec target -- sudo systemctl is-system-running --wait
       - name: Install Mroonga
         run: |
           sudo incus exec target \


### PR DESCRIPTION
close: https://github.com/mroonga/mroonga/issues/690

The reasons for this change are as follows.
- Using both LXD and Incus increases maintenance costs.
- Standardizing on Incus will simplify our infrastructure and reduce these costs.