### PR TITLE
packages mysql-8.0: remove a unuse file

### DIFF
--- a/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -20,7 +20,6 @@ RUN \
     software-properties-common \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
-  wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
   apt build-dep -y mysql-server && \
   apt install -y -V ${quiet} \
     autoconf-archive \


### PR DESCRIPTION
It seems that groonga-apt-source-latest-${codename}.deb is not used after we get this file by wget.