### PR TITLE
ci linux: skip upgrade test if packages haven't been released

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -114,14 +114,12 @@ mysql_community_install_mysql_apt_config() {
 
 case ${package} in
   mariadb-*)
-    old_package=${package}
     mysql_package_prefix=mariadb
     client_dev_package=libmariadb-dev
     test_package=mariadb-test
     mysql_test_dir=/usr/share/mysql/mysql-test
     ;;
   mysql-community-*)
-    old_package=${package}
     wget https://repo.mysql.com/mysql-apt-config.deb
     mysql_community_install_mysql_apt_config
     mysql_package_prefix=mysql
@@ -130,7 +128,6 @@ case ${package} in
     mysql_test_dir=/usr/lib/mysql-test
     ;;
   mysql-*)
-    old_package=${package}
     mysql_package_prefix=mysql
     client_dev_package=libmysqlclient-dev
     test_package=mysql-testsuite
@@ -241,13 +238,13 @@ if [[ "${package}" == mariadb-* && "${distribution}-${code_name}" == "debian-boo
   # version. We can't do upgrade test because the previous Mroonga
   # requires old MariaDB that isn't provided by Debian.
   echo "Skipping upgrade test for Debian Bookworm."
-elif apt show ${old_package} > /dev/null 2>&1; then
-  sudo apt install -V -y ${old_package}
+elif apt show ${package} > /dev/null 2>&1; then
+  sudo apt install -V -y ${package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/
   sudo apt update
   sudo apt upgrade -V -y
   sudo mysql -e "SHOW ENGINES" | grep Mroonga
 else
-  echo "Skip because ${old_package} hasn't been released yet."
+  echo "Skip because ${package} hasn't been released yet."
 fi
 echo "::endgroup::"

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -253,13 +253,13 @@ sudo apt purge -V -y \
 sudo rm -rf /var/lib/mysql
 
 sudo mv /etc/apt/sources.list.d/${package}.list /tmp/
+sudo apt update
 case ${package} in
   mysql-community-8.*)
     mysql_community_install_mysql_apt_config
     ;;
 esac
 
-sudo apt update
 if apt show ${old_package} > /dev/null 2>&1; then
   sudo apt install -V -y ${old_package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -233,12 +233,7 @@ case ${package} in
     ;;
 esac
 
-if [[ "${package}" == mariadb-* && "${distribution}-${code_name}" == "debian-bookworm" ]]; then
-  # TODO: Remove debian-bookworm after we release a new
-  # version. We can't do upgrade test because the previous Mroonga
-  # requires old MariaDB that isn't provided by Debian.
-  echo "Skipping upgrade test about mariadb package for Debian Bookworm."
-elif apt show ${package} > /dev/null 2>&1; then
+if apt show ${package} > /dev/null 2>&1; then
   sudo apt install -V -y ${package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/
   sudo apt update

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -237,7 +237,7 @@ if [[ "${package}" == mariadb-* && "${distribution}-${code_name}" == "debian-boo
   # TODO: Remove debian-bookworm after we release a new
   # version. We can't do upgrade test because the previous Mroonga
   # requires old MariaDB that isn't provided by Debian.
-  echo "Skipping upgrade test for Debian Bookworm."
+  echo "Skipping upgrade test about mariadb package for Debian Bookworm."
 elif apt show ${package} > /dev/null 2>&1; then
   sudo apt install -V -y ${package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -115,17 +115,6 @@ mysql_community_install_mysql_apt_config() {
 case ${package} in
   mariadb-*)
     old_package=${package}
-    case "${distribution}-${code_name}" in
-      # TODO: Remove debian-bookworm after we release a new
-      # version. We can't do upgrade test because the previous Mroonga
-      # requires old MariaDB that isn't provided by Debian.
-      #
-      # TODO: Remove ubuntu-noble after we release a package for
-      # ubuntu-noble on pckages.groonga.org.
-      debian-bookworm|ubuntu-noble)
-        old_package=
-        ;;
-    esac
     mysql_package_prefix=mariadb
     client_dev_package=libmariadb-dev
     test_package=mariadb-test
@@ -133,19 +122,6 @@ case ${package} in
     ;;
   mysql-community-*)
     old_package=${package}
-    case "${distribution}-${code_name}" in
-      # TODO: Remove debian-bookworm after we release a package for
-      # debian-bookworm on pckages.groonga.org.
-      #
-      # TODO: Remove ubuntu-jammy after we release a package for
-      # ubuntu-jammy on pckages.groonga.org.
-      #
-      # TODO: Remove ubuntu-noble after we release a package for
-      # ubuntu-noble on pckages.groonga.org.
-      debian-bookworm|ubuntu-jammy|ubuntu-noble)
-        old_package=
-        ;;
-    esac
     wget https://repo.mysql.com/mysql-apt-config.deb
     mysql_community_install_mysql_apt_config
     mysql_package_prefix=mysql
@@ -260,7 +236,12 @@ case ${package} in
     ;;
 esac
 
-if apt show ${old_package} > /dev/null 2>&1; then
+if [[ "${package}" == mariadb-* && "${distribution}-${code_name}" == "debian-bookworm" ]]; then
+  # TODO: Remove debian-bookworm after we release a new
+  # version. We can't do upgrade test because the previous Mroonga
+  # requires old MariaDB that isn't provided by Debian.
+  echo "Skipping upgrade test for Debian Bookworm."
+elif apt show ${old_package} > /dev/null 2>&1; then
   sudo apt install -V -y ${old_package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/
   sudo apt update


### PR DESCRIPTION
Specifying package names and code names needs high maintenance costs.
Because we have to change it when new OS version is released every time.