### PR TITLE
Implement "make update-latest-release" by Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,8 @@
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
-# License version 2.1 as published by the Free Software Foundation.
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
 #
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ def env_var(name, default=nil)
 end
 
 def version
-  ENV["VERSION"] || File.read("version_full")
+  env_var("VERSION", File.read("version_full"))
 end
 
 namespace :release do

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,48 @@
+# -*- ruby -*-
+#
+# Copyright(C) 2024  Horimoto Yasuhiro <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 2.1 as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+def env_var(name, default=nil)
+  value = ENV[name] || default
+  raise "${#{name}} is missing" if value.nil?
+  value
+end
+
+def version
+  ENV["VERSION"] || File.read("version_full")
+end
+
+namespace :release do
+  namespace :version do
+    desc "Update versions for a new release"
+    task :update do
+      new_release_date = env_var("NEW_RELEASE_DATE")
+      cd("packages") do
+        ruby("-S",
+             "rake",
+             "version:update")
+      end
+      sh("git",
+         "add",
+         *Dir.glob("packages/**/*.spec.in"),
+         *Dir.glob("packages/**/changelog"))
+      sh("git",
+         "commit",
+         "-m",
+         "doc package: update version info to #{version} (#{new_release_date})")
+    end
+  end
+end


### PR DESCRIPTION
We will drop support for GNU Autotools. This is a part of the work.

We can use `rake release:version:update` instead of `make update-latest-release`.

We don't need to implement the `update-latest-release.rb` part:
https://github.com/mroonga/mroonga/blob/72121be89dff15665490b8669de441bd12113ecf/Makefile.am#L68-L74

Because:
* There are no information updated by it in `doc/source/install/*.rst` and `doc/local/*/LC_MESSAGES/install.po`
* We can update `mroonga/mroonga.com`'s `_config.yml` separately.
