### PR TITLE
Implement "make update-version" by Ruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ def new_version_major
 end
 
 def new_version_minor
-  new_version.split('.')[1].slice(0)
+  new_version.split(".")[1][0]
 end
 
 def new_version_micro

--- a/Rakefile
+++ b/Rakefile
@@ -49,8 +49,10 @@ def new_version_in_hex
 end
 
 def new_plugin_version
-  minor_micro = new_version.split('.')[1].to_i(10)
-  "#{new_version_major}" + '.' + minor_micro.to_s
+  # 10.00 -> 10.0
+  # 10.01 -> 10.1
+  # 10.11 -> 10.11
+  new_version.gsub(".0", ".")
 end
 
 namespace :release do

--- a/Rakefile
+++ b/Rakefile
@@ -43,9 +43,8 @@ def new_version_micro
 end
 
 def new_version_in_hex
-  major_in_hex = new_version_major.to_i(16)
-  minor_micro_in_hex = new_version.split(".")[1].to_i(16)
-  '0x' + major_in_hex.to_s + minor_micro_in_hex.to_s
+  major, minor_micro = new_version.split(".").collect {|x| Integer(x, 10)}
+  "0x%02x%02x" % [major, minor_micro]
 end
 
 def new_plugin_version

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ namespace :dev do
       File.write("plugin_version", new_plugin_version)
       File.write("version_full", env_var("NEW_VERSION"))
       File.write("version_major", new_version_major)
-      File.write("version_minor",  new_version_minor)
+      File.write("version_minor", new_version_minor)
       File.write("version_micro", new_version_micro)
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,7 @@ namespace :dev do
     desc "Bump version for new development"
     task :bump do
       File.write("plugin_version", new_plugin_version)
-      File.write("version_full", env_var("NEW_VERSION"))
+      File.write("version_full", new_version)
       File.write("version_major", new_version_major)
       File.write("version_minor", new_version_minor)
       File.write("version_micro", new_version_micro)

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ end
 
 def new_version_in_hex
   major_in_hex = new_version_major.to_i(16)
-  minor_micro_in_hex = new_version.split('.')[1].to_i(16)
+  minor_micro_in_hex = new_version.split(".")[1].to_i(16)
   '0x' + major_in_hex.to_s + minor_micro_in_hex.to_s
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ def new_version_minor
 end
 
 def new_version_micro
-  new_version.split('.')[1].slice(1)
+  new_version.split(".")[1][1]
 end
 
 def new_version_in_hex

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ namespace :release do
       sh("git",
          "commit",
          "-m",
-         "doc package: update version info to #{version} (#{new_release_date})")
+         "package: update version info to #{version} (#{new_release_date})")
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ def new_version
 end
 
 def new_version_major
-  new_version.split('.')[0]
+  new_version.split(".")[0]
 end
 
 def new_version_minor

--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,7 @@ namespace :dev do
   namespace :version do
     desc "Bump version for new development"
     task :bump do
-      File.write("plugin_version", "#{new_plugin_version}")
+      File.write("plugin_version", new_plugin_version)
       File.write("version_full", env_var("NEW_VERSION"))
       File.write("version_major", "#{new_version_major}")
       File.write("version_minor", "#{new_version_minor}")

--- a/Rakefile
+++ b/Rakefile
@@ -83,9 +83,9 @@ namespace :dev do
     task :bump do
       File.write("plugin_version", new_plugin_version)
       File.write("version_full", env_var("NEW_VERSION"))
-      File.write("version_major", "#{new_version_major}")
-      File.write("version_minor", "#{new_version_minor}")
-      File.write("version_micro", "#{new_version_micro}")
+      File.write("version_major", new_version_major)
+      File.write("version_minor",  new_version_minor)
+      File.write("version_micro", new_version_micro)
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,33 @@ def version
   env_var("VERSION", File.read("version_full"))
 end
 
+def new_version
+  env_var("NEW_VERSION")
+end
+
+def new_version_major
+  new_version.split('.')[0]
+end
+
+def new_version_minor
+  new_version.split('.')[1].slice(0)
+end
+
+def new_version_micro
+  new_version.split('.')[1].slice(1)
+end
+
+def new_version_in_hex
+  major_in_hex = new_version_major.to_i(16)
+  minor_micro_in_hex = new_version.split('.')[1].to_i(16)
+  '0x' + major_in_hex.to_s + minor_micro_in_hex.to_s
+end
+
+def new_plugin_version
+  minor_micro = new_version.split('.')[1].to_i(10)
+  "#{new_version_major}" + '.' + minor_micro.to_s
+end
+
 namespace :release do
   namespace :version do
     desc "Update versions for a new release"
@@ -44,6 +71,19 @@ namespace :release do
          "commit",
          "-m",
          "doc package: update version info to #{version} (#{new_release_date})")
+    end
+  end
+end
+
+namespace :dev do
+  namespace :version do
+    desc "Bump version for new development"
+    task :bump do
+      File.write("plugin_version", "#{new_plugin_version}")
+      File.write("version_full", env_var("NEW_VERSION"))
+      File.write("version_major", "#{new_version_major}")
+      File.write("version_minor", "#{new_version_minor}")
+      File.write("version_micro", "#{new_version_micro}")
     end
   end
 end


### PR DESCRIPTION
We will drop support for GNU Autotools. This is a part of the work.
We can use `rake dev:version:bump` instead of `make update-version`.

`rake dev:version:bump` modify the following files.

* plugin_version
* version_full
* version_major
* version_minor
* version_micro

Usage:

`rake dev:version:bump NEW_VERSION=xx.xx`
We must specify `NEW_VERSION` when we execute `rake dev:version:bump`.