### PR TITLE
Add a missing write target file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,6 +82,7 @@ namespace :dev do
     task :bump do
       File.write("plugin_version", new_plugin_version)
       File.write("version_full", new_version)
+      File.write("version_in_hex", new_version_in_hex)
       File.write("version_major", new_version_major)
       File.write("version_minor", new_version_minor)
       File.write("version_micro", new_version_micro)


### PR DESCRIPTION
I forgot add writing target file in #698. I add it in this PR.
We must also modify `version_in_hex` when we execute `rake dev:version:bump`.