### PR TITLE
packages mysql-8.0: don't use "apt build-dep" when Mroonga build for Ubuntu noble

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # MariaDB 10.5
-          - os: almalinux-8
-            package: mariadb-10.5
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.5
-            test-image: "images:almalinux/9"
-
-          # MariaDB 10.6
-          - os: almalinux-8
-            package: mariadb-10.6
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.6
-            test-image: "images:almalinux/9"
-          - os: ubuntu-jammy
-            package: mariadb-10.6
-            test-image: "images:ubuntu/22.04"
-
-          # MariaDB 10.11
-          - os: almalinux-8
-            package: mariadb-10.11
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.11
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mariadb-10.11
-            test-image: "images:debian/12"
+#          # MariaDB 10.5
+#          - os: almalinux-8
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/9"
+#
+#          # MariaDB 10.6
+#          - os: almalinux-8
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/9"
+#          - os: ubuntu-jammy
+#            package: mariadb-10.6
+#            test-image: "images:ubuntu/22.04"
+#
+#          # MariaDB 10.11
+#          - os: almalinux-8
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mariadb-10.11
+#            test-image: "images:debian/12"
+#          - os: ubuntu-noble
+#            package: mariadb-10.11
+#            test-image: "images:ubuntu/24.04"
+#
+#          # MySQL 8.0
+#          - os: ubuntu-jammy
+#            package: mysql-8.0
+#            test-image: "images:ubuntu/22.04"
           - os: ubuntu-noble
-            package: mariadb-10.11
-            test-image: "images:ubuntu/24.04"
-
-          # MySQL 8.0
-          - os: ubuntu-jammy
-            package: mysql-8.0
-            test-image: "images:ubuntu/22.04"
-          - os: ubuntu-noble
             package: mysql-8.0
             test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.0
-          - os: almalinux-8
-            package: mysql-community-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.0
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.0
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.0
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.0
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.4
-          - os: almalinux-8
-            package: mysql-community-8.4
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.4
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.4
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.4
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.4
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community minimal 8.0
-          - os: almalinux-8
-            package: mysql-community-minimal-8.0
-            test-image: "images:almalinux/8"
-
-          # Percona Server 8.0
-          - os: almalinux-8
-            package: percona-server-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: percona-server-8.0
-            test-image: "images:almalinux/9"
+#
+#          # MySQL community 8.0
+#          - os: almalinux-8
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.0
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.0
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.0
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community 8.4
+#          - os: almalinux-8
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.4
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.4
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.4
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community minimal 8.0
+#          - os: almalinux-8
+#            package: mysql-community-minimal-8.0
+#            test-image: "images:almalinux/8"
+#
+#          # Percona Server 8.0
+#          - os: almalinux-8
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # MariaDB 10.5
-          - os: almalinux-8
-            package: mariadb-10.5
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.5
-            test-image: "images:almalinux/9"
-
-          # MariaDB 10.6
-          - os: almalinux-8
-            package: mariadb-10.6
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.6
-            test-image: "images:almalinux/9"
-          - os: ubuntu-jammy
-            package: mariadb-10.6
-            test-image: "images:ubuntu/22.04"
-
-          # MariaDB 10.11
-          - os: almalinux-8
-            package: mariadb-10.11
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.11
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mariadb-10.11
-            test-image: "images:debian/12"
+#          # MariaDB 10.5
+#          - os: almalinux-8
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/9"
+#
+#          # MariaDB 10.6
+#          - os: almalinux-8
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/9"
+#          - os: ubuntu-jammy
+#            package: mariadb-10.6
+#            test-image: "images:ubuntu/22.04"
+#
+#          # MariaDB 10.11
+#          - os: almalinux-8
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mariadb-10.11
+#            test-image: "images:debian/12"
+#          - os: ubuntu-noble
+#            package: mariadb-10.11
+#            test-image: "images:ubuntu/24.04"
+#
+#          # MySQL 8.0
+#          - os: ubuntu-jammy
+#            package: mysql-8.0
+#            test-image: "images:ubuntu/22.04"
           - os: ubuntu-noble
-            package: mariadb-10.11
+            package: mysql-8.0
             test-image: "images:ubuntu/24.04"
 
-          # MySQL 8.0
-          - os: ubuntu-jammy
-            package: mysql-8.0
-            test-image: "images:ubuntu/22.04"
-          - os: ubuntu-noble
-            package: mysql-8.0
-            test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.0
-          - os: almalinux-8
-            package: mysql-community-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.0
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.0
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.0
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.0
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.4
-          - os: almalinux-8
-            package: mysql-community-8.4
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.4
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.4
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.4
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.4
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community minimal 8.0
-          - os: almalinux-8
-            package: mysql-community-minimal-8.0
-            test-image: "images:almalinux/8"
-
-          # Percona Server 8.0
-          - os: almalinux-8
-            package: percona-server-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: percona-server-8.0
-            test-image: "images:almalinux/9"
+#          # MySQL community 8.0
+#          - os: almalinux-8
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.0
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.0
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.0
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community 8.4
+#          - os: almalinux-8
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.4
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.4
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.4
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community minimal 8.0
+#          - os: almalinux-8
+#            package: mysql-community-minimal-8.0
+#            test-image: "images:almalinux/8"
+#
+#          # Percona Server 8.0
+#          - os: almalinux-8
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # MariaDB 10.5
-#          - os: almalinux-8
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/9"
-#
-#          # MariaDB 10.6
-#          - os: almalinux-8
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/9"
-#          - os: ubuntu-jammy
-#            package: mariadb-10.6
-#            test-image: "images:ubuntu/22.04"
-#
-#          # MariaDB 10.11
-#          - os: almalinux-8
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mariadb-10.11
-#            test-image: "images:debian/12"
-#          - os: ubuntu-noble
-#            package: mariadb-10.11
-#            test-image: "images:ubuntu/24.04"
-#
-#          # MySQL 8.0
-#          - os: ubuntu-jammy
-#            package: mysql-8.0
-#            test-image: "images:ubuntu/22.04"
+          # MariaDB 10.5
+          - os: almalinux-8
+            package: mariadb-10.5
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.5
+            test-image: "images:almalinux/9"
+
+          # MariaDB 10.6
+          - os: almalinux-8
+            package: mariadb-10.6
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.6
+            test-image: "images:almalinux/9"
+          - os: ubuntu-jammy
+            package: mariadb-10.6
+            test-image: "images:ubuntu/22.04"
+
+          # MariaDB 10.11
+          - os: almalinux-8
+            package: mariadb-10.11
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.11
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mariadb-10.11
+            test-image: "images:debian/12"
+          - os: ubuntu-noble
+            package: mariadb-10.11
+            test-image: "images:ubuntu/24.04"
+
+          # MySQL 8.0
+          - os: ubuntu-jammy
+            package: mysql-8.0
+            test-image: "images:ubuntu/22.04"
           - os: ubuntu-noble
             package: mysql-8.0
             test-image: "images:ubuntu/24.04"
 
-#          # MySQL community 8.0
-#          - os: almalinux-8
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.0
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.0
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.0
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community 8.4
-#          - os: almalinux-8
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.4
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.4
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.4
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community minimal 8.0
-#          - os: almalinux-8
-#            package: mysql-community-minimal-8.0
-#            test-image: "images:almalinux/8"
-#
-#          # Percona Server 8.0
-#          - os: almalinux-8
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/9"
+          # MySQL community 8.0
+          - os: almalinux-8
+            package: mysql-community-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.0
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.0
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.0
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.0
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community 8.4
+          - os: almalinux-8
+            package: mysql-community-8.4
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.4
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.4
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.4
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.4
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community minimal 8.0
+          - os: almalinux-8
+            package: mysql-community-minimal-8.0
+            test-image: "images:almalinux/8"
+
+          # Percona Server 8.0
+          - os: almalinux-8
+            package: percona-server-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: percona-server-8.0
+            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # MariaDB 10.5
-#          - os: almalinux-8
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/9"
-#
-#          # MariaDB 10.6
-#          - os: almalinux-8
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/9"
-#          - os: ubuntu-jammy
-#            package: mariadb-10.6
-#            test-image: "images:ubuntu/22.04"
-#
-#          # MariaDB 10.11
-#          - os: almalinux-8
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mariadb-10.11
-#            test-image: "images:debian/12"
-#          - os: ubuntu-noble
-#            package: mariadb-10.11
-#            test-image: "images:ubuntu/24.04"
-#
-#          # MySQL 8.0
-#          - os: ubuntu-jammy
-#            package: mysql-8.0
-#            test-image: "images:ubuntu/22.04"
+          # MariaDB 10.5
+          - os: almalinux-8
+            package: mariadb-10.5
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.5
+            test-image: "images:almalinux/9"
+
+          # MariaDB 10.6
+          - os: almalinux-8
+            package: mariadb-10.6
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.6
+            test-image: "images:almalinux/9"
+          - os: ubuntu-jammy
+            package: mariadb-10.6
+            test-image: "images:ubuntu/22.04"
+
+          # MariaDB 10.11
+          - os: almalinux-8
+            package: mariadb-10.11
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.11
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mariadb-10.11
+            test-image: "images:debian/12"
+          - os: ubuntu-noble
+            package: mariadb-10.11
+            test-image: "images:ubuntu/24.04"
+
+          # MySQL 8.0
+          - os: ubuntu-jammy
+            package: mysql-8.0
+            test-image: "images:ubuntu/22.04"
           - os: ubuntu-noble
             package: mysql-8.0
             test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community 8.0
-#          - os: almalinux-8
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.0
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.0
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.0
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community 8.4
-#          - os: almalinux-8
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.4
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.4
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.4
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community minimal 8.0
-#          - os: almalinux-8
-#            package: mysql-community-minimal-8.0
-#            test-image: "images:almalinux/8"
-#
-#          # Percona Server 8.0
-#          - os: almalinux-8
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/9"
+
+          # MySQL community 8.0
+          - os: almalinux-8
+            package: mysql-community-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.0
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.0
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.0
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.0
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community 8.4
+          - os: almalinux-8
+            package: mysql-community-8.4
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.4
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.4
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.4
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.4
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community minimal 8.0
+          - os: almalinux-8
+            package: mysql-community-minimal-8.0
+            test-image: "images:almalinux/8"
+
+          # Percona Server 8.0
+          - os: almalinux-8
+            package: percona-server-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: percona-server-8.0
+            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -20,7 +20,6 @@ RUN \
     software-properties-common \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
-  apt build-dep -y mysql-server && \
   apt install -y -V ${quiet} \
     autoconf-archive \
     build-essential \

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -29,16 +29,26 @@ RUN \
     devscripts \
     dh-apparmor \
     groonga-normalizer-mysql \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libevent-dev \
     libgroonga-dev \
-    libmysqlclient-dev \
+    libicu-dev \
+    liblz4-dev \
     libmecab-dev \
+    libmysqlclient-dev \
+    libncurses5-dev \
     libpcre3-dev \
+    libprotobuf-dev \
+    libprotoc-dev \
     libreadline-dev \
     libssl-dev \
     libxml2-dev \
     libre2-dev \
+    libwrap0-dev \
     lsb-release \
     mecab-utils \
     pkg-config \
+    protobuf-compiler \
     unixodbc-dev \
     wget

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -30,6 +30,7 @@ RUN \
     devscripts \
     dh-apparmor \
     groonga-normalizer-mysql \
+    libaio-dev \
     libcurl4-openssl-dev \
     libedit-dev \
     libevent-dev \

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -45,6 +45,7 @@ RUN \
     libprotoc-dev \
     libreadline-dev \
     libssl-dev \
+    libtirpc-dev \
     libxml2-dev \
     libre2-dev \
     libwrap0-dev \

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -25,6 +25,7 @@ RUN \
     build-essential \
     ccache \
     chrpath \
+    cmake \
     debhelper \
     devscripts \
     dh-apparmor \

--- a/packages/mysql-8.0-mroonga/debian/control.in
+++ b/packages/mysql-8.0-mroonga/debian/control.in
@@ -7,6 +7,7 @@ Build-Depends:
 	cmake,
 	debhelper (>= 9),
 	groonga-normalizer-mysql,
+        libaio-dev,
 	libcurl4-openssl-dev,
 	libedit-dev,
 	libevent-dev,

--- a/packages/mysql-8.0-mroonga/debian/control.in
+++ b/packages/mysql-8.0-mroonga/debian/control.in
@@ -20,6 +20,7 @@ Build-Depends:
 	libprotobuf-dev,
 	libprotoc-dev,
 	libssl-dev,
+        libtirpc-dev,
 	libwrap0-dev,
 	lsb-release,
 	pkg-config,


### PR DESCRIPTION
We build Mroonga package for Ubuntu on Launchpad,
but "apt build-dep -y mysql-server" command is not used on Launchpad when we build Mroonga on Launchpad.
Only dependency packages that is specified Build-Depends of debian/control are installed on Launchpad.

Therefore, build of Mroonga package for Ubuntu failure on Launchpad even if build of Mroonga package for Ubuntu successful on CI.
So, we remove "apt build-dep -y mysql-server" from CI. We can notice missing dependency packages with CI by this PR.

I will apply same modification to Mroonga for Ubuntu jammy by the other PR.