### PR TITLE
doc: gem install `gettext` for generating documents

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,17 @@
+# Copyright (C) 2024 Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+/Gemfile.lock

--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -1,0 +1,19 @@
+# Copyright (C) 2024 Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org"
+
+gem "gettext"


### PR DESCRIPTION
ref: https://github.com/mroonga/mroonga/issues/695#issuecomment-2172734327

We faced the following error during generating documents.
Because we didn't install `gem gettext` so we couldn't require it.
```
<internal:/home/kodama/.rbenv/versions/3.3.2/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- gettext/tools (LoadError)
	from <internal:/home/kodama/.rbenv/versions/3.3.2/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from /home/kodama/work/cpp/mroonga/doc/../doc/update-edit-po.rb:20:in `<main>'
```

## How to reporduce

```console
$ cmake -S . -B ../mroonga.doc -GNinja \
                               -DMRN_WITH_DOC=ON \
                               -DCMAKE_INSTALL_PREFIX=/tmp/local \
                               -DMYSQL_SOURCE_DIR=~/work/cpp/mysql-8.4.0 \
                               -DMYSQL_BUILD_DIR=~/work/cpp/mysql-8.4.0.build \
                               -DMYSQL_CONFIG=/tmp/local/bin/mysql_config
$ cmake --build ../mroonga.doc
...
[42/293] Generating en/LC_MESSAGES/contribution/report.edit.po
FAILED: doc/en/LC_MESSAGES/contribution/report.edit.po /home/kodama/work/cpp/mroonga.doc/doc/en/LC_MESSAGES/contribution/report.edit.po
cd /home/kodama/work/cpp/mroonga.doc/doc && /home/kodama/work/cpp/mroonga/doc/../doc/update-edit-po.rb en en/gettext/contribution/report.pot /home/kodama/work/cpp/mroonga/doc/source/../locale/en/LC_MESSAGES/contribution/report.po en/LC_MESSAGES/contribution/report.po.time_stamp en/LC_MESSAGES/contribution/report.edit.po
<internal:/home/kodama/.rbenv/versions/3.3.2/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- gettext/tools (LoadError)
	from <internal:/home/kodama/.rbenv/versions/3.3.2/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from /home/kodama/work/cpp/mroonga/doc/../doc/update-edit-po.rb:20:in `<main>'
...
```

## Expected
We can successfully generate documents.