### PR TITLE
cmake: add a doc preset to CMakePresets for generating documentations

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 16,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "doc",
+      "displayName": "For documentation",
+      "inherits": ["base"],
+      "cacheVariables": {
+        "MRN_WITH_DOC": "ON"
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 1,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 16,
+    "minor": 19,
     "patch": 0
   },
   "configurePresets": [


### PR DESCRIPTION
ref: https://github.com/mroonga/mroonga/issues/695

This change introduces a new preset in `CMakePresets.json` to simplify the process of generating documentation.
It allows both new and existing developers to quickly and easily produce documents.

```console
$ cmake -S . -B ../mroonga.doc --preset=doc \
                               -DCMAKE_INSTALL_PREFIX=/tmp/local \
                               -DMYSQL_SOURCE_DIR=~/work/cpp/mysql-8.4.0 \
                               -DMYSQL_BUILD_DIR=~/work/cpp/mysql-8.4.0.build \
                               -DMYSQL_CONFIG=/tmp/local/bin/mysql_config
$ cmake --build ../mroonga.doc
$ open ../mroonga.doc/doc/ja/html/index.html
```

## What I will do in the following PRs
Update how to generate documentation using `CMake` instead of `GNU Autotools`
- https://mroonga.org/docs/contribution/documentation.html 
- https://mroonga.org/docs/developer.html#adding-and-updating-documents