### PR TITLE
packages mysql-8.0: don't use "apt build-dep" when Mroonga build for Ubuntu jammy

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # MariaDB 10.5
-#          - os: almalinux-8
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/9"
-#
-#          # MariaDB 10.6
-#          - os: almalinux-8
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/9"
-#          - os: ubuntu-jammy
-#            package: mariadb-10.6
-#            test-image: "images:ubuntu/22.04"
-#
-#          # MariaDB 10.11
-#          - os: almalinux-8
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mariadb-10.11
-#            test-image: "images:debian/12"
-#          - os: ubuntu-noble
-#            package: mariadb-10.11
-#            test-image: "images:ubuntu/24.04"
-#
-#          # MySQL 8.0
+          # MariaDB 10.5
+          - os: almalinux-8
+            package: mariadb-10.5
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.5
+            test-image: "images:almalinux/9"
+
+          # MariaDB 10.6
+          - os: almalinux-8
+            package: mariadb-10.6
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.6
+            test-image: "images:almalinux/9"
+          - os: ubuntu-jammy
+            package: mariadb-10.6
+            test-image: "images:ubuntu/22.04"
+
+          # MariaDB 10.11
+          - os: almalinux-8
+            package: mariadb-10.11
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.11
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mariadb-10.11
+            test-image: "images:debian/12"
+          - os: ubuntu-noble
+            package: mariadb-10.11
+            test-image: "images:ubuntu/24.04"
+
+          # MySQL 8.0
           - os: ubuntu-jammy
             package: mysql-8.0
             test-image: "images:ubuntu/22.04"
-#          - os: ubuntu-noble
-#            package: mysql-8.0
-#            test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community 8.0
-#          - os: almalinux-8
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.0
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.0
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.0
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community 8.4
-#          - os: almalinux-8
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.4
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.4
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.4
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community minimal 8.0
-#          - os: almalinux-8
-#            package: mysql-community-minimal-8.0
-#            test-image: "images:almalinux/8"
-#
-#          # Percona Server 8.0
-#          - os: almalinux-8
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/9"
+          - os: ubuntu-noble
+            package: mysql-8.0
+            test-image: "images:ubuntu/24.04"
+
+          # MySQL community 8.0
+          - os: almalinux-8
+            package: mysql-community-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.0
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.0
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.0
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.0
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community 8.4
+          - os: almalinux-8
+            package: mysql-community-8.4
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.4
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.4
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.4
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.4
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community minimal 8.0
+          - os: almalinux-8
+            package: mysql-community-minimal-8.0
+            test-image: "images:almalinux/8"
+
+          # Percona Server 8.0
+          - os: almalinux-8
+            package: percona-server-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: percona-server-8.0
+            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # MariaDB 10.5
-          - os: almalinux-8
-            package: mariadb-10.5
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.5
-            test-image: "images:almalinux/9"
-
-          # MariaDB 10.6
-          - os: almalinux-8
-            package: mariadb-10.6
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.6
-            test-image: "images:almalinux/9"
-          - os: ubuntu-jammy
-            package: mariadb-10.6
-            test-image: "images:ubuntu/22.04"
-
-          # MariaDB 10.11
-          - os: almalinux-8
-            package: mariadb-10.11
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.11
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mariadb-10.11
-            test-image: "images:debian/12"
-          - os: ubuntu-noble
-            package: mariadb-10.11
-            test-image: "images:ubuntu/24.04"
-
-          # MySQL 8.0
+#          # MariaDB 10.5
+#          - os: almalinux-8
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/9"
+#
+#          # MariaDB 10.6
+#          - os: almalinux-8
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/9"
+#          - os: ubuntu-jammy
+#            package: mariadb-10.6
+#            test-image: "images:ubuntu/22.04"
+#
+#          # MariaDB 10.11
+#          - os: almalinux-8
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mariadb-10.11
+#            test-image: "images:debian/12"
+#          - os: ubuntu-noble
+#            package: mariadb-10.11
+#            test-image: "images:ubuntu/24.04"
+#
+#          # MySQL 8.0
           - os: ubuntu-jammy
             package: mysql-8.0
             test-image: "images:ubuntu/22.04"
-          - os: ubuntu-noble
-            package: mysql-8.0
-            test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.0
-          - os: almalinux-8
-            package: mysql-community-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.0
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.0
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.0
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.0
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.4
-          - os: almalinux-8
-            package: mysql-community-8.4
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.4
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.4
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.4
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.4
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community minimal 8.0
-          - os: almalinux-8
-            package: mysql-community-minimal-8.0
-            test-image: "images:almalinux/8"
-
-          # Percona Server 8.0
-          - os: almalinux-8
-            package: percona-server-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: percona-server-8.0
-            test-image: "images:almalinux/9"
+#          - os: ubuntu-noble
+#            package: mysql-8.0
+#            test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community 8.0
+#          - os: almalinux-8
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.0
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.0
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.0
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community 8.4
+#          - os: almalinux-8
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.4
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.4
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.4
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community minimal 8.0
+#          - os: almalinux-8
+#            package: mysql-community-minimal-8.0
+#            test-image: "images:almalinux/8"
+#
+#          # Percona Server 8.0
+#          - os: almalinux-8
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
@@ -30,6 +30,7 @@ RUN \
     dh-apparmor \
     groonga-normalizer-mysql \
     libcurl4-openssl-dev \
+    libaio-dev \
     libedit-dev \
     libevent-dev \
     libgroonga-dev \

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
@@ -19,26 +19,36 @@ RUN \
     software-properties-common \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
-  apt build-dep -y mysql-server && \
   apt install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     ccache \
     chrpath \
+    cmake \
     debhelper \
     devscripts \
     dh-apparmor \
     groonga-normalizer-mysql \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libevent-dev \
     libgroonga-dev \
-    libmysqlclient-dev \
+    libicu-dev \
+    liblz4-dev \
     libmecab-dev \
+    libmysqlclient-dev \
+    libncurses5-dev \
     libpcre3-dev \
+    libprotobuf-dev \
+    libprotoc-dev \
     libreadline-dev \
     libssl-dev \
     libxml2-dev \
     libre2-dev \
+    libwrap0-dev \
     lsb-release \
     mecab-utils \
     pkg-config \
+    protobuf-compiler \
     unixodbc-dev \
     wget


### PR DESCRIPTION
This modification is the same kind of #701.

We remove "apt build-dep -y mysql-server" when we build Mroonga for Ubuntu jammy on CI. The reason for this modification refer #701.