### PR TITLE
packages mariadb-10.11: don't use "apt build-dep" when Mroonga build for Ubuntu noble

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # MariaDB 10.5
-#          - os: almalinux-8
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.5
-#            test-image: "images:almalinux/9"
-#
-#          # MariaDB 10.6
-#          - os: almalinux-8
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.6
-#            test-image: "images:almalinux/9"
-#          - os: ubuntu-jammy
-#            package: mariadb-10.6
-#            test-image: "images:ubuntu/22.04"
-#
-#          # MariaDB 10.11
-#          - os: almalinux-8
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mariadb-10.11
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mariadb-10.11
-#            test-image: "images:debian/12"
+          # MariaDB 10.5
+          - os: almalinux-8
+            package: mariadb-10.5
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.5
+            test-image: "images:almalinux/9"
+
+          # MariaDB 10.6
+          - os: almalinux-8
+            package: mariadb-10.6
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.6
+            test-image: "images:almalinux/9"
+          - os: ubuntu-jammy
+            package: mariadb-10.6
+            test-image: "images:ubuntu/22.04"
+
+          # MariaDB 10.11
+          - os: almalinux-8
+            package: mariadb-10.11
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mariadb-10.11
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mariadb-10.11
+            test-image: "images:debian/12"
           - os: ubuntu-noble
             package: mariadb-10.11
             test-image: "images:ubuntu/24.04"
 
           # MySQL 8.0
-#          - os: ubuntu-jammy
-#            package: mysql-8.0
-#            test-image: "images:ubuntu/22.04"
-#          - os: ubuntu-noble
-#            package: mysql-8.0
-#            test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community 8.0
-#          - os: almalinux-8
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.0
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.0
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.0
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.0
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community 8.4
-#          - os: almalinux-8
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: mysql-community-8.4
-#            test-image: "images:almalinux/9"
-#          - os: debian-bookworm
-#            package: mysql-community-8.4
-#            test-image: "images:debian/12"
-#          - os: ubuntu-jammy
-#            package: mysql-community-8.4
-#            test-image: "images:ubuntu/22.04"
-#          # Source isn't available yet.
-#          # - os: ubuntu-noble
-#          #   package: mysql-community-8.4
-#          #   test-image: "images:ubuntu/24.04"
-#
-#          # MySQL community minimal 8.0
-#          - os: almalinux-8
-#            package: mysql-community-minimal-8.0
-#            test-image: "images:almalinux/8"
-#
-#          # Percona Server 8.0
-#          - os: almalinux-8
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/8"
-#          - os: almalinux-9
-#            package: percona-server-8.0
-#            test-image: "images:almalinux/9"
+          - os: ubuntu-jammy
+            package: mysql-8.0
+            test-image: "images:ubuntu/22.04"
+          - os: ubuntu-noble
+            package: mysql-8.0
+            test-image: "images:ubuntu/24.04"
+
+          # MySQL community 8.0
+          - os: almalinux-8
+            package: mysql-community-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.0
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.0
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.0
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.0
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community 8.4
+          - os: almalinux-8
+            package: mysql-community-8.4
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: mysql-community-8.4
+            test-image: "images:almalinux/9"
+          - os: debian-bookworm
+            package: mysql-community-8.4
+            test-image: "images:debian/12"
+          - os: ubuntu-jammy
+            package: mysql-community-8.4
+            test-image: "images:ubuntu/22.04"
+          # Source isn't available yet.
+          # - os: ubuntu-noble
+          #   package: mysql-community-8.4
+          #   test-image: "images:ubuntu/24.04"
+
+          # MySQL community minimal 8.0
+          - os: almalinux-8
+            package: mysql-community-minimal-8.0
+            test-image: "images:almalinux/8"
+
+          # Percona Server 8.0
+          - os: almalinux-8
+            package: percona-server-8.0
+            test-image: "images:almalinux/8"
+          - os: almalinux-9
+            package: percona-server-8.0
+            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,95 +134,95 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # MariaDB 10.5
-          - os: almalinux-8
-            package: mariadb-10.5
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.5
-            test-image: "images:almalinux/9"
-
-          # MariaDB 10.6
-          - os: almalinux-8
-            package: mariadb-10.6
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.6
-            test-image: "images:almalinux/9"
-          - os: ubuntu-jammy
-            package: mariadb-10.6
-            test-image: "images:ubuntu/22.04"
-
-          # MariaDB 10.11
-          - os: almalinux-8
-            package: mariadb-10.11
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mariadb-10.11
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mariadb-10.11
-            test-image: "images:debian/12"
+#          # MariaDB 10.5
+#          - os: almalinux-8
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.5
+#            test-image: "images:almalinux/9"
+#
+#          # MariaDB 10.6
+#          - os: almalinux-8
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.6
+#            test-image: "images:almalinux/9"
+#          - os: ubuntu-jammy
+#            package: mariadb-10.6
+#            test-image: "images:ubuntu/22.04"
+#
+#          # MariaDB 10.11
+#          - os: almalinux-8
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mariadb-10.11
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mariadb-10.11
+#            test-image: "images:debian/12"
           - os: ubuntu-noble
             package: mariadb-10.11
             test-image: "images:ubuntu/24.04"
 
           # MySQL 8.0
-          - os: ubuntu-jammy
-            package: mysql-8.0
-            test-image: "images:ubuntu/22.04"
-          - os: ubuntu-noble
-            package: mysql-8.0
-            test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.0
-          - os: almalinux-8
-            package: mysql-community-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.0
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.0
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.0
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.0
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community 8.4
-          - os: almalinux-8
-            package: mysql-community-8.4
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: mysql-community-8.4
-            test-image: "images:almalinux/9"
-          - os: debian-bookworm
-            package: mysql-community-8.4
-            test-image: "images:debian/12"
-          - os: ubuntu-jammy
-            package: mysql-community-8.4
-            test-image: "images:ubuntu/22.04"
-          # Source isn't available yet.
-          # - os: ubuntu-noble
-          #   package: mysql-community-8.4
-          #   test-image: "images:ubuntu/24.04"
-
-          # MySQL community minimal 8.0
-          - os: almalinux-8
-            package: mysql-community-minimal-8.0
-            test-image: "images:almalinux/8"
-
-          # Percona Server 8.0
-          - os: almalinux-8
-            package: percona-server-8.0
-            test-image: "images:almalinux/8"
-          - os: almalinux-9
-            package: percona-server-8.0
-            test-image: "images:almalinux/9"
+#          - os: ubuntu-jammy
+#            package: mysql-8.0
+#            test-image: "images:ubuntu/22.04"
+#          - os: ubuntu-noble
+#            package: mysql-8.0
+#            test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community 8.0
+#          - os: almalinux-8
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.0
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.0
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.0
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.0
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community 8.4
+#          - os: almalinux-8
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: mysql-community-8.4
+#            test-image: "images:almalinux/9"
+#          - os: debian-bookworm
+#            package: mysql-community-8.4
+#            test-image: "images:debian/12"
+#          - os: ubuntu-jammy
+#            package: mysql-community-8.4
+#            test-image: "images:ubuntu/22.04"
+#          # Source isn't available yet.
+#          # - os: ubuntu-noble
+#          #   package: mysql-community-8.4
+#          #   test-image: "images:ubuntu/24.04"
+#
+#          # MySQL community minimal 8.0
+#          - os: almalinux-8
+#            package: mysql-community-minimal-8.0
+#            test-image: "images:almalinux/8"
+#
+#          # Percona Server 8.0
+#          - os: almalinux-8
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/8"
+#          - os: almalinux-9
+#            package: percona-server-8.0
+#            test-image: "images:almalinux/9"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest

--- a/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
@@ -42,7 +42,7 @@ RUN \
     libmecab-dev \
     libncurses5-dev \
     libpam0g-dev \
-    libpcre3-dev \
+    libpcre2-dev \
     libreadline-dev \
     libsnappy-dev \
     libssl-dev \

--- a/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
@@ -46,6 +46,7 @@ RUN \
     libreadline-dev \
     libsnappy-dev \
     libssl-dev \
+    liburing-dev \
     libxml2-dev \
     libre2-dev \
     lsb-release \

--- a/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
@@ -22,6 +22,7 @@ RUN \
   add-apt-repository -y ppa:groonga/ppa && \
   apt install -y -V ${quiet} \
     autoconf-archive \
+    bison \
     build-essential \
     ccache \
     chrpath \

--- a/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
@@ -43,6 +43,7 @@ RUN \
     libncurses5-dev \
     libpam0g-dev \
     libpcre2-dev \
+    libpmem-dev \
     libreadline-dev \
     libsnappy-dev \
     libssl-dev \

--- a/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mariadb-10.11-mroonga/apt/ubuntu-noble/Dockerfile
@@ -20,27 +20,37 @@ RUN \
     software-properties-common \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
-  apt build-dep -y mariadb-server && \
   apt install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     ccache \
     chrpath \
+    cmake \
     debhelper \
     devscripts \
     dh-apparmor \
+    gdb \
     groonga-normalizer-mysql \
     libaio-dev \
+    libboost-dev \
     libgroonga-dev \
+    libjemalloc-dev \
+    libjudy-dev \
     libmariadb-client-lgpl-dev-compat \
     libmariadbd-dev \
     libmecab-dev \
+    libncurses5-dev \
+    libpam0g-dev \
     libpcre3-dev \
     libreadline-dev \
+    libsnappy-dev \
     libssl-dev \
     libxml2-dev \
     libre2-dev \
     lsb-release \
+    perl \
     mecab-utils \
     pkg-config \
-    unixodbc-dev
+    psmisc \
+    unixodbc-dev \
+    zlib1g-dev

--- a/packages/mariadb-10.11-mroonga/debian/control.in
+++ b/packages/mariadb-10.11-mroonga/debian/control.in
@@ -25,6 +25,7 @@ Build-Depends:
 	libreadline-dev,
 	libsnappy-dev,
 	libssl-dev,
+        liburing-dev,
 	libxml2-dev,
 	lsb-release,
 	perl,

--- a/packages/mariadb-10.11-mroonga/debian/control.in
+++ b/packages/mariadb-10.11-mroonga/debian/control.in
@@ -21,7 +21,7 @@ Build-Depends:
 	libmariadbd-dev,
 	libncurses5-dev,
 	libpam0g-dev,
-	libpcre3-dev,
+	libpcre2-dev,
 	libreadline-dev,
 	libsnappy-dev,
 	libssl-dev,

--- a/packages/mariadb-10.11-mroonga/debian/control.in
+++ b/packages/mariadb-10.11-mroonga/debian/control.in
@@ -22,6 +22,7 @@ Build-Depends:
 	libncurses5-dev,
 	libpam0g-dev,
 	libpcre2-dev,
+        libpmem-dev,
 	libreadline-dev,
 	libsnappy-dev,
 	libssl-dev,


### PR DESCRIPTION
This modification is the same kind of #701.

We remove "apt build-dep -y mysql-server" when we build Mroonga for Ubuntu jammy on CI. The reason for this modification refer #701.

Also, This modification resolve https://launchpadlibrarian.net/735682999/buildlog_ubuntu-noble-amd64.mariadb-10.11-mroonga_14.04-1.ubuntu24.04.1_BUILDING.txt.gz probably.