### PR TITLE
Implement "make tag" by Ruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,6 +74,17 @@ namespace :release do
          "package: update version info to #{version} (#{new_release_date})")
     end
   end
+
+  desc "Tag"
+  task :tag do
+    sh("git",
+       "tag",
+       "v#{version}",
+       "-a",
+       "-m",
+       "Mroonga #{version}!!!")
+    sh("git", "push", "origin", "v#{version}")
+  end
 end
 
 namespace :dev do


### PR DESCRIPTION
We will drop support for GNU Autotools. This is a part of the work. We can use `rake release:tag` instead of `make tag`.

The behavior of this modification https://github.com/mroonga/mroonga/blob/v13.05/Makefile.am#L45-L47 about the same as below.

* Setting tag by `git tag vXX.XX -a -m "Mroonga XX.XX!!!"`
* Push tag to Mroonga repository by `git push origin "vXX.XX"`

Usage:

$ rake release:tag