### PR TITLE
packages: add a missing definition

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -269,4 +269,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
       raise NotImplementedError
     end
   end
+
+  def tag_name
+    "v#{@version}"
+  end
 end


### PR DESCRIPTION
Upload script use "gh release upload #{tag_name}" when we upload source archive. The tag name of Mroonga is vXX.XX, but the tag name is XX.XX (missing "v") in upload script currently.

Therefore, "gh release upload #{tag_name}" is failed. Because tag name such as XX.XX does not exist.