### PR TITLE
packages mysql-*-community-server: disable ubuntu-noble targets

### DIFF
--- a/packages/mysql-community-8.0-mroonga/Rakefile
+++ b/packages/mysql-community-8.0-mroonga/Rakefile
@@ -9,7 +9,9 @@ class MySQLCommunity80MroongaPackageTask < MroongaPackageTask
     [
       "debian-bookworm",
       "ubuntu-jammy",
-      "ubuntu-noble",
+      # The source of MySQL Community Server for Ubuntu noble isn't available yet.
+      # So, we don't build Mroonga with MySQL 8.0 Community Server for Ubuntu noble.
+      # "ubuntu-noble",
     ]
   end
 

--- a/packages/mysql-community-8.4-mroonga/Rakefile
+++ b/packages/mysql-community-8.4-mroonga/Rakefile
@@ -9,7 +9,9 @@ class MySQLCommunity84MroongaPackageTask < MroongaPackageTask
     [
       "debian-bookworm",
       "ubuntu-jammy",
-      "ubuntu-noble",
+      # The source of MySQL Community Server for Ubuntu noble isn't available yet.
+      # So, we don't build Mroonga with MySQL 8.0 Community Server for Ubuntu noble.
+      # "ubuntu-noble",
     ]
   end
 


### PR DESCRIPTION
The source of MySQL 8.0 Community Server and MySQL 8.4 Community Server for Ubuntu noble are not available yet.
 So, These packages don't exist currently.