### PR TITLE
cmake: update CMake presets' JSON schema version from 1 to 3

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 1,
+  "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 19,
+    "minor": 21,
     "patch": 0
   },
   "configurePresets": [


### PR DESCRIPTION
The following error raised.
Because we have to specify the `binaryDir` by version 2 and it is optional after version 3.
- ref: [See also `binaryDir`](https://cmake.org/cmake/help/v3.30/manual/cmake-presets.7.html#configure-preset)

```console
$ cmake --list-presets
CMake Error: Could not read presets from /host:
Preset "doc" missing field "binaryDir"
Invalid preset: "doc"
```

I think of the following options. And the I chose the second option. Because it will be better for developers to decide their own build directories and keep CMakePresets.json simple for maintenances.

1. Set `"binaryDir": xxx` and use `"version: 1"`.
2. Specify `"version: 3"` without setting `"binaryDir": xxx` (Upgrade the required CMake version).