### PR TITLE
ci windows: fix the uploading packages error by checking out source

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -249,7 +249,8 @@ jobs:
           matrix.use-main != 'yes' && startsWith(github.ref, 'refs/tags/')
         run: |
           gh release upload ${Env:GITHUB_REF_NAME} `
-            "${Env:ARTIFACT_NAME}.zip"
+            "${Env:ARTIFACT_NAME}.zip" `
+            --repo ${Env:GITHUB_REPOSITORY}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The following error happened when uploading Windows' packages on release step.
ref: https://github.com/mroonga/mroonga/actions/runs/9575531620/job/26400564227
```
Run gh release upload ${Env:GITHUB_REF_NAME} `
  gh release upload ${Env:GITHUB_REF_NAME} `
    "${Env:ARTIFACT_NAME}.zip"
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    PACKAGE_PLATFORM: winx64
    VC_ARCHITECTURE: x64
    MARIADB_VERSION: 10.11.8
    MROONGA_VERSION: 14.04
    ARTIFACT_NAME: mariadb-10.11.8-with-mroonga-14.04-winx64
    CMAKE_C_COMPILER_LAUNCHER: ccache
    CMAKE_CXX_COMPILER_LAUNCHER: ccache
    GITHUB_TOKEN: ***
failed to run git: fatal: not a git repository (or any of the parent directories): .git

Error: Process completed with exit code 1.
```

## The cause of this error

As the error said, there is no Git repository we can reference to detect the default target GitHub repository.
Because we checkout the repository at `mariadb/storage/mroonga` so `gh release` cannot use it to detect the default target GitHub repository.

https://github.com/mroonga/mroonga/blob/7067580839923885f0c12951cc7e7f4181c5771e/.github/workflows/windows.yml#L91-L94

## Solution

To resolve this issue, explicitly specify the repository information when using the `gh release upload` command by including the `--repo` option.
It ensures the `gh` command has the necessary repository context to execute successfully.

ref: https://docs.github.com/en/actions/learn-github-actions/variables
ref: https://cli.github.com/manual/gh_release_upload