### PR TITLE
packages mariadb-10.6: fix wrong source base

### DIFF
--- a/packages/mariadb-10.6-mroonga/debian/rules
+++ b/packages/mariadb-10.6-mroonga/debian/rules
@@ -22,7 +22,7 @@ override_dh_auto_configure:
 	  path=universe/m/mariadb-10.6;					\
 	  base_url=http://archive.ubuntu.com/ubuntu/pool;		\
 	  security_base_url=http://security.ubuntu.com/ubuntu/pool;	\
-	  source_base=mariadb-10.6-$(MARIADB_VERSION);		\
+	  source_base=mariadb-$(MARIADB_VERSION);		\
 	  build_dir=$${source_base}/builddir;				\
 	else								\
 	  path=main/m/mariadb-10.6;					\


### PR DESCRIPTION
Fix #718.

MariaDB' source directory name is changed to mariadb-${mariadb_major_minor_micro} from mariadb-${mariadb_major_minor}-${mariadb_major_minor_micro} since MariaDB 10.6.18 on Ubuntu.

So, The build of Mroonga on Ubuntu is failure because of mariadb source directory is not found.

I modify source directory name correctly by this PR.