### PR TITLE
ci install: add support Ubuntu 24.04

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install to Ubuntu
 on:
-  pull_request:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -20,6 +20,10 @@ jobs:
             package: mariadb
           - image: "images:ubuntu/22.04"
             package: mysql
+          - image: "images:ubuntu/24.04"
+            package: mariadb
+          - image: "images:ubuntu/24.04"
+            package: mysql
     steps:
       - uses: actions/checkout@v4
       - name: Install Incus

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install to Ubuntu
 on:
+  pull_request:
   schedule:
     - cron: |
         0 0 * * *


### PR DESCRIPTION
Fix #720.

We confirmed successful install tests for Ubuntu 24.04 (noble) as below CI.
https://github.com/mroonga/mroonga/actions/runs/9608564664?pr=724 