### PR TITLE
ci: disable mysql-community-minimal-8.0 temporality

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -211,10 +211,11 @@ jobs:
           #   package: mysql-community-8.4
           #   test-image: "images:ubuntu/24.04"
 
+          # Source of version 8.0.38 isn't available yet.
           # MySQL community minimal 8.0
-          - os: almalinux-8
-            package: mysql-community-minimal-8.0
-            test-image: "images:almalinux/8"
+          #- os: almalinux-8
+          #  package: mysql-community-minimal-8.0
+          #  test-image: "images:almalinux/8"
 
           # Percona Server 8.0
           - os: almalinux-8


### PR DESCRIPTION
The SRPM of mysql-community-minimal-8.0 doesn't provide yet on the following repository.

https://repo.mysql.com/yum/mysql-8.0-community/docker/el/8/SRPMS/

Currently, Mroonga build with MySQL 8.0.38.
So, the build of Mroonga for mysql-community-minimal-8.0 need the SRPM of mysql-community-minimal-8.0.

We disable build and test for mysql-community-minimal-8.0 temporality until the SRPM of mysql-community-minimal-8.0 provide.