### PR TITLE
doc contribution/documentation: update initial configuration for building documentation

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation.po
@@ -92,13 +92,13 @@ msgid "We use Sphinx for documentation tool and use gettext gem for localization
 msgstr "ドキュメントツールとしてSphinxを使用し、ローカライズにはgettext gemを使用します。以下のコマンドでこれらのツールをインストールできます。"
 
 msgid "Initial configuration for building documentation"
-msgstr ""
+msgstr "ドキュメント生成の初期設定"
 
 msgid "Execute following commands to prepare for generating Mroonga documentation."
-msgstr ""
+msgstr "下記のコマンドで、Mroongaドキュメントを生成する設定をします。"
 
 msgid "Next step is \"The things you need to do every tasks\"."
-msgstr ""
+msgstr "次のステップは、\"ドキュメント編集・更新時に毎回必要な作業\"の説明をします。"
 
 msgid "以下では作業ごとにやることを説明します。"
 msgstr ""

--- a/doc/source/contribution/documentation.md
+++ b/doc/source/contribution/documentation.md
@@ -70,8 +70,10 @@ You can install both tools using the following commands.
 Execute following commands to prepare for generating Mroonga documentation.
 
 ```console
-% ./autogen.sh
-% ./configure --enable-document --with-mysql-source=(SOURCE_DIRECTORY_OF_MySQL)
+% cmake -S . -B ../mroonga.doc --preset=doc \
+                               -DMYSQL_SOURCE_DIR=(MySQL_SOURCE_DIRECTORY) \
+                               -DMYSQL_BUILD_DIR=(MySQL_BUILD_DIRECTORY) \
+                               -DMYSQL_CONFIG=(MySQL_CONFIG)
 ```
 
 Next step is "The things you need to do every tasks".

--- a/doc/source/contribution/documentation.md
+++ b/doc/source/contribution/documentation.md
@@ -70,10 +70,13 @@ You can install both tools using the following commands.
 Execute following commands to prepare for generating Mroonga documentation.
 
 ```console
-% cmake -S . -B ../mroonga.doc --preset=doc \
-                               -DMYSQL_SOURCE_DIR=(MySQL_SOURCE_DIRECTORY) \
-                               -DMYSQL_BUILD_DIR=(MySQL_BUILD_DIRECTORY) \
-                               -DMYSQL_CONFIG=(MySQL_CONFIG)
+% cmake \
+  -S . \
+  -B ../mroonga.doc \
+  --preset=doc \
+  -DMYSQL_SOURCE_DIR=(MySQL_SOURCE_DIRECTORY) \
+  -DMYSQL_BUILD_DIR=(MySQL_BUILD_DIRECTORY) \
+  -DMYSQL_CONFIG=(MySQL_CONFIG)
 ```
 
 Next step is "The things you need to do every tasks".

--- a/doc/source/contribution/documentation.md
+++ b/doc/source/contribution/documentation.md
@@ -71,12 +71,12 @@ Execute following commands to prepare for generating Mroonga documentation.
 
 ```console
 % cmake \
-  -S . \
-  -B ../mroonga.doc \
-  --preset=doc \
-  -DMYSQL_SOURCE_DIR=(MySQL_SOURCE_DIRECTORY) \
-  -DMYSQL_BUILD_DIR=(MySQL_BUILD_DIRECTORY) \
-  -DMYSQL_CONFIG=(MySQL_CONFIG)
+    -S . \
+    -B ../mroonga.doc \
+    --preset=doc \
+    -DMYSQL_SOURCE_DIR=(MySQL_SOURCE_DIRECTORY) \
+    -DMYSQL_BUILD_DIR=(MySQL_BUILD_DIRECTORY) \
+    -DMYSQL_CONFIG=(MySQL_CONFIG)
 ```
 
 Next step is "The things you need to do every tasks".


### PR DESCRIPTION
GitHub: ref GH-707

Update the commands using `CMake` instead of `GNU Autotools`.
Because we will drop using `GNU Autotools` in near future.