### PR TITLE
doc contribution/documentation: update 'confirm generated document'

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation.po
@@ -128,13 +128,13 @@ msgid "Fix typos, styles or write a new document for Mroonga."
 msgstr ""
 
 msgid "Confirm generated document"
-msgstr ""
+msgstr "生成されたドキュメントを確認"
 
-msgid "マークアップに問題がないか、HTMLを確認します。HTMLを生成するには以下のコマンドを実行します。"
-msgstr ""
+msgid "Execute following command to generate HTML files that reflect your changes."
+msgstr "下記のコマンドで、変更内容を反映したHTMLを生成します。"
 
-msgid "いつも使っているブラウザで該当ファイルを確認して、変更した内容が反映されていればOKです。"
-msgstr ""
+msgid "Open the generated file in your Web browser to preview your changes are reflected."
+msgstr "変更が反映されたHTML形式のドキュメントをWebブラウザで確認します。"
 
 msgid "Commit"
 msgstr ""

--- a/doc/source/contribution/documentation.md
+++ b/doc/source/contribution/documentation.md
@@ -115,17 +115,16 @@ Fix typos, styles or write a new document for Mroonga.
 
 ### Confirm generated document
 
-マークアップに問題がないか、HTMLを確認します。HTMLを生成するには以下のコマンドを実行します。
+Execute following command to generate HTML files that reflect your changes.
 
 ```console
-% cd doc/locale/en
-% make html
+% cmake --build ../mroonga.doc
 ```
 
-いつも使っているブラウザで該当ファイルを確認して、変更した内容が反映されていればOKです。
+Open the generated file in your Web browser to preview your changes are reflected.
 
 ```console
-% firefox html/characteristic.html
+% open ../mroonga.doc/doc/en/html/characteristic.html
 ```
 
 ### Commit


### PR DESCRIPTION
GitHub: fix GH-707

Update the commands using CMake instead of GNU Autotools. Because we will drop using GNU Autotools in near future.