### PR TITLE
doc install/others: update MySQL's build step using CMake

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/others.po
+++ b/doc/locale/ja/LC_MESSAGES/install/others.po
@@ -46,17 +46,17 @@ msgstr "シェル（ `dash` 、 `bash` 、 `zsh` など、どのようなシェ�
 msgid "C compiler and C++ compiler (`gcc` and `g++` are supported but other compilers may work)"
 msgstr "CコンパイラーとC++コンパイラー （ `gcc` と `g++` がサポート対象だが、他のコンパイラーでもたぶん大丈夫）"
 
-msgid "`make` (GNU make is supported but other make like BSD make will work)"
-msgstr "`make` （GNU makeがサポート対象だが、BSD makeなど他のmakeでもたぶん大丈夫）"
+msgid "[CMake](https://cmake.org/) as a cross-platform build system generator"
+msgstr "[CMake](https://cmake.org/)（クロスプラットフォームのビルドシステムとして利用するため）"
+
+msgid "[Ninja](https://ninja-build.org/) as a small build system with a focus on speed"
+msgstr "[Ninja](https://ninja-build.org/)（高速にビルドするため）"
 
 msgid "[pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config) for detecting libraries"
-msgstr "[pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config)`（ライブラリを検出するため）"
+msgstr "[pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config)（ライブラリを検出するため）"
 
 msgid "You must get them ready."
 msgstr "これらを用意してください。"
-
-msgid "You can use [CMake](http://www.cmake.org/) instead of shell but this document doesn't describe about building with CMake."
-msgstr "シェルの代わりに [CMake](http://www.cmake.org/)を使うこともできますが、このドキュメントではCMakeを使ってビルドする方法については説明しません。"
 
 msgid "Here are optional tools."
 msgstr "あるとよいツール"
@@ -94,14 +94,14 @@ msgstr "Mroongaはインストール済みのMySQLだけでなくMySQLのソー�
 msgid "If you use MariaDB instead of MySQL, you need MariaDB source."
 msgstr "MySQLの代わりにMariaDBを使う場合でもMariaDBのソースが必要です。"
 
-msgid "Download the latest MySQL 5.6 source code, then build and install it."
-msgstr "MySQL 5.6最新版のソースコードをダウンロードし、ビルド＆インストールして下さい。"
+msgid "Download the latest MySQL 8.4 source code, then build and install it."
+msgstr "MySQL 8.4最新版のソースコードをダウンロードし、ビルド＆インストールして下さい。"
 
 msgid "See also [Download MySQL Community Server](http://dev.mysql.com/downloads/mysql/)"
 msgstr "こちらの[Download MySQL Community Server](http://dev.mysql.com/downloads/mysql/) を参照して下さい。"
 
-msgid "Here we assume that you use mysql-5.6.21 and its source code is extracted in the following directory."
-msgstr "mysql-5.6.21を使用し、以下にソースディレクトリが展開されているものと仮定します。"
+msgid "Here we assume that you use mysql-8.4.1 and its source code is extracted in the following directory."
+msgstr "mysql-8.4.1を使用し、以下にソースディレクトリが展開されているものと仮定します。"
 
 msgid "Then build in the following directory."
 msgstr "次のディレクトリーでビルドします。"

--- a/doc/locale/ja/LC_MESSAGES/install/others.po
+++ b/doc/locale/ja/LC_MESSAGES/install/others.po
@@ -160,8 +160,8 @@ msgstr "MySQLのソースコードをビルドしたディレクトリーを指�
 msgid "If you build MySQL in MySQL source code directory, you don't need to specify this parameter. If you build MySQL in other directory, you need to specify this parameter."
 msgstr "MySQLのソースコードがあるディレクトリーでビルドした場合はこの引数を指定する必要はありません。他のディレクトリーでビルドしたときはこの引数を指定する必要があります。"
 
-msgid "Here is an example when you build MySQL in `/usr/local/src/mysql-8.4.1.build`."
-msgstr "以下は `/usr/local/src/mysql-8.4.1.build` でMySQLをビルドした時の例です。"
+msgid "Here is an example when you build MySQL in `/usr/local/build/mysql-8.4.1`."
+msgstr "以下は `/usr/local/build/mysql-8.4.1` でMySQLをビルドした時の例です。"
 
 msgid "`--with-mysql-config=PATH`"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/install/others.po
+++ b/doc/locale/ja/LC_MESSAGES/install/others.po
@@ -160,8 +160,8 @@ msgstr "MySQLのソースコードをビルドしたディレクトリーを指�
 msgid "If you build MySQL in MySQL source code directory, you don't need to specify this parameter. If you build MySQL in other directory, you need to specify this parameter."
 msgstr "MySQLのソースコードがあるディレクトリーでビルドした場合はこの引数を指定する必要はありません。他のディレクトリーでビルドしたときはこの引数を指定する必要があります。"
 
-msgid "Here is an example when you build MySQL in `/usr/local/build/mysql-8.4.1`."
-msgstr "以下は `/usr/local/build/mysql-8.4.1` でMySQLをビルドした時の例です。"
+msgid "Here is an example when you build MySQL in `$HOME/local/build/mysql-8.4.1`."
+msgstr "以下は `$HOME/local/build/mysql-8.4.1` でMySQLをビルドした時の例です。"
 
 msgid "`--with-mysql-config=PATH`"
 msgstr ""
@@ -193,8 +193,8 @@ msgstr "インストール先となるディレクトリを指定します。Mro
 msgid "The default is `/usr/local`. In this case, `install.sql` that is used for installing Mroonga is installed to `/usr/local/share/mroonga/install.sql`."
 msgstr "デフォルトは `/usr/local` です。この場合、Mroongaをインストールするために使う `install.sql` は `/usr/local/share/mroonga/install.sql` にインストールされます。"
 
-msgid "Here is an example that installs Mroonga into `~/local` for an user use instead of system wide use."
-msgstr "以下はシステム全体にMroongaをインストールするのではなく、ユーザーが個人で使う目的で `~/local` にインストールする例です。"
+msgid "Here is an example that installs Mroonga into `$HOME/local` for an user use instead of system wide use."
+msgstr "以下はシステム全体にMroongaをインストールするのではなく、ユーザーが個人で使う目的で `$HOME/local` にインストールする例です。"
 
 msgid "`PKG_CONFIG_PATH=PATH`"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/install/others.po
+++ b/doc/locale/ja/LC_MESSAGES/install/others.po
@@ -160,8 +160,8 @@ msgstr "MySQLのソースコードをビルドしたディレクトリーを指�
 msgid "If you build MySQL in MySQL source code directory, you don't need to specify this parameter. If you build MySQL in other directory, you need to specify this parameter."
 msgstr "MySQLのソースコードがあるディレクトリーでビルドした場合はこの引数を指定する必要はありません。他のディレクトリーでビルドしたときはこの引数を指定する必要があります。"
 
-msgid "Here is an example when you build MySQL in `/usr/local/build/mysql-5.6.21`."
-msgstr "以下は `/usr/local/build/mysql-5.6.21` でMySQLをビルドした時の例です。"
+msgid "Here is an example when you build MySQL in `/usr/local/src/mysql-8.4.1.build`."
+msgstr "以下は `/usr/local/src/mysql-8.4.1.build` でMySQLをビルドした時の例です。"
 
 msgid "`--with-mysql-config=PATH`"
 msgstr ""

--- a/doc/source/install/others.md
+++ b/doc/source/install/others.md
@@ -60,27 +60,31 @@ Here we assume that you use mysql-8.4.1 and its source code is
 extracted in the following directory.
 
 ```
-/usr/local/src/mysql-8.4.1
+$HOME/local/src/mysql-8.4.1
 ```
 
 Then build in the following directory.
 
 ```
-/usr/local/build/mysql-8.4.1
+$HOME/local/build/mysql-8.4.1
 ```
 
 Here are command lines to build and install MySQL.
 
 ```console
-% sudo cmake -S /usr/local/src/mysql-8.4.1 -B /usr/local/build/mysql-8.4.1 -GNinja
-% sudo cmake --build /usr/local/build/mysql-8.4.1
-% sudo cmake --install /usr/local/build/mysql-8.4.1
+% cmake \
+    -S $HOME/local/src/mysql-8.4.1 \
+    -B $HOME/local/build/mysql-8.4.1 \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX=$HOME/local
+% cmake --build $HOME/local/build/mysql-8.4.1
+% cmake --install $HOME/local/build/mysql-8.4.1
 ```
 
 And we assume that MySQL is installed in the following directory.
 
 ```
-/usr/local
+$HOME/local
 ```
 
 ## Build from source
@@ -93,12 +97,12 @@ steps.
 % tar xvzf mroonga-6.12.tar.gz
 % cd mroonga-6.12
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
-    --with-mysql-build=/usr/local/build/mysql-8.4.1 \
-    --with-mysql-config=/usr/local/bin/mysql_config
+    --with-mysql-source=$HOME/local/src/mysql-8.4.1 \
+    --with-mysql-build=$HOME/local/build/mysql-8.4.1 \
+    --with-mysql-config=$HOME/local/bin/mysql_config
 % make
 % sudo make install
-% /usr/local/bin/mysql -u root < /usr/local/share/mroonga/install.sql
+% $HOME/local/bin/mysql -u root < /usr/local/share/mroonga/install.sql
 ```
 
 You need to specify the following on `configure`.
@@ -143,8 +147,8 @@ This is required parameter.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
-    --with-mysql-config=/usr/local/bin/mysql_config
+    --with-mysql-source=$HOME/local/src/mysql-8.4.1 \
+    --with-mysql-config=$HOME/local/bin/mysql_config
 ```
 
 #### `--with-mysql-build=PATH`
@@ -156,13 +160,13 @@ specify this parameter. If you build MySQL in other directory, you
 need to specify this parameter.
 
 Here is an example when you build MySQL in
-`/usr/local/build/mysql-8.4.1`.
+`$HOME/local/build/mysql-8.4.1`.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
-    --with-mysql-build=/usr/local/build/mysql-8.4.1 \
-    --with-mysql-config=/usr/local/bin/mysql_config
+    --with-mysql-source=$HOME/local/src/mysql-8.4.1 \
+    --with-mysql-build=$HOME/local/build/mysql-8.4.1 \
+    --with-mysql-config=$HOME/local/bin/mysql_config
 ```
 
 #### `--with-mysql-config=PATH`
@@ -176,7 +180,7 @@ this parameter.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-8.4.1
+    --with-mysql-source=$HOME/local/src/mysql-8.4.1
 ```
 
 #### `--with-default-tokenizer=TOKENIZER`
@@ -190,8 +194,8 @@ Here is an example to use `TokenMecab` as the default tokenizer.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
-    --with-mysql-config=/usr/local/bin/mysql_config \
+    --with-mysql-source=$HOME/local/src/mysql-8.4.1 \
+    --with-mysql-config=$HOME/local/bin/mysql_config \
     --with-default-tokenizer=TokenMecab
 ```
 
@@ -206,7 +210,7 @@ The default is `/usr/local`. In this case, `install.sql` that is
 used for installing Mroonga is installed to
 `/usr/local/share/mroonga/install.sql`.
 
-Here is an example that installs Mroonga into `~/local` for an user
+Here is an example that installs Mroonga into `$HOME/local` for an user
 use instead of system wide use.
 
 ```console
@@ -229,8 +233,8 @@ If Groonga is not installed in the standard location like
 ```console
 ./configure \
   PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig \
-  --with-mysql-source=/usr/local/src/mysql-8.4.1 \
-  --with-mysql-config=/usr/local/bin/mysql_config
+  --with-mysql-source=$HOME/local/src/mysql-8.4.1 \
+  --with-mysql-config=$HOME/local/bin/mysql_config
 ```
 
 ### `make`

--- a/doc/source/install/others.md
+++ b/doc/source/install/others.md
@@ -94,12 +94,12 @@ steps.
 % tar xvzf mroonga-6.12.tar.gz
 % cd mroonga-6.12
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-5.6.21 \
-    --with-mysql-build=/usr/local/build/mysql-5.6.21 \
-    --with-mysql-config=/usr/local/mysql/bin/mysql_config
+    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
+    --with-mysql-build=/usr/local/src/mysql-8.4.1.build \
+    --with-mysql-config=/usr/local/bin/mysql_config
 % make
 % sudo make install
-% /usr/local/mysql/bin/mysql -u root < /usr/local/share/mroonga/install.sql
+% /usr/local/bin/mysql -u root < /usr/local/share/mroonga/install.sql
 ```
 
 You need to specify the following on `configure`.
@@ -144,8 +144,8 @@ This is required parameter.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-5.6.21 \
-    --with-mysql-config=/usr/local/mysql/bin/mysql_config
+    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
+    --with-mysql-config=/usr/local/bin/mysql_config
 ```
 
 #### `--with-mysql-build=PATH`
@@ -157,13 +157,13 @@ specify this parameter. If you build MySQL in other directory, you
 need to specify this parameter.
 
 Here is an example when you build MySQL in
-`/usr/local/build/mysql-5.6.21`.
+`/usr/local/src/mysql-8.4.1.build`.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-5.6.21 \
-    --with-mysql-build=/usr/local/build/mysql-5.6.21 \
-    --with-mysql-config=/usr/local/mysql/bin/mysql_config
+    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
+    --with-mysql-build=/usr/local/src/mysql-8.4.1.build \
+    --with-mysql-config=/usr/local/bin/mysql_config
 ```
 
 #### `--with-mysql-config=PATH`
@@ -177,7 +177,7 @@ this parameter.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-5.6.21
+    --with-mysql-source=/usr/local/src/mysql-8.4.1
 ```
 
 #### `--with-default-tokenizer=TOKENIZER`
@@ -191,8 +191,8 @@ Here is an example to use `TokenMecab` as the default tokenizer.
 
 ```console
 % ./configure \
-    --with-mysql-source=/usr/local/src/mysql-5.6.21 \
-    --with-mysql-config=/usr/local/mysql/bin/mysql_config \
+    --with-mysql-source=/usr/local/src/mysql-8.4.1 \
+    --with-mysql-config=/usr/local/bin/mysql_config \
     --with-default-tokenizer=TokenMecab
 ```
 
@@ -213,8 +213,8 @@ use instead of system wide use.
 ```console
 % ./configure \
     --prefix=$HOME/local \
-    --with-mysql-source=$HOME/local/src/mysql-5.6.21 \
-    --with-mysql-config=$HOME/local/mysql/bin/mysql_config
+    --with-mysql-source=$HOME/local/src/mysql-8.4.1 \
+    --with-mysql-config=$HOME/local/bin/mysql_config
 ```
 
 #### `PKG_CONFIG_PATH=PATH`
@@ -230,8 +230,8 @@ If Groonga is not installed in the standard location like
 ```console
 ./configure \
   PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig \
-  --with-mysql-source=/usr/local/src/mysql-5.6.21 \
-  --with-mysql-config=/usr/local/mysql/bin/mysql_config
+  --with-mysql-source=/usr/local/src/mysql-8.4.1 \
+  --with-mysql-config=/usr/local/bin/mysql_config
 ```
 
 ### `make`

--- a/doc/source/install/others.md
+++ b/doc/source/install/others.md
@@ -17,13 +17,11 @@ Here are required tools.
 - `tar` and `gzip` for extracting source archive
 - shell (many shells such as `dash`, `bash` and `zsh` will work)
 - C compiler and C++ compiler (`gcc` and `g++` are supported but other compilers may work)
-- `make` (GNU make is supported but other make like BSD make will work)
+- [CMake](https://cmake.org/) as a cross-platform build system generator
+- [Ninja](https://ninja-build.org/) as a small build system with a focus on speed
 - [pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config) for detecting libraries
 
 You must get them ready.
-
-You can use [CMake](http://www.cmake.org/) instead of shell but this
-document doesn't describe about building with CMake.
 
 Here are optional tools.
 
@@ -54,36 +52,36 @@ source and build directory. You need MySQL source and build directory!
 
 If you use MariaDB instead of MySQL, you need MariaDB source.
 
-Download the latest MySQL 5.6 source code, then build and install it.
+Download the latest MySQL 8.4 source code, then build and install it.
 
 See also [Download MySQL Community Server](http://dev.mysql.com/downloads/mysql/)
 
-Here we assume that you use mysql-5.6.21 and its source code is
+Here we assume that you use mysql-8.4.1 and its source code is
 extracted in the following directory.
 
 ```
-/usr/local/src/mysql-5.6.21
+/usr/local/src/mysql-8.4.1
 ```
 
 Then build in the following directory.
 
 ```
-/usr/local/build/mysql-5.6.21
+/usr/local/src/mysql-8.4.1.build
 ```
 
 Here are command lines to build and install MySQL.
 
 ```console
-% cd /usr/local/build/mysql-5.6.21
-% cmake /usr/local/src/mysql-5.6.21
-% make
-% sudo make install
+% cd /usr/local/src/mysql-8.4.1
+% cmake -S . -B ../mysql-8.4.1.build -GNinja
+% cmake --build ../mysql-8.4.1.build
+% sudo cmake --install ../mysql-8.4.1.build
 ```
 
 And we assume that MySQL is installed in the following directory.
 
 ```
-/usr/local/mysql
+/usr/local/bin/mysql
 ```
 
 ## Build from source

--- a/doc/source/install/others.md
+++ b/doc/source/install/others.md
@@ -66,16 +66,15 @@ extracted in the following directory.
 Then build in the following directory.
 
 ```
-/usr/local/src/mysql-8.4.1.build
+/usr/local/build/mysql-8.4.1
 ```
 
 Here are command lines to build and install MySQL.
 
 ```console
-% cd /usr/local/src/mysql-8.4.1
-% cmake -S . -B ../mysql-8.4.1.build -GNinja
-% cmake --build ../mysql-8.4.1.build
-% sudo cmake --install ../mysql-8.4.1.build
+% sudo cmake -S /usr/local/src/mysql-8.4.1 -B /usr/local/build/mysql-8.4.1 -GNinja
+% sudo cmake --build /usr/local/build/mysql-8.4.1
+% sudo cmake --install /usr/local/build/mysql-8.4.1
 ```
 
 And we assume that MySQL is installed in the following directory.
@@ -95,7 +94,7 @@ steps.
 % cd mroonga-6.12
 % ./configure \
     --with-mysql-source=/usr/local/src/mysql-8.4.1 \
-    --with-mysql-build=/usr/local/src/mysql-8.4.1.build \
+    --with-mysql-build=/usr/local/build/mysql-8.4.1 \
     --with-mysql-config=/usr/local/bin/mysql_config
 % make
 % sudo make install
@@ -157,12 +156,12 @@ specify this parameter. If you build MySQL in other directory, you
 need to specify this parameter.
 
 Here is an example when you build MySQL in
-`/usr/local/src/mysql-8.4.1.build`.
+`/usr/local/build/mysql-8.4.1`.
 
 ```console
 % ./configure \
     --with-mysql-source=/usr/local/src/mysql-8.4.1 \
-    --with-mysql-build=/usr/local/src/mysql-8.4.1.build \
+    --with-mysql-build=/usr/local/build/mysql-8.4.1 \
     --with-mysql-config=/usr/local/bin/mysql_config
 ```
 

--- a/doc/source/install/others.md
+++ b/doc/source/install/others.md
@@ -81,7 +81,7 @@ Here are command lines to build and install MySQL.
 And we assume that MySQL is installed in the following directory.
 
 ```
-/usr/local/bin/mysql
+/usr/local
 ```
 
 ## Build from source


### PR DESCRIPTION
GtiHub: ref GH-710

We will drop using GNU Autotools in near future. That's why we should update documentation using CMake.

- [x] 2.11.1.3. MySQL <- This PR is here!
- [ ] 2.11.2. Build from source
- [ ] 2.11.2.1.1. --with-mysql-source=PATH
- [ ] 2.11.2.1.2. --with-mysql-build=PATH
- [ ] 2.11.2.1.3. --with-mysql-config=PATH
- [ ] 2.11.2.1.4. --with-default-tokenizer=TOKENIZER
- [ ] 2.11.2.1.5. --prefix=PATH
- [ ] 2.11.2.1.6. PKG_CONFIG_PATH=PATH
- [ ] 2.11.2.2. make
- [ ] 2.11.2.3. make install