### PR TITLE
ci ubuntu: add missing test for Ubuntu 20.04 (focal) with mysql-8.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -168,6 +168,9 @@ jobs:
             test-image: "images:ubuntu/24.04"
 
           # MySQL 8.0
+          - os: ubuntu-focal
+            package: mysql-8.0
+            test-image: "images:ubuntu/20.04"
           - os: ubuntu-jammy
             package: mysql-8.0
             test-image: "images:ubuntu/22.04"

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-focal/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-focal/Dockerfile
@@ -1,0 +1,55 @@
+ARG FROM=ubuntu:focal
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  grep '^deb ' /etc/apt/sources.list | \
+    sed -e 's/^deb /deb-src /' > /etc/apt/sources.list.d/base-source.list && \
+  apt update ${quiet} && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    ca-certificates \
+    gpg-agent \
+    lsb-release \
+    software-properties-common \
+    wget && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  apt install -y -V ${quiet} \
+    autoconf-archive \
+    build-essential \
+    ccache \
+    chrpath \
+    cmake \
+    debhelper \
+    devscripts \
+    dh-apparmor \
+    groonga-normalizer-mysql \
+    libcurl4-openssl-dev \
+    libaio-dev \
+    libedit-dev \
+    libevent-dev \
+    libgroonga-dev \
+    libicu-dev \
+    liblz4-dev \
+    libmecab-dev \
+    libmysqlclient-dev \
+    libncurses5-dev \
+    libpcre3-dev \
+    libprotobuf-dev \
+    libprotoc-dev \
+    libreadline-dev \
+    libssl-dev \
+    libxml2-dev \
+    libre2-dev \
+    libwrap0-dev \
+    lsb-release \
+    mecab-utils \
+    pkg-config \
+    protobuf-compiler \
+    unixodbc-dev \
+    wget

--- a/packages/mysql-8.0-mroonga/apt/ubuntu-focal/Dockerfile
+++ b/packages/mysql-8.0-mroonga/apt/ubuntu-focal/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     libprotoc-dev \
     libreadline-dev \
     libssl-dev \
+    libtirpc-dev \
     libxml2-dev \
     libre2-dev \
     libwrap0-dev \


### PR DESCRIPTION
This PR support Mroonga on Ubuntu 20.04 with mysql-8.0.
This PR doesn't support Ubuntu 20.04 with mysql-community-8.0.

I will support Ubuntu 20.04 with mysql-community-8.0 in the other PR.
