### PR TITLE
ci ubuntu: add missing test for Ubuntu 20.04 (focal) with mysql-community-8.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -188,6 +188,9 @@ jobs:
           - os: debian-bookworm
             package: mysql-community-8.0
             test-image: "images:debian/12"
+          - os: ubuntu-focal
+            package: mysql-community-8.0
+            test-image: "images:ubuntu/20.04"
           - os: ubuntu-jammy
             package: mysql-community-8.0
             test-image: "images:ubuntu/22.04"

--- a/packages/mysql-community-8.0-mroonga/Rakefile
+++ b/packages/mysql-community-8.0-mroonga/Rakefile
@@ -8,6 +8,7 @@ class MySQLCommunity80MroongaPackageTask < MroongaPackageTask
   def apt_targets_default
     [
       "debian-bookworm",
+      "ubuntu-focal",
       "ubuntu-jammy",
       "ubuntu-noble",
     ]

--- a/packages/mysql-community-8.0-mroonga/apt/ubuntu-focal/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/ubuntu-focal/Dockerfile
@@ -1,0 +1,45 @@
+ARG FROM=ubuntu:focal
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ENV \
+  DEBIAN_FRONTEND=noninteractive \
+  MYSQL_SERVER_VERSION=mysql-8.0
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    ca-certificates \
+    gpg-agent \
+    lsb-release \
+    software-properties-common \
+    wget && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    ./*.deb && \
+  rm *.deb && \
+  apt update ${quiet} && \
+  apt build-dep -y --no-install-recommends ${quiet} \
+    mysql-community && \
+  apt source ${quiet} \
+    mysql-community && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    build-essential \
+    ccache \
+    devscripts \
+    dh-apparmor \
+    groonga-normalizer-mysql \
+    libgroonga-dev \
+    libmysqlclient-dev && \
+  mkdir -p /usr/global/share && \
+  wget --no-verbose \
+    https://packages.groonga.org/tmp/boost/boost_1_77_0.tar.bz2 && \
+  mv boost_1_77_0.tar.bz2 /usr/global/share/


### PR DESCRIPTION
This PR build and test the package of Mroonga for Ubntu 20.04 with mysql-community-8.0 same as the following tests.

* https://github.com/mroonga/mroonga/actions/runs/10293925162/job/28491156447
* https://github.com/mroonga/mroonga/actions/runs/10293925162/job/28491156618