### PR TITLE
mariadb: add support for MariaDB 10.11.9/10.6.19/10.6.26

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -3752,12 +3752,12 @@ int ha_mroonga::create_share_for_create() const
   }
   mrn_init_alloc_root(&mem_root_for_create, "mroonga::create", 1024, 0, MYF(0));
   analyzed_for_create = true;
-  if (lex->query_tables && lex->query_tables->get_table_name()) {
+  if (lex->query_tables && MRN_GET_TABLE_NAME(lex->query_tables)) {
     share_for_create.table_name =
-      mrn_my_strdup(lex->query_tables->get_table_name(),
+      mrn_my_strdup(MRN_GET_TABLE_NAME(lex->query_tables),
                     MYF(MY_WME));
     share_for_create.table_name_length =
-      strlen(lex->query_tables->get_table_name());
+      MRN_GET_TABLE_LENGTH(lex->query_tables);
   }
   share_for_create.table_share = &table_share_for_create;
   table_for_create.s = &table_share_for_create;
@@ -11646,10 +11646,10 @@ bool ha_mroonga::check_fast_order_limit(grn_obj *result_set,
     !query_block->group_list.elements &&
     !MRN_QUERY_BLOCK_GET_HAVING_COND(query_block) &&
     MRN_QUERY_BLOCK_GET_TABLE_LIST(query_block).elements == 1 &&
-    strcmp(MRN_QUERY_BLOCK_GET_TABLE_LIST(query_block).first->get_db_name(),
-           table_list->get_db_name()) == 0 &&
-    strcmp(MRN_QUERY_BLOCK_GET_TABLE_LIST(query_block).first->get_table_name(),
-           table_list->get_table_name()) == 0 &&
+    strcmp(MRN_GET_DB_NAME(MRN_QUERY_BLOCK_GET_TABLE_LIST(query_block).first),
+           MRN_GET_DB_NAME(table_list)) == 0 &&
+    strcmp(MRN_GET_TABLE_NAME(MRN_QUERY_BLOCK_GET_TABLE_LIST(query_block).first),
+           MRN_GET_TABLE_NAME(table_list)) == 0 &&
     query_block->order_list.elements &&
     MRN_QUERY_BLOCK_HAS_LIMIT(query_block) &&
     MRN_QUERY_BLOCK_SELECT_LIMIT(query_block) &&

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -3757,7 +3757,7 @@ int ha_mroonga::create_share_for_create() const
       mrn_my_strdup(MRN_GET_TABLE_NAME(lex->query_tables),
                     MYF(MY_WME));
     share_for_create.table_name_length =
-      MRN_GET_TABLE_LENGTH(lex->query_tables);
+      MRN_GET_TABLE_NAME_LENGTH(lex->query_tables);
   }
   share_for_create.table_share = &table_share_for_create;
   table_for_create.s = &table_share_for_create;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -988,5 +988,5 @@ typedef uint mrn_srid;
   (table_list->get_db_name().str)
 #else
 #  define MRN_GET_DB_NAME(table_list)                              \
-  (table_list->get_db_name().str)
+  (table_list->get_db_name())
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -969,14 +969,14 @@ typedef uint mrn_srid;
      (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200))
 #  define MRN_GET_TABLE_NAME(query_tables)                         \
   (query_tables->get_table_name().str)
-#  define MRN_GET_TABLE_LENGTH(query_tables)                       \
+#  define MRN_GET_TABLE_NAME_LENGTH(query_tables)                       \
   (query_tables->get_table_name().length)
 #  define MRN_GET_DB_NAME(table_list)                              \
   (table_list->get_db_name().str)
 #else
 #  define MRN_GET_TABLE_NAME(query_tables)                         \
   (query_tables->get_table_name())
-#  define MRN_GET_TABLE_LENGTH(query_tables)                       \
+#  define MRN_GET_TABLE_NAME_LENGTH(query_tables)                       \
   (strlen(query_tables->get_table_name()))
 #  define MRN_GET_DB_NAME(table_list)                              \
   (table_list->get_db_name())

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -972,21 +972,13 @@ typedef uint mrn_srid;
   (query_tables->get_table_name().str)
 #  define MRN_GET_TABLE_LENGTH(query_tables)                       \
   (query_tables->get_table_name().length)
+#  define MRN_GET_DB_NAME(table_list)                              \
+  (table_list->get_db_name().str)
 #else
 #  define MRN_GET_TABLE_NAME(query_tables)                         \
   (query_tables->get_table_name())
 #  define MRN_GET_TABLE_LENGTH(query_tables)                       \
   (strlen(query_tables->get_table_name()))
-#endif
-
-#if defined(MRN_MARIADB_P) &&                                      \
-    ((MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) ||  \
-     (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) ||  \
-     (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200))
-
-#  define MRN_GET_DB_NAME(table_list)                              \
-  (table_list->get_db_name().str)
-#else
 #  define MRN_GET_DB_NAME(table_list)                              \
   (table_list->get_db_name())
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -967,7 +967,6 @@ typedef uint mrn_srid;
     ((MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) ||  \
      (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) ||  \
      (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200))
-
 #  define MRN_GET_TABLE_NAME(query_tables)                         \
   (query_tables->get_table_name().str)
 #  define MRN_GET_TABLE_LENGTH(query_tables)                       \

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -962,3 +962,33 @@ typedef uint mrn_srid;
 #  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code)     \
   my_message(error_code, ctx->errbuf, MYF(0))
 #endif
+
+#ifdef MRN_MARIADB_P
+#  if (MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) || \
+      (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) || \
+      (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200)
+
+#    define MRN_GET_TABLE_NAME(query_tables)                       \
+  (query_tables->get_table_name().str)
+#    define MRN_GET_TABLE_LENGTH(query_tables)                     \
+  (query_tables->get_table_name().length)
+#  else
+#    define MRN_GET_TABLE_NAME(query_tables)                       \
+  (query_tables->get_table_name())
+#    define MRN_GET_TABLE_LENGTH(query_tables)                     \
+  (strlen(query_tables->get_table_name()))
+#  endif
+#endif
+
+#ifdef MRN_MARIADB_P
+#  if (MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) || \
+      (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) || \
+      (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200)
+
+#    define MRN_GET_DB_NAME(table_list)                            \
+  (table_list->get_db_name().str)
+#  else
+#    define MRN_GET_DB_NAME(table_list)                            \
+  (table_list->get_db_name().str)
+#  endif
+#endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -963,32 +963,30 @@ typedef uint mrn_srid;
   my_message(error_code, ctx->errbuf, MYF(0))
 #endif
 
-#ifdef MRN_MARIADB_P
-#  if (MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) || \
-      (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) || \
-      (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200)
+#if defined(MRN_MARIADB_P) &&                                      \
+    ((MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) ||  \
+     (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) ||  \
+     (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200))
 
-#    define MRN_GET_TABLE_NAME(query_tables)                       \
+#  define MRN_GET_TABLE_NAME(query_tables)                         \
   (query_tables->get_table_name().str)
-#    define MRN_GET_TABLE_LENGTH(query_tables)                     \
+#  define MRN_GET_TABLE_LENGTH(query_tables)                       \
   (query_tables->get_table_name().length)
-#  else
-#    define MRN_GET_TABLE_NAME(query_tables)                       \
+#else
+#  define MRN_GET_TABLE_NAME(query_tables)                         \
   (query_tables->get_table_name())
-#    define MRN_GET_TABLE_LENGTH(query_tables)                     \
+#  define MRN_GET_TABLE_LENGTH(query_tables)                       \
   (strlen(query_tables->get_table_name()))
-#  endif
 #endif
 
-#ifdef MRN_MARIADB_P
-#  if (MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) || \
-      (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) || \
-      (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200)
+#if defined(MRN_MARIADB_P) &&                                      \
+    ((MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) ||  \
+     (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) ||  \
+     (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200))
 
-#    define MRN_GET_DB_NAME(table_list)                            \
+#  define MRN_GET_DB_NAME(table_list)                              \
   (table_list->get_db_name().str)
-#  else
-#    define MRN_GET_DB_NAME(table_list)                            \
+#else
+#  define MRN_GET_DB_NAME(table_list)                              \
   (table_list->get_db_name().str)
-#  endif
 #endif

--- a/packages/mariadb-10.11-mroonga/yum/mariadb-10.11-mroonga.spec.in
+++ b/packages/mariadb-10.11-mroonga/yum/mariadb-10.11-mroonga.spec.in
@@ -1,6 +1,6 @@
 # -*- sh-shell: rpm -*-
 
-%define mariadb_version_default 10.11.8
+%define mariadb_version_default 10.11.9
 %define mariadb_release_default 1
 %if %{rhel} == 7
 %define mariadb_dist_default    el%{rhel}.centos
@@ -24,7 +24,7 @@
 
 Name:		mariadb-10.11-mroonga
 Version:	@VERSION@
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	A fast fulltext searchable storage engine for MariaDB
 
 Group:		Applications/Databases
@@ -128,6 +128,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc mroonga-doc/*
 
 %changelog
+* Fri Aug 09 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-2
+- Rebuild against MariaDB 10.11.9.
+
 * Mon Jun 17 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-1
 - New upstream release.
 

--- a/packages/mariadb-10.5-mroonga/yum/mariadb-10.5-mroonga.spec.in
+++ b/packages/mariadb-10.5-mroonga/yum/mariadb-10.5-mroonga.spec.in
@@ -3,7 +3,7 @@
 %define mariadb_package MariaDB
 %define mariadb_client_package %{mariadb_package}-client
 #%%define mariadb_epoch_default
-%define mariadb_version_default 10.5.25
+%define mariadb_version_default 10.5.26
 %define mariadb_release_default 1
 %if %{rhel} == 7
   %define mariadb_dist_default    el%{rhel}.centos
@@ -29,7 +29,7 @@
 
 Name:		mariadb-10.5-mroonga
 Version:	@VERSION@
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	A fast fulltext searchable storage engine for MariaDB
 
 Group:		Applications/Databases
@@ -146,6 +146,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc mroonga-doc/*
 
 %changelog
+* Fri Aug 09 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-2
+- Rebuild against MariaDB 10.5.26.
+
 * Mon Jun 17 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-1
 - New upstream release.
 

--- a/packages/mariadb-10.6-mroonga/yum/mariadb-10.6-mroonga.spec.in
+++ b/packages/mariadb-10.6-mroonga/yum/mariadb-10.6-mroonga.spec.in
@@ -2,7 +2,7 @@
 
 %define _centos_ver %{?centos_ver:%{centos_ver}}%{!?centos_ver:7}
 
-%define mariadb_version_default 10.6.18
+%define mariadb_version_default 10.6.19
 %define mariadb_release_default 1
 %if %{_centos_ver} == 7
 %define mariadb_dist_default    el%{_centos_ver}.centos
@@ -26,7 +26,7 @@
 
 Name:		mariadb-10.6-mroonga
 Version:	@VERSION@
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	A fast fulltext searchable storage engine for MariaDB
 
 Group:		Applications/Databases
@@ -130,6 +130,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc mroonga-doc/*
 
 %changelog
+* Fri Aug 09 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-2
+- Rebuild against MariaDB 10.6.19.
+
 * Mon Jun 17 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-1
 - New upstream release.
 


### PR DESCRIPTION
Because MariaDB 10.11.9, 10.6.19, and 10.5.26 have been released.

However, the current version of Mroonga with the above MariaDBs fail build as below.

```
ha_mroonga.cpp: In member function ‘int ha_mroonga::create_share_for_create() const’:
ha_mroonga.cpp:3755:25: error: no match for ‘operator&&’ (operand types are ‘TABLE_LIST*’ and ‘const LEX_CSTRING’ {aka ‘const st_mysql_const_lex_string’})
 3755 |   if (lex->query_tables && lex->query_tables->get_table_name()) {
      |       ~~~~~~~~~~~~~~~~~ ^~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |            |                                                |
      |            TABLE_LIST*                                      const LEX_CSTRING {aka const st_mysql_const_lex_string}
ha_mroonga.cpp:3755:25: note: candidate: ‘operator&&(bool, bool)’ (built-in)
```

Because theses versions modify return value type of `get_table_name()` and `get_db_name()` in https://github.com/MariaDB/server/commit/310fd6ff695541247db766baf3ade1e3b4db16e9.

The return type of `get_table_name()` and `get_db_name()` change to `const LEX_CSTRING` from `const char *` as below.

```diff
-  const char *get_table_name() const { return view != NULL ? view_name.str : table_name.str; }
+  const LEX_CSTRING get_table_name() const
+  {
+    return view != NULL ? view_name : table_name;
+  }
```

```diff
-  const char *get_db_name() const { return view != NULL ? view_db.str : db.str; }
+ const LEX_CSTRING get_db_name() const
+ {
+   return view != NULL ? view_db : db;
+ }
```

I deal with these modifications in this PR.