### PR TITLE
mariadb 11.0: Use IO_AND_COST type instead of double

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14894,9 +14894,9 @@ int ha_mroonga::truncate(
 }
 
 #ifdef MRN_ENABLE_WRAPPER_MODE
-double ha_mroonga::wrapper_scan_time()
+mrn_io_and_cpu_cost ha_mroonga::wrapper_scan_time()
 {
-  double res;
+  mrn_io_and_cpu_cost res;
   MRN_DBUG_ENTER_METHOD();
   MRN_SET_WRAP_SHARE_KEY(share, table->s);
   MRN_SET_WRAP_TABLE_KEY(this, table);
@@ -14907,17 +14907,17 @@ double ha_mroonga::wrapper_scan_time()
 }
 #endif
 
-double ha_mroonga::storage_scan_time()
+mrn_io_and_cpu_cost ha_mroonga::storage_scan_time()
 {
   MRN_DBUG_ENTER_METHOD();
-  double time = handler::scan_time();
+  mrn_io_and_cpu_cost time = handler::scan_time();
   DBUG_RETURN(time);
 }
 
-double ha_mroonga::scan_time()
+mrn_io_and_cpu_cost ha_mroonga::scan_time()
 {
   MRN_DBUG_ENTER_METHOD();
-  double time;
+  mrn_io_and_cpu_cost time;
 #ifdef MRN_ENABLE_WRAPPER_MODE
   if (share->wrapper_mode)
   {

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -692,7 +692,7 @@ public:
                            uint child_key_name_len) mrn_override;
 #endif
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg) mrn_override;
-  double scan_time() mrn_override;
+  mrn_io_and_cpu_cost scan_time() mrn_override;
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
   longlong get_memory_buffer_size() const mrn_override;
@@ -1514,9 +1514,9 @@ private:
 #endif
   void storage_change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg);
 #ifdef MRN_ENABLE_WRAPPER_MODE
-  double wrapper_scan_time();
+  mrn_io_and_cpu_cost wrapper_scan_time();
 #endif
-  double storage_scan_time();
+  mrn_io_and_cpu_cost storage_scan_time();
 #ifdef MRN_ENABLE_WRAPPER_MODE
   double wrapper_read_time(uint index, uint ranges, ha_rows rows);
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -981,3 +981,10 @@ typedef uint mrn_srid;
 #  define MRN_GET_DB_NAME(table_list)                              \
   (table_list->get_db_name())
 #endif
+
+#if defined(MRN_MARIADB_P) &&                                   \
+    (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
+  using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
+#else
+  using mrn_io_and_cpu_cost = double;
+#endif


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.0.4 LTS.

I fail to build of Mroonga with MariaDB 11.0.4 by the following error.

```
n file included from mroonga.dev/ha_mroonga.cpp:108:
mroonga.dev/ha_mroonga.hpp:695:10: error: conflicting return type specified for ‘virtual double ha_mroonga::scan_time()’
  695 |   double scan_time() mrn_override;
      |          ^~~~~~~~~
In file included from /mariadb-11.4.2/sql/log.h:20,
                 from /mariadb-11.4.2/sql/sql_class.h:29,
                 from /mroonga.dev/mrn_mysql.h:57,
                 from /mroonga.dev/ha_mroonga.cpp:25:
/mariadb-11.4.2/sql/handler.h:3765:27: note: overridden function is ‘virtual IO_AND_CPU_COST handler::scan_time()’
 3765 |   virtual IO_AND_CPU_COST scan_time()
      |                           ^~~~~~~~~
```

The cause of this error by the following MaraiDB's modification.
https://github.com/MariaDB/server/commit/b66cdbd1eaeed7e96317a03a190c496fd062ec71

I use alias of type name as below to fix this error and maintain backward compatibility.

```c
#if defined(MRN_MARIADB_P) &&                                   \
    (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
  using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
#else
  using mrn_io_and_cpu_cost = double;
#endif
```