### PR TITLE
mariaddb 11.0: add a new argument into handler::multi_range_read_info_const()

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14178,6 +14178,9 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                                        ha_rows limit,
+#  endif
                                                         Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14185,7 +14188,11 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
   KEY *key_info = &(table->key_info[keyno]);
   if (mrn_is_geo_key(key_info)) {
     rows = handler::multi_range_read_info_const(keyno, seq, seq_init_param,
-                                                n_ranges, bufsz, flags, cost);
+                                                n_ranges, bufsz, flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                                limit,
+#  endif
+                                                cost);
     DBUG_RETURN(rows);
   }
   MRN_SET_WRAP_SHARE_KEY(share, table->s);
@@ -14194,6 +14201,9 @@ ha_rows ha_mroonga::wrapper_multi_range_read_info_const(uint keyno,
     set_pk_bitmap();
   rows = wrap_handler->multi_range_read_info_const(keyno, seq, seq_init_param,
                                                    n_ranges, bufsz, flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                                   limit,
+#  endif
                                                    cost);
   MRN_SET_BASE_SHARE_KEY(share, table->s);
   MRN_SET_BASE_TABLE_KEY(this, table);
@@ -14207,12 +14217,18 @@ ha_rows ha_mroonga::storage_multi_range_read_info_const(uint keyno,
                                                         uint n_ranges,
                                                         uint *bufsz,
                                                         uint *flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                                        ha_rows limit,
+#  endif
                                                         Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
   ha_rows rows = handler::multi_range_read_info_const(keyno, seq,
                                                       seq_init_param,
                                                       n_ranges, bufsz, flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                                      limit,
+#  endif
                                                       cost);
   DBUG_RETURN(rows);
 }
@@ -14221,6 +14237,9 @@ ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                                 void *seq_init_param,
                                                 uint n_ranges, uint *bufsz,
                                                 uint *flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                                ha_rows limit,
+#  endif
                                                 Cost_estimate *cost)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14229,13 +14248,19 @@ ha_rows ha_mroonga::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   if (share->wrapper_mode)
   {
     rows = wrapper_multi_range_read_info_const(keyno, seq, seq_init_param,
-                                               n_ranges, bufsz,
-                                               flags, cost);
+                                               n_ranges, bufsz, flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                               limit,
+#  endif
+                                               cost);
   } else {
 #endif
     rows = storage_multi_range_read_info_const(keyno, seq, seq_init_param,
-                                               n_ranges, bufsz,
-                                               flags, cost);
+                                               n_ranges, bufsz, flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                               limit,
+#  endif
+                                               cost);
 #ifdef MRN_ENABLE_WRAPPER_MODE
   }
 #endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -706,6 +706,9 @@ public:
                                       uint n_ranges,
                                       uint *bufsz,
                                       uint *flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                      ha_rows limit,
+#  endif
                                       Cost_estimate *cost) mrn_override;
   ha_rows multi_range_read_info(uint keyno,
                                 uint n_ranges,
@@ -1540,6 +1543,9 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                              ha_rows limit,
+#  endif
                                               Cost_estimate *cost);
 #endif
   ha_rows storage_multi_range_read_info_const(uint keyno,
@@ -1548,6 +1554,9 @@ private:
                                               uint n_ranges,
                                               uint *bufsz,
                                               uint *flags,
+#  ifdef MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+                                              ha_rows limit,
+#  endif
                                               Cost_estimate *cost);
 #ifdef MRN_ENABLE_WRAPPER_MODE
   ha_rows wrapper_multi_range_read_info(uint keyno, uint n_ranges, uint keys,

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -985,6 +985,7 @@ typedef uint mrn_srid;
 #if defined(MRN_MARIADB_P) &&                                   \
     (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
+#  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #else
   using mrn_io_and_cpu_cost = double;
 #endif


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.0.4 LTS.

I fail to build of Mroonga with MariaDB 11.0.4 by the following error.

```
/mroonga.dev/ha_mroonga.cpp:14187:48: error: no matching function for call to ‘ha_mroonga::multi_range_read_info_const(uint&, RANGE_SEQ_IF*&, void*&, uint&, uint*&, uint*&, Cost_estimate*&)’
14187 |     rows = handler::multi_range_read_info_const(keyno, seq, seq_init_param,
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
14188 |                                                 n_ranges, bufsz, flags, cost);
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /mariadb-11.4.2/sql/log.h:20,
                 from /mariadb-11.4.2/sql/sql_class.h:29,
                 from /mroonga.dev/mrn_mysql.h:57,
                 from /mroonga.dev/ha_mroonga.cpp:25:
/mariadb-11.4.2/sql/handler.h:4260:19: note: candidate: ‘virtual ha_rows handler::multi_range_read_info_const(uint, RANGE_SEQ_IF*, void*, uint, uint*, uint*, ha_rows, Cost_estimate*)’
 4260 |   virtual ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/mariadb-11.4.2/sql/handler.h:4260:19: note:   candidate expects 8 arguments, 7 provided
/mroonga.dev/ha_mroonga.cpp:14195:51: error: no matching function for call to ‘handler::multi_range_read_info_const(uint&, RANGE_SEQ_IF*&, void*&, uint&, uint*&, uint*&, Cost_estimate*&)’
14195 |   rows = wrap_handler->multi_range_read_info_const(keyno, seq, seq_init_param,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
14196 |                                                    n_ranges, bufsz, flags,
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~
14197 |                                                    cost);
      |                                                    ~~~~~
/mariadb-11.4.2/sql/handler.h:4260:19: note: candidate: ‘virtual ha_rows handler::multi_range_read_info_const(uint, RANGE_SEQ_IF*, void*, uint, uint*, uint*, ha_rows, Cost_estimate*)’
 4260 |   virtual ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/mariadb-11.4.2/sql/handler.h:4260:19: note:   candidate expects 8 arguments, 7 provided
/mroonga.dev/ha_mroonga.cpp: In member function ‘ha_rows ha_mroonga::storage_multi_range_read_info_const(uint, RANGE_SEQ_IF*, void*, uint, uint*, uint*, Cost_estimate*)’:
/mroonga.dev/ha_mroonga.cpp:14213:54: error: no matching function for call to ‘ha_mroonga::multi_range_read_info_const(uint&, RANGE_SEQ_IF*&, void*&, uint&, uint*&, uint*&, Cost_estimate*&)’
14213 |   ha_rows rows = handler::multi_range_read_info_const(keyno, seq,
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
14214 |                                                       seq_init_param,
      |                                                       ~~~~~~~~~~~~~~~
14215 |                                                       n_ranges, bufsz, flags,
      |                                                       ~~~~~~~~~~~~~~~~~~~~~~~
14216 |                                                       cost);
      |                                                       ~~~~~
/mariadb-11.4.2/sql/handler.h:4260:19: note: candidate: ‘virtual ha_rows handler::multi_range_read_info_const(uint, RANGE_SEQ_IF*, void*, uint, uint*, uint*, ha_rows, Cost_estimate*)’
 4260 |   virtual ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The cause of this error by the following MaraiDB's modification.
https://github.com/MariaDB/server/commit/009db2288ba8d22c5e8e5e047d8f8694f7097923

I define  `MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT` to fix this error and maintain backward compatibility.
However, This modification is difficult to read...