### PR TITLE
mariadb 11.4: follow enable_indexes() and disable_indexes() API change

### DIFF
--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -392,7 +392,8 @@ typedef uint mrn_alter_table_flags;
 #if defined(MRN_MARIADB_P) &&                                                  \
     ((MYSQL_VERSION_ID >= 100525 && MYSQL_VERSION_ID < 100600) ||              \
      (MYSQL_VERSION_ID >= 100618 && MYSQL_VERSION_ID < 100700) ||              \
-     (MYSQL_VERSION_ID >= 101108 && MYSQL_VERSION_ID < 101200))
+     (MYSQL_VERSION_ID >= 101108 && MYSQL_VERSION_ID < 101200) ||              \
+     (MYSQL_VERSION_ID >= 110402 && MYSQL_VERSION_ID < 110500))
 #  define MRN_HANDLER_ENABLE_INDEXES_PARAMETERS key_map map, bool persist
 #  define MRN_HANDLER_DISABLE_INDEXES_PARAMETERS key_map map, bool persist
 #  define MRN_HANDLER_ENABLE_INDEXES_ALL_ARGS key_map(table->s->keys), false

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -393,7 +393,7 @@ typedef uint mrn_alter_table_flags;
     ((MYSQL_VERSION_ID >= 100525 && MYSQL_VERSION_ID < 100600) ||              \
      (MYSQL_VERSION_ID >= 100618 && MYSQL_VERSION_ID < 100700) ||              \
      (MYSQL_VERSION_ID >= 101108 && MYSQL_VERSION_ID < 101200) ||              \
-     (MYSQL_VERSION_ID >= 110402 && MYSQL_VERSION_ID < 110500))
+     (MYSQL_VERSION_ID >= 110402))
 #  define MRN_HANDLER_ENABLE_INDEXES_PARAMETERS key_map map, bool persist
 #  define MRN_HANDLER_DISABLE_INDEXES_PARAMETERS key_map map, bool persist
 #  define MRN_HANDLER_ENABLE_INDEXES_ALL_ARGS key_map(table->s->keys), false


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.4 LTS.

I fail to build of Mroonga with MariaDB 11.4.2 by the following error.

```
/mroonga.dev/ha_mroonga.cpp: In member function ‘int ha_mroonga::wrapper_open(const char*, int, uint)’:
/mroonga.dev/ha_mroonga.hpp:418:48: error: ‘HA_KEY_SWITCH_ALL’ was not declared in this scope
  418 | #  define MRN_HANDLER_DISABLE_INDEXES_ALL_ARGS HA_KEY_SWITCH_ALL
      |                                                ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:418:48: note: in definition of macro ‘MRN_HANDLER_DISABLE_INDEXES_ALL_ARGS’
  418 | #  define MRN_HANDLER_DISABLE_INDEXES_ALL_ARGS HA_KEY_SWITCH_ALL
      |                                                ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.cpp: In member function ‘int ha_mroonga::wrapper_disable_indexes_mroonga(uint)’:
/mroonga.dev/ha_mroonga.hpp:424:15: error: ‘HA_KEY_SWITCH_NONUNIQ_SAVE’ was not declared in this scope
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:424:15: note: in definition of macro ‘MRN_HANDLER_DISABLE_INDEXES_NEED_TO_EXECUTE’
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:424:53: error: ‘HA_KEY_SWITCH_ALL’ was not declared in this scope
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:424:53: note: in definition of macro ‘MRN_HANDLER_DISABLE_INDEXES_NEED_TO_EXECUTE’
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.cpp: In member function ‘int ha_mroonga::wrapper_disable_indexes(uint)’:
/mroonga.dev/ha_mroonga.cpp:15805:43: error: no matching function for call to ‘handler::ha_disable_indexes(uint&)’
15805 |   error = wrap_handler->ha_disable_indexes(MRN_HANDLER_DISABLE_INDEXES_FORWARD_ARGS);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /mariadb-11.4.2/sql/log.h:20,
                 from /mariadb-11.4.2/sql/sql_class.h:29,
                 from /mroonga.dev/mrn_mysql.h:57,
                 from /mroonga.dev/ha_mroonga.cpp:25:
/mariadb-11.4.2/sql/handler.h:3633:7: note: candidate: ‘int handler::ha_disable_indexes(key_map, bool)’
 3633 |   int ha_disable_indexes(key_map map, bool persist);
      |       ^~~~~~~~~~~~~~~~~~
/mariadb-11.4.2/sql/handler.h:3633:7: note:   candidate expects 2 arguments, 1 provided
/mroonga.dev/ha_mroonga.cpp: In member function ‘int ha_mroonga::storage_disable_indexes(uint)’:
/mroonga.dev/ha_mroonga.hpp:424:15: error: ‘HA_KEY_SWITCH_NONUNIQ_SAVE’ was not declared in this scope
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:424:15: note: in definition of macro ‘MRN_HANDLER_DISABLE_INDEXES_NEED_TO_EXECUTE’
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:424:53: error: ‘HA_KEY_SWITCH_ALL’ was not declared in this scope
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:424:53: note: in definition of macro ‘MRN_HANDLER_DISABLE_INDEXES_NEED_TO_EXECUTE’
  424 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.cpp: In member function ‘int ha_mroonga::wrapper_enable_indexes_mroonga(uint)’:
/mroonga.dev/ha_mroonga.hpp:422:15: error: ‘HA_KEY_SWITCH_NONUNIQ_SAVE’ was not declared in this scope
  422 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:422:15: note: in definition of macro ‘MRN_HANDLER_ENABLE_INDEXES_NEED_TO_EXECUTE’
  422 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:422:53: error: ‘HA_KEY_SWITCH_ALL’ was not declared in this scope
  422 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:422:53: note: in definition of macro ‘MRN_HANDLER_ENABLE_INDEXES_NEED_TO_EXECUTE’
  422 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.cpp: In member function ‘int ha_mroonga::wrapper_enable_indexes(uint)’:
/mroonga.dev/ha_mroonga.cpp:15952:42: error: no matching function for call to ‘handler::ha_enable_indexes(uint&)’
15952 |   error = wrap_handler->ha_enable_indexes(MRN_HANDLER_ENABLE_INDEXES_FORWARD_ARGS);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mariadb-11.4.2/sql/handler.h:3634:7: note: candidate: ‘int handler::ha_enable_indexes(key_map, bool)’
 3634 |   int ha_enable_indexes(key_map map, bool persist);
      |       ^~~~~~~~~~~~~~~~~
/mariadb-11.4.2/sql/handler.h:3634:7: note:   candidate expects 2 arguments, 1 provided
/mroonga.dev/ha_mroonga.cpp: In member function ‘int ha_mroonga::storage_enable_indexes(uint)’:
/mroonga.dev/ha_mroonga.hpp:426:15: error: ‘HA_KEY_SWITCH_NONUNIQ_SAVE’ was not declared in this scope
  426 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:426:15: note: in definition of macro ‘MRN_HANDLER_ENABLE_INDEXES_SKIP_UNIQUE_KEY’
  426 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:422:53: error: ‘HA_KEY_SWITCH_ALL’ was not declared in this scope
  422 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
/mroonga.dev/ha_mroonga.hpp:422:53: note: in definition of macro ‘MRN_HANDLER_ENABLE_INDEXES_NEED_TO_EXECUTE’
  422 |      (mode == HA_KEY_SWITCH_NONUNIQ_SAVE || mode == HA_KEY_SWITCH_ALL)
      |                                                     ^~~~~~~~~~~~~~~~~
```

The cause of this error by the following MaraiDB's modification.
https://github.com/MariaDB/server/commit/22b3ba93121581db1cca4d2f9bfaf8d889cb2b32

The support of the above MaraiDB's modification has already implemented.
So, I only add support version in this PR.

I don't put upper limit as below.

```
#if defined(MRN_MARIADB_P) &&                                                  \
    ((MYSQL_VERSION_ID >= 100525 && MYSQL_VERSION_ID < 100600) ||              \
     (MYSQL_VERSION_ID >= 100618 && MYSQL_VERSION_ID < 100700) ||              \
     (MYSQL_VERSION_ID >= 101108 && MYSQL_VERSION_ID < 101200) ||              \
     (MYSQL_VERSION_ID >= 110402))
```

Because the latest MariaDB LTS is 11.4.0 and https://github.com/MariaDB/server/commit/22b3ba93121581db1cca4d2f9bfaf8d889cb2b32 is implemented in 11.4.2 or later.
So, MariaDB LTS 11.4.2 or later does not use HA_KEY_SWITCH_ALL.