### PR TITLE
mariadb 11.4: use keyread_time() and rnd_pos_time() instead of read_time()

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15002,9 +15002,9 @@ IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
     MRN_SET_WRAP_SHARE_KEY(share, table->s);
     MRN_SET_WRAP_TABLE_KEY(this, table);
     cost = wrap_handler->keyread_time(share->wrap_key_nr[index],
-                                     ranges,
-                                     rows,
-                                     blocks);
+                                      ranges,
+                                      rows,
+                                      blocks);
     MRN_SET_BASE_SHARE_KEY(share, table->s);
     MRN_SET_BASE_TABLE_KEY(this, table);
   } else {

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15062,7 +15062,7 @@ IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
     time = wrapper_rnd_pos_time(rows);
   } else {
 #endif
-    //    time = storage_rnd_pos_time(rows);
+    time = storage_rnd_pos_time(rows);
 #ifdef MRN_ENABLE_WRAPPER_MODE
   }
 #endif

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15044,56 +15044,50 @@ IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
 }
 #endif
 
-#ifdef MRN_HANDLER_HAVE_READ_TIME
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+#if defined(MRN_HANDLER_HAVE_READ_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
 double ha_mroonga::wrapper_read_time(uint index, uint ranges, ha_rows rows)
 {
-  double res;
+  double cost;
   MRN_DBUG_ENTER_METHOD();
   if (index < MAX_KEY) {
     KEY *key_info = &(table->key_info[index]);
     if (mrn_is_geo_key(key_info)) {
-      res = handler::read_time(index, ranges, rows);
-      DBUG_RETURN(res);
+      cost = handler::read_time(index, ranges, rows);
+      DBUG_RETURN(cost);
     }
     MRN_SET_WRAP_SHARE_KEY(share, table->s);
     MRN_SET_WRAP_TABLE_KEY(this, table);
-    res = wrap_handler->read_time(share->wrap_key_nr[index], ranges, rows);
+    cost = wrap_handler->read_time(share->wrap_key_nr[index], ranges, rows);
     MRN_SET_BASE_SHARE_KEY(share, table->s);
     MRN_SET_BASE_TABLE_KEY(this, table);
   } else {
     MRN_SET_WRAP_SHARE_KEY(share, table->s);
     MRN_SET_WRAP_TABLE_KEY(this, table);
-    res = wrap_handler->read_time(index, ranges, rows);
+    cost = wrap_handler->read_time(index, ranges, rows);
     MRN_SET_BASE_SHARE_KEY(share, table->s);
     MRN_SET_BASE_TABLE_KEY(this, table);
   }
-  DBUG_RETURN(res);
+  DBUG_RETURN(cost);
 }
-#  endif
 
 double ha_mroonga::storage_read_time(uint index, uint ranges, ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
-  double time = handler::read_time(index, ranges, rows);
+  auto cost = handler::read_time(index, ranges, rows);
   DBUG_RETURN(time);
 }
 
 double ha_mroonga::read_time(uint index, uint ranges, ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
-  double time;
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+  double cost;
   if (share->wrapper_mode)
   {
-    time = wrapper_read_time(index, ranges, rows);
+    cost = wrapper_read_time(index, ranges, rows);
   } else {
-#  endif
-    time = storage_read_time(index, ranges, rows);
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+    cost = storage_read_time(index, ranges, rows);
   }
-#  endif
-  DBUG_RETURN(time);
+  DBUG_RETURN(cost);
 }
 #endif
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14997,7 +14997,7 @@ mrn_io_and_cpu_cost ha_mroonga::storage_read_time(uint index,
   DBUG_RETURN(time);
 }
 
-#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
 IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
                                          uint ranges,
                                          ha_rows rows,
@@ -15013,14 +15013,14 @@ double ha_mroonga::read_time(uint index, uint ranges, ha_rows rows)
   if (share->wrapper_mode)
   {
     time = wrapper_read_time(index, ranges, rows
-#  ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#  ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
                              , blocks
 #  endif
                              );
   } else {
 #endif
     time = storage_read_time(index, ranges, rows
-#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
                              , blocks
 #endif
                              );
@@ -15030,7 +15030,7 @@ double ha_mroonga::read_time(uint index, uint ranges, ha_rows rows)
   DBUG_RETURN(time);
 }
 
-#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
 {

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14969,8 +14969,8 @@ IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
 IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
-  IO_AND_CPU_COST res = handler::rnd_pos_time(rows);
-  DBUG_RETURN(res);
+  auto cost = handler::rnd_pos_time(rows);
+  DBUG_RETURN(cost);
 }
 
 IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15081,8 +15081,7 @@ double ha_mroonga::wrapper_read_time(uint index, uint ranges, ha_rows rows)
 double ha_mroonga::storage_read_time(uint index, uint ranges, ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
-  double time =
-    handler::read_time(index, ranges, rows);
+  double time = handler::read_time(index, ranges, rows);
   DBUG_RETURN(time);
 }
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15033,14 +15033,14 @@ IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
                                          ulonglong blocks)
 {
   MRN_DBUG_ENTER_METHOD();
-  IO_AND_CPU_COST time;
+  IO_AND_CPU_COST cost;
   if (share->wrapper_mode)
   {
-    time = wrapper_keyread_time(index, ranges, rows, blocks);
+    cost = wrapper_keyread_time(index, ranges, rows, blocks);
   } else {
-    time = storage_keyread_time(index, ranges, rows, blocks);
+    cost = storage_keyread_time(index, ranges, rows, blocks);
   }
-  DBUG_RETURN(time);
+  DBUG_RETURN(cost);
 }
 #endif
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15023,9 +15023,8 @@ IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,
                                                  ulonglong blocks)
 {
   MRN_DBUG_ENTER_METHOD();
-  IO_AND_CPU_COST time =
-    handler::keyread_time(index, ranges, rows, blocks);
-  DBUG_RETURN(time);
+  auto cost = handler::keyread_time(index, ranges, rows, blocks);
+  DBUG_RETURN(cost);
 }
 
 IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15048,8 +15048,7 @@ IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
 IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
-  IO_AND_CPU_COST res;
-  res = handler::rnd_pos_time(rows);
+  auto res = handler::rnd_pos_time(rows);
   DBUG_RETURN(res);
 }
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14991,17 +14991,17 @@ IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
                                                  ha_rows rows,
                                                  ulonglong blocks)
 {
-  IO_AND_CPU_COST res;
+  IO_AND_CPU_COST cost;
   MRN_DBUG_ENTER_METHOD();
   if (index < MAX_KEY) {
     KEY *key_info = &(table->key_info[index]);
     if (mrn_is_geo_key(key_info)) {
-      res = handler::keyread_time(index, ranges, rows, blocks);
-      DBUG_RETURN(res);
+      cost = handler::keyread_time(index, ranges, rows, blocks);
+      DBUG_RETURN(cost);
     }
     MRN_SET_WRAP_SHARE_KEY(share, table->s);
     MRN_SET_WRAP_TABLE_KEY(this, table);
-    res = wrap_handler->keyread_time(share->wrap_key_nr[index],
+    cost = wrap_handler->keyread_time(share->wrap_key_nr[index],
                                      ranges,
                                      rows,
                                      blocks);
@@ -15010,11 +15010,11 @@ IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
   } else {
     MRN_SET_WRAP_SHARE_KEY(share, table->s);
     MRN_SET_WRAP_TABLE_KEY(this, table);
-    res = wrap_handler->keyread_time(index, ranges, rows, blocks);
+    cost = wrap_handler->keyread_time(index, ranges, rows, blocks);
     MRN_SET_BASE_SHARE_KEY(share, table->s);
     MRN_SET_BASE_TABLE_KEY(this, table);
   }
-  DBUG_RETURN(res);
+  DBUG_RETURN(cost);
 }
 
 IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14976,14 +14976,14 @@ IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)
 IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
-  IO_AND_CPU_COST time;
+  IO_AND_CPU_COST cost;
   if (share->wrapper_mode)
   {
-    time = wrapper_rnd_pos_time(rows);
+    cost = wrapper_rnd_pos_time(rows);
   } else {
-    time = storage_rnd_pos_time(rows);
+    cost = storage_rnd_pos_time(rows);
   }
-  DBUG_RETURN(time);
+  DBUG_RETURN(cost);
 }
 
 IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14968,6 +14968,13 @@ IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
 }
 #  endif
 
+IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST res = handler::rnd_pos_time(rows);
+  DBUG_RETURN(res);
+}
+
 IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14978,7 +14985,7 @@ IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
     time = wrapper_rnd_pos_time(rows);
   } else {
 #  endif
-    time = handler::rnd_pos_time(rows);
+    time = storage_rnd_pos_time(rows);
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   }
 #  endif

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14954,7 +14954,37 @@ mrn_io_and_cpu_cost ha_mroonga::scan_time()
 }
 
 #ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
 {
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST res;
+  MRN_SET_WRAP_SHARE_KEY(share, table->s);
+  MRN_SET_WRAP_TABLE_KEY(this, table);
+  res = wrap_handler->rnd_pos_time(rows);
+  MRN_SET_BASE_SHARE_KEY(share, table->s);
+  MRN_SET_BASE_TABLE_KEY(this, table);
+  DBUG_RETURN(res);
+}
+#  endif
+
+IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST time;
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+  if (share->wrapper_mode)
+  {
+    time = wrapper_rnd_pos_time(rows);
+  } else {
+#  endif
+    time = handler::rnd_pos_time(rows);
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+  }
+#  endif
+  DBUG_RETURN(time);
+}
+
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
                                                  uint ranges,

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15056,16 +15056,16 @@ IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
   IO_AND_CPU_COST time;
-#ifdef MRN_ENABLE_WRAPPER_MODE
+#  ifdef MRN_ENABLE_WRAPPER_MODE
   if (share->wrapper_mode)
   {
     time = wrapper_rnd_pos_time(rows);
   } else {
-#endif
+#  endif
     time = storage_rnd_pos_time(rows);
-#ifdef MRN_ENABLE_WRAPPER_MODE
+#  ifdef MRN_ENABLE_WRAPPER_MODE
   }
-#endif
+#  endif
   DBUG_RETURN(time);
 }
 #endif

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15029,6 +15029,47 @@ double ha_mroonga::read_time(uint index, uint ranges, ha_rows rows)
   DBUG_RETURN(time);
 }
 
+#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST res;
+  MRN_SET_WRAP_SHARE_KEY(share, table->s);
+  MRN_SET_WRAP_TABLE_KEY(this, table);
+  res = wrap_handler->rnd_pos_time(rows);
+  MRN_SET_BASE_SHARE_KEY(share, table->s);
+  MRN_SET_BASE_TABLE_KEY(this, table);
+  DBUG_RETURN(res);
+}
+#  endif
+
+IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST res;
+  res = handler::rnd_pos_time(rows);
+  DBUG_RETURN(res);
+}
+
+IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
+{
+  MRN_DBUG_ENTER_METHOD();
+  IO_AND_CPU_COST time;
+#ifdef MRN_ENABLE_WRAPPER_MODE
+  if (share->wrapper_mode)
+  {
+    time = wrapper_rnd_pos_time(rows);
+  } else {
+#endif
+    //    time = storage_rnd_pos_time(rows);
+#ifdef MRN_ENABLE_WRAPPER_MODE
+  }
+#endif
+  DBUG_RETURN(time);
+}
+#endif
+
 #ifdef MRN_HANDLER_HAVE_KEYS_TO_USE_FOR_SCANNING
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 const key_map *ha_mroonga::wrapper_keys_to_use_for_scanning()

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15074,7 +15074,7 @@ double ha_mroonga::storage_read_time(uint index, uint ranges, ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
   auto cost = handler::read_time(index, ranges, rows);
-  DBUG_RETURN(time);
+  DBUG_RETURN(cost);
 }
 
 double ha_mroonga::read_time(uint index, uint ranges, ha_rows rows)

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14957,13 +14957,13 @@ mrn_io_and_cpu_cost ha_mroonga::scan_time()
 IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
-  IO_AND_CPU_COST res;
+  IO_AND_CPU_COST cost;
   MRN_SET_WRAP_SHARE_KEY(share, table->s);
   MRN_SET_WRAP_TABLE_KEY(this, table);
-  res = wrap_handler->rnd_pos_time(rows);
+  cost = wrap_handler->rnd_pos_time(rows);
   MRN_SET_BASE_SHARE_KEY(share, table->s);
   MRN_SET_BASE_TABLE_KEY(this, table);
-  DBUG_RETURN(res);
+  DBUG_RETURN(cost);
 }
 
 IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -15002,7 +15002,8 @@ IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
                                          uint ranges,
                                          ha_rows rows,
                                          ulonglong blocks)
-#else
+#endif
+#ifdef MRN_HANDLER_HAVE_READ_TIME
 double ha_mroonga::read_time(uint index, uint ranges, ha_rows rows)
 #endif
 {

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14953,8 +14953,7 @@ mrn_io_and_cpu_cost ha_mroonga::scan_time()
   DBUG_RETURN(time);
 }
 
-#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+#if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
 IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -14966,7 +14965,6 @@ IO_AND_CPU_COST ha_mroonga::wrapper_rnd_pos_time(ha_rows rows)
   MRN_SET_BASE_TABLE_KEY(this, table);
   DBUG_RETURN(res);
 }
-#  endif
 
 IO_AND_CPU_COST ha_mroonga::storage_rnd_pos_time(ha_rows rows)
 {
@@ -14979,20 +14977,15 @@ IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
 {
   MRN_DBUG_ENTER_METHOD();
   IO_AND_CPU_COST time;
-#  ifdef MRN_ENABLE_WRAPPER_MODE
   if (share->wrapper_mode)
   {
     time = wrapper_rnd_pos_time(rows);
   } else {
-#  endif
     time = storage_rnd_pos_time(rows);
-#  ifdef MRN_ENABLE_WRAPPER_MODE
   }
-#  endif
   DBUG_RETURN(time);
 }
 
-#  ifdef MRN_ENABLE_WRAPPER_MODE
 IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
                                                  uint ranges,
                                                  ha_rows rows,
@@ -15023,7 +15016,6 @@ IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
   }
   DBUG_RETURN(res);
 }
-#  endif
 
 IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,
                                                  uint ranges,
@@ -15043,16 +15035,12 @@ IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
 {
   MRN_DBUG_ENTER_METHOD();
   IO_AND_CPU_COST time;
-#  ifdef MRN_ENABLE_WRAPPER_MODE
   if (share->wrapper_mode)
   {
     time = wrapper_keyread_time(index, ranges, rows, blocks);
   } else {
-#  endif
     time = storage_keyread_time(index, ranges, rows, blocks);
-#  ifdef MRN_ENABLE_WRAPPER_MODE
   }
-#  endif
   DBUG_RETURN(time);
 }
 #endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -699,6 +699,7 @@ public:
                                uint ranges,
                                ha_rows rows,
                                ulonglong blocks) mrn_override;
+  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
 #else
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #endif
@@ -1533,11 +1534,17 @@ private:
                                         uint ranges,
                                         ha_rows rows,
                                         ulonglong blocks = 0);
+#  ifdef MRN_HANDLER_USE_KEYREAD_TIME
+  IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);
+#  endif
 #endif
   mrn_io_and_cpu_cost storage_read_time(uint index,
                                         uint ranges,
                                         ha_rows rows,
                                         ulonglong blocks = 0);
+#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+  IO_AND_CPU_COST storage_rnd_pos_time(ha_rows rows);
+#endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   longlong wrapper_get_memory_buffer_size() const;

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -694,7 +694,14 @@ public:
 #endif
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg) mrn_override;
   mrn_io_and_cpu_cost scan_time() mrn_override;
+#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+  IO_AND_CPU_COST keyread_time(uint index,
+                               uint ranges,
+                               ha_rows rows,
+                               ulonglong blocks) mrn_override;
+#else
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
+#endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
   longlong get_memory_buffer_size() const mrn_override;
 #endif
@@ -1522,9 +1529,15 @@ private:
 #endif
   mrn_io_and_cpu_cost storage_scan_time();
 #ifdef MRN_ENABLE_WRAPPER_MODE
-  double wrapper_read_time(uint index, uint ranges, ha_rows rows);
+  mrn_io_and_cpu_cost wrapper_read_time(uint index,
+                                        uint ranges,
+                                        ha_rows rows,
+                                        ulonglong blocks = 0);
 #endif
-  double storage_read_time(uint index, uint ranges, ha_rows rows);
+  mrn_io_and_cpu_cost storage_read_time(uint index,
+                                        uint ranges,
+                                        ha_rows rows,
+                                        ulonglong blocks = 0);
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   longlong wrapper_get_memory_buffer_size() const;

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -694,9 +694,6 @@ public:
 #endif
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg) mrn_override;
   mrn_io_and_cpu_cost scan_time() mrn_override;
-#ifdef MRN_HANDLER_HAVE_READ_TIME
-  double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
-#endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
   longlong get_memory_buffer_size() const mrn_override;
 #endif
@@ -1524,10 +1521,9 @@ private:
 #endif
   mrn_io_and_cpu_cost storage_scan_time();
 
-#ifdef MRN_HANDLER_HAVE_READ_TIME
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+#if defined(MRN_HANDLER_HAVE_READ_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
+  double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
   double wrapper_read_time(uint index, uint ranges, ha_rows rows);
-#  endif
   double storage_read_time(uint index, uint ranges, ha_rows rows);
 #endif
 

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -694,7 +694,7 @@ public:
 #endif
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg) mrn_override;
   mrn_io_and_cpu_cost scan_time() mrn_override;
-#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
   IO_AND_CPU_COST keyread_time(uint index,
                                uint ranges,
                                ha_rows rows,
@@ -1535,7 +1535,7 @@ private:
                                         uint ranges,
                                         ha_rows rows,
                                         ulonglong blocks = 0);
-#  ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#  ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
   IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);
 #  endif
 #endif
@@ -1543,7 +1543,7 @@ private:
                                         uint ranges,
                                         ha_rows rows,
                                         ulonglong blocks = 0);
-#ifdef MRN_HANDLER_USE_KEYREAD_TIME
+#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
   IO_AND_CPU_COST storage_rnd_pos_time(ha_rows rows);
 #endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -1550,6 +1550,7 @@ private:
                                        uint ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
+  IO_AND_CPU_COST storage_rnd_pos_time(ha_rows rows);
 #endif
 
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -1530,22 +1530,28 @@ private:
   mrn_io_and_cpu_cost wrapper_scan_time();
 #endif
   mrn_io_and_cpu_cost storage_scan_time();
-#ifdef MRN_ENABLE_WRAPPER_MODE
-  mrn_io_and_cpu_cost wrapper_read_time(uint index,
-                                        uint ranges,
-                                        ha_rows rows,
-                                        ulonglong blocks = 0);
-#  ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
+
+#define MRN_HANDLER_HAVE_READ_TIME
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+  double wrapper_read_time(uint index, uint ranges, ha_rows rows);
+#  endif
+  double storage_read_time(uint index, uint ranges, ha_rows rows);
+#endif
+
+#define MRN_HANDLER_HAVE_KEYREAD_TIME
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+  IO_AND_CPU_COST wrapper_keyread_time(uint index,
+                                       uint ranges,
+                                       ha_rows rows,
+                                       ulonglong blocks);
   IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);
 #  endif
+  IO_AND_CPU_COST storage_keyread_time(uint index,
+                                       uint ranges,
+                                       ha_rows rows,
+                                       ulonglong blocks);
 #endif
-  mrn_io_and_cpu_cost storage_read_time(uint index,
-                                        uint ranges,
-                                        ha_rows rows,
-                                        ulonglong blocks = 0);
-#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
-  IO_AND_CPU_COST storage_rnd_pos_time(ha_rows rows);
-#endif
+
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   longlong wrapper_get_memory_buffer_size() const;

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -694,13 +694,6 @@ public:
 #endif
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg) mrn_override;
   mrn_io_and_cpu_cost scan_time() mrn_override;
-#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
-  IO_AND_CPU_COST keyread_time(uint index,
-                               uint ranges,
-                               ha_rows rows,
-                               ulonglong blocks) mrn_override;
-  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
-#endif
 #ifdef MRN_HANDLER_HAVE_READ_TIME
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #endif
@@ -1538,18 +1531,21 @@ private:
   double storage_read_time(uint index, uint ranges, ha_rows rows);
 #endif
 
-#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+#if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
+  IO_AND_CPU_COST keyread_time(uint index,
+                               uint ranges,
+                               ha_rows rows,
+                               ulonglong blocks) mrn_override;
   IO_AND_CPU_COST wrapper_keyread_time(uint index,
                                        uint ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
-  IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);
-#  endif
   IO_AND_CPU_COST storage_keyread_time(uint index,
                                        uint ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
+  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
+  IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);
   IO_AND_CPU_COST storage_rnd_pos_time(ha_rows rows);
 #endif
 

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -694,6 +694,16 @@ public:
 #endif
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share_arg) mrn_override;
   mrn_io_and_cpu_cost scan_time() mrn_override;
+#if defined(MRN_HANDLER_HAVE_READ_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
+  double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
+#endif
+#if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
+  IO_AND_CPU_COST keyread_time(uint index,
+                               uint ranges,
+                               ha_rows rows,
+                               ulonglong blocks) mrn_override;
+  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
+#endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
   longlong get_memory_buffer_size() const mrn_override;
 #endif
@@ -1522,16 +1532,11 @@ private:
   mrn_io_and_cpu_cost storage_scan_time();
 
 #if defined(MRN_HANDLER_HAVE_READ_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
-  double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
   double wrapper_read_time(uint index, uint ranges, ha_rows rows);
   double storage_read_time(uint index, uint ranges, ha_rows rows);
 #endif
 
 #if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
-  IO_AND_CPU_COST keyread_time(uint index,
-                               uint ranges,
-                               ha_rows rows,
-                               ulonglong blocks) mrn_override;
   IO_AND_CPU_COST wrapper_keyread_time(uint index,
                                        uint ranges,
                                        ha_rows rows,
@@ -1540,7 +1545,6 @@ private:
                                        uint ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
-  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
   IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);
   IO_AND_CPU_COST storage_rnd_pos_time(ha_rows rows);
 #endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -697,13 +697,6 @@ public:
 #if defined(MRN_HANDLER_HAVE_READ_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #endif
-#if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
-  IO_AND_CPU_COST keyread_time(uint index,
-                               uint ranges,
-                               ha_rows rows,
-                               ulonglong blocks) mrn_override;
-  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
-#endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE
   longlong get_memory_buffer_size() const mrn_override;
 #endif
@@ -891,6 +884,14 @@ protected:
 #    endif
     ) mrn_override;
 #  endif
+
+#if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
+  IO_AND_CPU_COST keyread_time(uint index,
+                               uint ranges,
+                               ha_rows rows,
+                               ulonglong blocks) mrn_override;
+  IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
+#endif
 
 private:
   bool have_unique_index();

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -700,7 +700,8 @@ public:
                                ha_rows rows,
                                ulonglong blocks) mrn_override;
   IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
-#else
+#endif
+#ifdef MRN_HANDLER_HAVE_READ_TIME
   double read_time(uint index, uint ranges, ha_rows rows) mrn_override;
 #endif
 #ifdef MRN_HANDLER_HAVE_GET_MEMORY_BUFFER_SIZE

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -1531,14 +1531,14 @@ private:
 #endif
   mrn_io_and_cpu_cost storage_scan_time();
 
-#define MRN_HANDLER_HAVE_READ_TIME
+#ifdef MRN_HANDLER_HAVE_READ_TIME
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   double wrapper_read_time(uint index, uint ranges, ha_rows rows);
 #  endif
   double storage_read_time(uint index, uint ranges, ha_rows rows);
 #endif
 
-#define MRN_HANDLER_HAVE_KEYREAD_TIME
+#ifdef MRN_HANDLER_HAVE_KEYREAD_TIME
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   IO_AND_CPU_COST wrapper_keyread_time(uint index,
                                        uint ranges,

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -991,6 +991,7 @@ typedef uint mrn_srid;
    keyread_time(index, ranges, rows, blocks)
 #else
   using mrn_io_and_cpu_cost = double;
+#  define MRN_HANDLER_HAVE_READ_TIME
 #  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks)  \
    read_time(index, ranges, rows)
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -982,10 +982,15 @@ typedef uint mrn_srid;
   (table_list->get_db_name())
 #endif
 
-#if defined(MRN_MARIADB_P) &&                                   \
+#if defined(MRN_MARIADB_P) &&                                    \
     (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
+#  define MRN_HANDLER_USE_KEYREAD_TIME
+#  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks) \
+   keyread_time(index, ranges, rows, blocks)
 #else
   using mrn_io_and_cpu_cost = double;
+#  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks)  \
+   read_time(index, ranges, rows)
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -986,7 +986,7 @@ typedef uint mrn_srid;
     (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
-#  define MRN_HANDLER_USE_KEYREAD_TIME
+#  define MRN_HANDLER_HAVE_KEYREAD_TIME
 #  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks)  \
    keyread_time(index, ranges, rows, blocks)
 #else

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -982,7 +982,7 @@ typedef uint mrn_srid;
   (table_list->get_db_name())
 #endif
 
-#if defined(MRN_MARIADB_P) &&                                    \
+#if defined(MRN_MARIADB_P) &&                                   \
     (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -987,7 +987,7 @@ typedef uint mrn_srid;
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_USE_KEYREAD_TIME
-#  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks) \
+#  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks)  \
    keyread_time(index, ranges, rows, blocks)
 #else
   using mrn_io_and_cpu_cost = double;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -987,11 +987,7 @@ typedef uint mrn_srid;
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
-#  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks)  \
-   keyread_time(index, ranges, rows, blocks)
 #else
   using mrn_io_and_cpu_cost = double;
 #  define MRN_HANDLER_HAVE_READ_TIME
-#  define MRN_HANDLER_KEYREAD_TIME(index, ranges, rows, blocks)  \
-   read_time(index, ranges, rows)
 #endif


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.4 LTS.

I fail to build of Mroonga with MariaDB 11.4.2 by the following error.

```
/mroonga.dev/ha_mroonga.cpp: In member function ‘double ha_mroonga::wrapper_read_time(uint, uint, ha_rows)’:
/mroonga.dev/ha_mroonga.cpp:14964:22: error: ‘read_time’ is not a member of ‘handler’
14964 |       res = handler::read_time(index, ranges, rows);
      |                      ^~~~~~~~~
/mroonga.dev/ha_mroonga.cpp:14969:25: error: ‘class handler’ has no member named ‘read_time’; did you mean ‘scan_time’?
14969 |     res = wrap_handler->read_time(share->wrap_key_nr[index], ranges, rows);
      |                         ^~~~~~~~~
      |                         scan_time
/mroonga.dev/ha_mroonga.cpp:14975:25: error: ‘class handler’ has no member named ‘read_time’; did you mean ‘scan_time’?
14975 |     res = wrap_handler->read_time(index, ranges, rows);
      |                         ^~~~~~~~~
      |                         scan_time
/mroonga.dev/ha_mroonga.cpp: In member function ‘double ha_mroonga::storage_read_time(uint, uint, ha_rows)’:
/mroonga.dev/ha_mroonga.cpp:14986:26: error: ‘read_time’ is not a member of ‘handler’
14986 |   double time = handler::read_time(index, ranges, rows);
      |                          ^~~~~~~~~
```

The cause of this error by the following MaraiDB's modification.
https://github.com/MariaDB/server/commit/b66cdbd1eaeed7e96317a03a190c496fd062ec71

I added `keyread_time()` and `rnd_pos_time()` in this modification.
Because `read_time()` is removed by https://github.com/MariaDB/server/commit/b66cdbd1eaeed7e96317a03a190c496fd062ec71.
Also, the commit message of the above MariaDB's modification says `read_time()` as `keyread_time()` + `rnd_pos_time()` can do the same thing and more.

I implemented `rnd_pos_time()` refer to https://github.com/MariaDB/server/blob/b66cdbd1eaeed7e96317a03a190c496fd062ec71/storage/mroonga/ha_mroonga.cpp#L5636-L5671.