### PR TITLE
mariadb 11.4: follow push_warning_printf() API change

### DIFF
--- a/lib/mrn_parameters_parser.cpp
+++ b/lib/mrn_parameters_parser.cpp
@@ -189,7 +189,7 @@ namespace mrn {
   const char *ParametersParser::tokenizer() {
     const char *parser = (*this)["parser"];
     if (parser) {
-      MRN_WARN_DEPRECATED(current_thd, "parser", "tokenizer", 1001);
+      MRN_WARN_DEPRECATED(current_thd, "parser", "tokenizer");
     }
     const char *tokenizer = (*this)["tokenizer"];
     if (!tokenizer) {

--- a/lib/mrn_parameters_parser.cpp
+++ b/lib/mrn_parameters_parser.cpp
@@ -189,7 +189,7 @@ namespace mrn {
   const char *ParametersParser::tokenizer() {
     const char *parser = (*this)["parser"];
     if (parser) {
-      MRN_WARN_DEPRECATED(current_thd, "parser", "tokenizer");
+      MRN_WARN_DEPRECATED(current_thd, "parser", "tokenizer", 1001);
     }
     const char *tokenizer = (*this)["tokenizer"];
     if (!tokenizer) {

--- a/lib/mrn_parameters_parser.cpp
+++ b/lib/mrn_parameters_parser.cpp
@@ -189,11 +189,7 @@ namespace mrn {
   const char *ParametersParser::tokenizer() {
     const char *parser = (*this)["parser"];
     if (parser) {
-      push_warning_printf(current_thd,
-                          MRN_SEVERITY_WARNING,
-                          ER_WARN_DEPRECATED_SYNTAX,
-                          MRN_GET_ERR_MSG(ER_WARN_DEPRECATED_SYNTAX),
-                          "parser", "tokenizer");
+      MRN_WARN_DEPRECATED(current_thd, "parser", "tokenizer");
     }
     const char *tokenizer = (*this)["tokenizer"];
     if (!tokenizer) {

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -987,8 +987,14 @@ typedef uint mrn_srid;
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
+/*
+ * warn_deprecated() require deprecated version.
+ * However, backward compatibility is important for Mroonga.
+ * Therefore we rarely remove deprecated features.
+ * So, Mroonga output only warning by specifing 999999 into deprecated version.
+ */
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
-   (warn_deprecated<999999>(thd, what, to))
+  (warn_deprecated<999999>(thd, what, to))
 #else
   using mrn_io_and_cpu_cost = double;
 #  define MRN_HANDLER_HAVE_READ_TIME

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -987,12 +987,15 @@ typedef uint mrn_srid;
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
-/*
- * warn_deprecated() require deprecated version.
- * However, backward compatibility is important for Mroonga.
- * Therefore we rarely remove deprecated features.
- * So, Mroonga output only warning by specifing 999999 into deprecated version.
- */
+// warn_deprecated<>() requires deprecated version. MariaDB will report an error
+// on build when the deprecated version will reach EOL.
+// 
+// However, MariaDB version isn't related to Mroonga version. So the mechanism
+// isn't suitable for Mroonga.
+//
+// We always use 999999 as the deprecated version here to disable the build time check.
+// The version is never reported as an error. See the warn_deprecated<>() definition
+// for details.
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
   (warn_deprecated<999999>(thd, what, to))
 #else

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -987,12 +987,12 @@ typedef uint mrn_srid;
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
-#  define MRN_WARN_DEPRECATED(thd, what, to, version)                \
-   (warn_deprecated<version>(thd, what, to))
+#  define MRN_WARN_DEPRECATED(thd, what, to)                         \
+   (warn_deprecated<999999>(thd, what, to))
 #else
   using mrn_io_and_cpu_cost = double;
 #  define MRN_HANDLER_HAVE_READ_TIME
-#  define MRN_WARN_DEPRECATED(thd, what, to, version)                \
+#  define MRN_WARN_DEPRECATED(thd, what, to)                         \
    (push_warning_printf(thd,                                         \
                         MRN_SEVERITY_WARNING,                        \
                         ER_WARN_DEPRECATED_SYNTAX,                   \

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -987,12 +987,12 @@ typedef uint mrn_srid;
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
-#  define MRN_WARN_DEPRECATED(thd, what, to)                         \
-   (warn_deprecated<1001>(thd, what, to))
+#  define MRN_WARN_DEPRECATED(thd, what, to, version)                \
+   (warn_deprecated<version>(thd, what, to))
 #else
   using mrn_io_and_cpu_cost = double;
 #  define MRN_HANDLER_HAVE_READ_TIME
-#  define MRN_WARN_DEPRECATED(thd, what, to)                         \
+#  define MRN_WARN_DEPRECATED(thd, what, to, version)                \
    (push_warning_printf(thd,                                         \
                         MRN_SEVERITY_WARNING,                        \
                         ER_WARN_DEPRECATED_SYNTAX,                   \

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -982,12 +982,21 @@ typedef uint mrn_srid;
   (table_list->get_db_name())
 #endif
 
-#if defined(MRN_MARIADB_P) &&                                   \
+#if defined(MRN_MARIADB_P) &&                                        \
     (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
+#  define MRN_WARN_DEPRECATED(thd, what, to)                         \
+   (warn_deprecated<1001>(thd, what, to))
 #else
   using mrn_io_and_cpu_cost = double;
 #  define MRN_HANDLER_HAVE_READ_TIME
+#  define MRN_WARN_DEPRECATED(thd, what, to)                         \
+   (push_warning_printf(thd,                                         \
+                        MRN_SEVERITY_WARNING,                        \
+                        ER_WARN_DEPRECATED_SYNTAX,                   \
+                        MRN_GET_ERR_MSG(ER_WARN_DEPRECATED_SYNTAX),  \
+                        what,                                        \
+                        to))
 #endif


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.4 LTS.

I fail to build of Mroonga with MariaDB 11.4.2 by the following error.

```
/mroonga.dev/lib/mrn_parameters_parser.cpp: In member function ‘const char* mrn::ParametersParser::tokenizer()’:
/mroonga.dev/lib/mrn_parameters_parser.cpp:194:27: error: ‘ER_WARN_DEPRECATED_SYNTAX’ was not declared in this scope
  194 |                           ER_WARN_DEPRECATED_SYNTAX,
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
```

The cause of this error by the following MaraiDB's modification.
https://github.com/MariaDB/server/commit/df4bfefbb8f670a986cd9ebe376fe09248dba4a2

`warn_deprecated()` require deprecated version.
However, backward compatibility is important for Mroonga. Therefore we rarely remove deprecated features.
So, Mroonga output only warning by specifing `999999` into deprecated version.