### PR TITLE
mariadb 11.4: follow get_table_name() and get_db_name() API change

### DIFF
--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -966,7 +966,8 @@ typedef uint mrn_srid;
 #if defined(MRN_MARIADB_P) &&                                      \
     ((MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) ||  \
      (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) ||  \
-     (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200))
+     (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200) ||  \
+     (MYSQL_VERSION_ID >= 110403 && MYSQL_VERSION_ID < 110500))
 #  define MRN_GET_TABLE_NAME(query_tables)                         \
   (query_tables->get_table_name().str)
 #  define MRN_GET_TABLE_NAME_LENGTH(query_tables)                       \


### PR DESCRIPTION
This problem is same as #752.

---

The current version of Mroonga with the MariaDB 11.4.3 fail build as below.

```
ha_mroonga.cpp: In member function ‘int ha_mroonga::create_share_for_create() const’:
ha_mroonga.cpp:3755:25: error: no match for ‘operator&&’ (operand types are ‘TABLE_LIST*’ and ‘const LEX_CSTRING’ {aka ‘const st_mysql_const_lex_string’})
 3755 |   if (lex->query_tables && lex->query_tables->get_table_name()) {
      |       ~~~~~~~~~~~~~~~~~ ^~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |            |                                                |
      |            TABLE_LIST*                                      const LEX_CSTRING {aka const st_mysql_const_lex_string}
ha_mroonga.cpp:3755:25: note: candidate: ‘operator&&(bool, bool)’ (built-in)
```

Because theses versions modify return value type of `get_table_name()` and `get_db_name()` in https://github.com/MariaDB/server/commit/310fd6ff695541247db766baf3ade1e3b4db16e9.

The return type of `get_table_name()` and `get_db_name()` change to `const LEX_CSTRING` from `const char *` as below.

```diff
-  const char *get_table_name() const { return view != NULL ? view_name.str : table_name.str; }
+  const LEX_CSTRING get_table_name() const
+  {
+    return view != NULL ? view_name : table_name;
+  }
```

```diff
-  const char *get_db_name() const { return view != NULL ? view_db.str : db.str; }
+ const LEX_CSTRING get_db_name() const
+ {
+   return view != NULL ? view_db : db;
+ }
```

I deal with these modifications in this PR.