### PR TITLE
mariadb 11.4: follow get_foreign_key_list() and get_parent_foreign_key_list() API change

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -18733,13 +18733,9 @@ char *ha_mroonga::get_foreign_key_create_info()
 }
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-#    if defined(MARIADB_11_4_OR_LATER)
-int ha_mroonga::wrapper_get_foreign_key_list(const THD *thd,
-                                             List<FOREIGN_KEY_INFO> *f_key_list)
-#    else
-int ha_mroonga::wrapper_get_foreign_key_list(THD *thd,
-                                             List<FOREIGN_KEY_INFO> *f_key_list)
-#    endif
+int ha_mroonga::wrapper_get_foreign_key_list(
+    mrn_handler_get_foreign_key_list_thread *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18750,15 +18746,11 @@ int ha_mroonga::wrapper_get_foreign_key_list(THD *thd,
   MRN_SET_BASE_TABLE_KEY(this, table);
   DBUG_RETURN(res);
 }
-#endif
-
-#  if defined(MARIADB_11_4_OR_LATER)
-int ha_mroonga::storage_get_foreign_key_list(const THD *thd,
-                                             List<FOREIGN_KEY_INFO> *f_key_list)
-#  else
-int ha_mroonga::storage_get_foreign_key_list(THD *thd,
-                                             List<FOREIGN_KEY_INFO> *f_key_list)
 #  endif
+
+int ha_mroonga::storage_get_foreign_key_list(
+    mrn_handler_get_foreign_key_list_thread *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
 {
   int error;
   uint i;
@@ -18869,15 +18861,9 @@ int ha_mroonga::storage_get_foreign_key_list(THD *thd,
   DBUG_RETURN(0);
 }
 
-#  if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::get_foreign_key_list(
-    const THD *thd,
+    mrn_handler_get_foreign_key_list_thread *thd,
     List<FOREIGN_KEY_INFO> *f_key_list)
-#  else
-int ha_mroonga::get_foreign_key_list(
-    THD *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18895,15 +18881,9 @@ int ha_mroonga::get_foreign_key_list(
 }
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-#    if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::wrapper_get_parent_foreign_key_list(
-    const THD *thd,
+    mrn_handler_get_foreign_key_list_thread *thd,
     List<FOREIGN_KEY_INFO> *f_key_list)
-#    else
-int ha_mroonga::wrapper_get_parent_foreign_key_list(
-    THD *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
-#    endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18916,26 +18896,18 @@ int ha_mroonga::wrapper_get_parent_foreign_key_list(
 }
 #  endif
 
-#  if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::storage_get_parent_foreign_key_list(
-    const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
-#  else
-int ha_mroonga::storage_get_parent_foreign_key_list(
-    THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
+    mrn_handler_get_foreign_key_list_thread *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res = handler::get_parent_foreign_key_list(thd, f_key_list);
   DBUG_RETURN(res);
 }
 
-#  if defined(MARIADB_11_4_OR_LATER)
-int ha_mroonga::get_parent_foreign_key_list(const THD *thd,
-                                            List<FOREIGN_KEY_INFO> *f_key_list)
-#  else
-int ha_mroonga::get_parent_foreign_key_list(THD *thd,
-                                            List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
+int ha_mroonga::get_parent_foreign_key_list(
+    mrn_handler_get_foreign_key_list_thread *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res;

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -18734,8 +18734,8 @@ char *ha_mroonga::get_foreign_key_create_info()
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 int ha_mroonga::wrapper_get_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
+  mrn_handler_get_foreign_key_list_thread *thd,
+  List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18749,8 +18749,8 @@ int ha_mroonga::wrapper_get_foreign_key_list(
 #  endif
 
 int ha_mroonga::storage_get_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
+  mrn_handler_get_foreign_key_list_thread *thd,
+  List<FOREIGN_KEY_INFO> *f_key_list)
 {
   int error;
   uint i;
@@ -18862,8 +18862,8 @@ int ha_mroonga::storage_get_foreign_key_list(
 }
 
 int ha_mroonga::get_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
+  mrn_handler_get_foreign_key_list_thread *thd,
+  List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18882,8 +18882,8 @@ int ha_mroonga::get_foreign_key_list(
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 int ha_mroonga::wrapper_get_parent_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
+  mrn_handler_get_foreign_key_list_thread *thd,
+  List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18897,8 +18897,8 @@ int ha_mroonga::wrapper_get_parent_foreign_key_list(
 #  endif
 
 int ha_mroonga::storage_get_parent_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
+  mrn_handler_get_foreign_key_list_thread *thd,
+  List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res = handler::get_parent_foreign_key_list(thd, f_key_list);
@@ -18906,8 +18906,8 @@ int ha_mroonga::storage_get_parent_foreign_key_list(
 }
 
 int ha_mroonga::get_parent_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread *thd,
-    List<FOREIGN_KEY_INFO> *f_key_list)
+  mrn_handler_get_foreign_key_list_thread *thd,
+  List<FOREIGN_KEY_INFO> *f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
   int res;

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -18733,8 +18733,14 @@ char *ha_mroonga::get_foreign_key_create_info()
 }
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+int ha_mroonga::wrapper_get_foreign_key_list(const THD *thd,
+                                             List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
 int ha_mroonga::wrapper_get_foreign_key_list(THD *thd,
                                              List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18745,10 +18751,16 @@ int ha_mroonga::wrapper_get_foreign_key_list(THD *thd,
   MRN_SET_BASE_TABLE_KEY(this, table);
   DBUG_RETURN(res);
 }
-#  endif
+#endif
 
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+int ha_mroonga::storage_get_foreign_key_list(const THD *thd,
+                                             List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
 int ha_mroonga::storage_get_foreign_key_list(THD *thd,
                                              List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
 {
   int error;
   uint i;
@@ -18859,8 +18871,16 @@ int ha_mroonga::storage_get_foreign_key_list(THD *thd,
   DBUG_RETURN(0);
 }
 
-int ha_mroonga::get_foreign_key_list(THD *thd,
-                                     List<FOREIGN_KEY_INFO> *f_key_list)
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+int ha_mroonga::get_foreign_key_list(
+    const THD *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+int ha_mroonga::get_foreign_key_list(
+    THD *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18877,10 +18897,17 @@ int ha_mroonga::get_foreign_key_list(THD *thd,
   DBUG_RETURN(res);
 }
 
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+#ifdef MRN_ENABLE_WRAPPER_MODE
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
 int ha_mroonga::wrapper_get_parent_foreign_key_list(
-  THD *thd,
-  List<FOREIGN_KEY_INFO> *f_key_list)
+    const THD *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+int ha_mroonga::wrapper_get_parent_foreign_key_list(
+    THD *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18893,17 +18920,28 @@ int ha_mroonga::wrapper_get_parent_foreign_key_list(
 }
 #  endif
 
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
 int ha_mroonga::storage_get_parent_foreign_key_list(
-  THD *thd,
-  List<FOREIGN_KEY_INFO> *f_key_list)
+    const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+int ha_mroonga::storage_get_parent_foreign_key_list(
+    THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res = handler::get_parent_foreign_key_list(thd, f_key_list);
   DBUG_RETURN(res);
 }
 
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+int ha_mroonga::get_parent_foreign_key_list(const THD *thd,
+                                            List<FOREIGN_KEY_INFO> *f_key_list)
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
 int ha_mroonga::get_parent_foreign_key_list(THD *thd,
                                             List<FOREIGN_KEY_INFO> *f_key_list)
+#endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -18733,14 +18733,13 @@ char *ha_mroonga::get_foreign_key_create_info()
 }
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#    if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::wrapper_get_foreign_key_list(const THD *thd,
                                              List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#    else
 int ha_mroonga::wrapper_get_foreign_key_list(THD *thd,
                                              List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
+#    endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18753,11 +18752,10 @@ int ha_mroonga::wrapper_get_foreign_key_list(THD *thd,
 }
 #endif
 
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#  if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::storage_get_foreign_key_list(const THD *thd,
                                              List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#  else
 int ha_mroonga::storage_get_foreign_key_list(THD *thd,
                                              List<FOREIGN_KEY_INFO> *f_key_list)
 #  endif
@@ -18871,12 +18869,11 @@ int ha_mroonga::storage_get_foreign_key_list(THD *thd,
   DBUG_RETURN(0);
 }
 
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#  if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::get_foreign_key_list(
     const THD *thd,
     List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#  else
 int ha_mroonga::get_foreign_key_list(
     THD *thd,
     List<FOREIGN_KEY_INFO> *f_key_list)
@@ -18897,17 +18894,16 @@ int ha_mroonga::get_foreign_key_list(
   DBUG_RETURN(res);
 }
 
-#ifdef MRN_ENABLE_WRAPPER_MODE
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#  ifdef MRN_ENABLE_WRAPPER_MODE
+#    if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::wrapper_get_parent_foreign_key_list(
     const THD *thd,
     List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#    else
 int ha_mroonga::wrapper_get_parent_foreign_key_list(
     THD *thd,
     List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
+#    endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;
@@ -18920,11 +18916,10 @@ int ha_mroonga::wrapper_get_parent_foreign_key_list(
 }
 #  endif
 
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#  if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::storage_get_parent_foreign_key_list(
     const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#  else
 int ha_mroonga::storage_get_parent_foreign_key_list(
     THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
 #  endif
@@ -18934,14 +18929,13 @@ int ha_mroonga::storage_get_parent_foreign_key_list(
   DBUG_RETURN(res);
 }
 
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#  if defined(MARIADB_11_4_OR_LATER)
 int ha_mroonga::get_parent_foreign_key_list(const THD *thd,
                                             List<FOREIGN_KEY_INFO> *f_key_list)
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#  else
 int ha_mroonga::get_parent_foreign_key_list(THD *thd,
                                             List<FOREIGN_KEY_INFO> *f_key_list)
-#endif
+#  endif
 {
   MRN_DBUG_ENTER_METHOD();
   int res;

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -838,13 +838,12 @@ protected:
 #ifdef MRN_HANDLER_HAVE_FOREIGN_KEY_INFO
   bool is_fk_defined_on_table_or_index(uint index) mrn_override;
   char *get_foreign_key_create_info() mrn_override;
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#  if defined(MARIADB_11_4_OR_LATER)
   int get_foreign_key_list(const THD *thd,
                            List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
   int get_parent_foreign_key_list(const THD *thd,
                                   List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#  else
   int get_foreign_key_list(THD *thd,
                            List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
   int get_parent_foreign_key_list(THD *thd,
@@ -1943,15 +1942,14 @@ private:
   char *wrapper_get_foreign_key_create_info();
 #  endif
   char *storage_get_foreign_key_create_info();
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#  if defined(MARIADB_11_4_OR_LATER)
 #    ifdef MRN_ENABLE_WRAPPER_MODE
   int wrapper_get_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
   int wrapper_get_parent_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
 #    endif
   int storage_get_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
   int storage_get_parent_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-#  endif
-#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#  else
 #    ifdef MRN_ENABLE_WRAPPER_MODE
   int wrapper_get_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
   int wrapper_get_parent_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -838,10 +838,18 @@ protected:
 #ifdef MRN_HANDLER_HAVE_FOREIGN_KEY_INFO
   bool is_fk_defined_on_table_or_index(uint index) mrn_override;
   char *get_foreign_key_create_info() mrn_override;
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+  int get_foreign_key_list(const THD *thd,
+                           List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
+  int get_parent_foreign_key_list(const THD *thd,
+                                  List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
   int get_foreign_key_list(THD *thd,
                            List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
   int get_parent_foreign_key_list(THD *thd,
                                   List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
+#  endif
   uint referenced_by_foreign_key()mrn_override;
   void free_foreign_key_create_info(char* str) mrn_override;
 #endif
@@ -1935,14 +1943,22 @@ private:
   char *wrapper_get_foreign_key_create_info();
 #  endif
   char *storage_get_foreign_key_create_info();
-#  ifdef MRN_ENABLE_WRAPPER_MODE
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITH_CONST)
+#    ifdef MRN_ENABLE_WRAPPER_MODE
+  int wrapper_get_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
+  int wrapper_get_parent_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
+#    endif
+  int storage_get_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
+  int storage_get_parent_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
+#  endif
+#  if defined(MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST)
+#    ifdef MRN_ENABLE_WRAPPER_MODE
   int wrapper_get_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-#  endif
-  int storage_get_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-#  ifdef MRN_ENABLE_WRAPPER_MODE
   int wrapper_get_parent_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-#  endif
+#    endif
+  int storage_get_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
   int storage_get_parent_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
+#  endif
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   uint wrapper_referenced_by_foreign_key();
 #  endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -838,17 +838,10 @@ protected:
 #ifdef MRN_HANDLER_HAVE_FOREIGN_KEY_INFO
   bool is_fk_defined_on_table_or_index(uint index) mrn_override;
   char *get_foreign_key_create_info() mrn_override;
-#  if defined(MARIADB_11_4_OR_LATER)
-  int get_foreign_key_list(const THD *thd,
+  int get_foreign_key_list(mrn_handler_get_foreign_key_list_thread *thd,
                            List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
-  int get_parent_foreign_key_list(const THD *thd,
+  int get_parent_foreign_key_list(mrn_handler_get_foreign_key_list_thread *thd,
                                   List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
-#  else
-  int get_foreign_key_list(THD *thd,
-                           List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
-  int get_parent_foreign_key_list(THD *thd,
-                                  List<FOREIGN_KEY_INFO> *f_key_list) mrn_override;
-#  endif
   uint referenced_by_foreign_key()mrn_override;
   void free_foreign_key_create_info(char* str) mrn_override;
 #endif
@@ -1942,21 +1935,18 @@ private:
   char *wrapper_get_foreign_key_create_info();
 #  endif
   char *storage_get_foreign_key_create_info();
-#  if defined(MARIADB_11_4_OR_LATER)
 #    ifdef MRN_ENABLE_WRAPPER_MODE
-  int wrapper_get_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-  int wrapper_get_parent_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
+  int wrapper_get_foreign_key_list(mrn_handler_get_foreign_key_list_thread *thd,
+                                   List<FOREIGN_KEY_INFO> *f_key_list);
+  int wrapper_get_parent_foreign_key_list(
+      mrn_handler_get_foreign_key_list_thread *thd,
+      List<FOREIGN_KEY_INFO> *f_key_list);
 #    endif
-  int storage_get_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-  int storage_get_parent_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-#  else
-#    ifdef MRN_ENABLE_WRAPPER_MODE
-  int wrapper_get_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-  int wrapper_get_parent_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-#    endif
-  int storage_get_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-  int storage_get_parent_foreign_key_list(THD *thd, List<FOREIGN_KEY_INFO> *f_key_list);
-#  endif
+  int storage_get_foreign_key_list(mrn_handler_get_foreign_key_list_thread *thd,
+                                   List<FOREIGN_KEY_INFO> *f_key_list);
+  int storage_get_parent_foreign_key_list(
+      mrn_handler_get_foreign_key_list_thread *thd,
+      List<FOREIGN_KEY_INFO> *f_key_list);
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   uint wrapper_referenced_by_foreign_key();
 #  endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -1935,18 +1935,18 @@ private:
   char *wrapper_get_foreign_key_create_info();
 #  endif
   char *storage_get_foreign_key_create_info();
-#    ifdef MRN_ENABLE_WRAPPER_MODE
+#  ifdef MRN_ENABLE_WRAPPER_MODE
   int wrapper_get_foreign_key_list(mrn_handler_get_foreign_key_list_thread *thd,
                                    List<FOREIGN_KEY_INFO> *f_key_list);
   int wrapper_get_parent_foreign_key_list(
-      mrn_handler_get_foreign_key_list_thread *thd,
-      List<FOREIGN_KEY_INFO> *f_key_list);
-#    endif
+    mrn_handler_get_foreign_key_list_thread *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list);
+#  endif
   int storage_get_foreign_key_list(mrn_handler_get_foreign_key_list_thread *thd,
                                    List<FOREIGN_KEY_INFO> *f_key_list);
   int storage_get_parent_foreign_key_list(
-      mrn_handler_get_foreign_key_list_thread *thd,
-      List<FOREIGN_KEY_INFO> *f_key_list);
+    mrn_handler_get_foreign_key_list_thread *thd,
+    List<FOREIGN_KEY_INFO> *f_key_list);
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   uint wrapper_referenced_by_foreign_key();
 #  endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -999,6 +999,7 @@ typedef uint mrn_srid;
 // for details.
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
   (warn_deprecated<999999>(thd, what, to))
+#  define MRN_GET_FOREIGN_KEY_LIST_WITH_CONST
 #else
   using mrn_io_and_cpu_cost = double;
 #  define MRN_HANDLER_HAVE_READ_TIME
@@ -1009,4 +1010,5 @@ typedef uint mrn_srid;
                         MRN_GET_ERR_MSG(ER_WARN_DEPRECATED_SYNTAX),  \
                         what,                                        \
                         to))
+#  define MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -999,7 +999,6 @@ typedef uint mrn_srid;
 // for details.
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
   (warn_deprecated<999999>(thd, what, to))
-#  define MRN_GET_FOREIGN_KEY_LIST_WITH_CONST
 #else
   using mrn_io_and_cpu_cost = double;
 #  define MRN_HANDLER_HAVE_READ_TIME
@@ -1010,5 +1009,8 @@ typedef uint mrn_srid;
                         MRN_GET_ERR_MSG(ER_WARN_DEPRECATED_SYNTAX),  \
                         what,                                        \
                         to))
-#  define MRN_GET_FOREIGN_KEY_LIST_WITHOUT_CONST
+#endif
+
+#if defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 110400)
+#  define MARIADB_11_4_OR_LATER
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -986,11 +986,12 @@ typedef uint mrn_srid;
 #if defined(MRN_MARIADB_P) &&                                        \
     (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
+  using mrn_handler_get_foreign_key_list_thread = const THD;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
 // warn_deprecated<>() requires deprecated version. MariaDB will report an error
 // on build when the deprecated version will reach EOL.
-// 
+//
 // However, MariaDB version isn't related to Mroonga version. So the mechanism
 // isn't suitable for Mroonga.
 //
@@ -1001,6 +1002,7 @@ typedef uint mrn_srid;
   (warn_deprecated<999999>(thd, what, to))
 #else
   using mrn_io_and_cpu_cost = double;
+  using mrn_handler_get_foreign_key_list_thread = THD;
 #  define MRN_HANDLER_HAVE_READ_TIME
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
    (push_warning_printf(thd,                                         \
@@ -1009,8 +1011,4 @@ typedef uint mrn_srid;
                         MRN_GET_ERR_MSG(ER_WARN_DEPRECATED_SYNTAX),  \
                         what,                                        \
                         to))
-#endif
-
-#if defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 110400)
-#  define MARIADB_11_4_OR_LATER
 #endif


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.4 LTS.

I fail to build of Mroonga with MariaDB 11.4.3 by the following error.

```
2024-08-27T05:11:48.3976514Z ha_mroonga.hpp:841:7: error: 'int ha_mroonga::get_foreign_key_list(THD*, List<st_foreign_key_info>*)' marked 'override', but does not override
2024-08-27T05:11:48.3977826Z    int get_foreign_key_list(THD *thd,
2024-08-27T05:11:48.3979650Z        ^~~~~~~~~~~~~~~~~~~~
2024-08-27T05:11:48.3981492Z ha_mroonga.hpp:843:7: error: 'int ha_mroonga::get_parent_foreign_key_list(THD*, List<st_foreign_key_info>*)' marked 'override', but does not override
2024-08-27T05:11:48.3982876Z    int get_parent_foreign_key_list(THD *thd,
2024-08-27T05:11:48.3983903Z        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-08-27T05:11:48.3988143Z In file included from /root/rpmbuild/BUILD/MariaDB-11.4.3/mariadb-11.4.3/sql/log.h:20,
2024-08-27T05:11:48.3988921Z                  from /root/rpmbuild/BUILD/MariaDB-11.4.3/mariadb-11.4.3/sql/sql_class.h:29,
2024-08-27T05:11:48.3989438Z                  from mrn_mysql.h:57,
2024-08-27T05:11:48.3989778Z                  from ha_mroonga.cpp:25:
2024-08-27T05:11:48.3991013Z /root/rpmbuild/BUILD/MariaDB-11.4.3/mariadb-11.4.3/sql/handler.h:4502:3: error: 'virtual int handler::get_parent_foreign_key_list(const THD*, List<st_foreign_key_info>*)' was hidden [-Werror=overloaded-virtual]
2024-08-27T05:11:48.3992354Z    get_parent_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
2024-08-27T05:11:48.3992833Z    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-08-27T05:11:48.3993136Z In file included from ha_mroonga.cpp:108:
2024-08-27T05:11:48.3993992Z ha_mroonga.hpp:843:7: error:   by 'int ha_mroonga::get_parent_foreign_key_list(THD*, List<st_foreign_key_info>*)' [-Werror=overloaded-virtual]
2024-08-27T05:11:48.3994723Z    int get_parent_foreign_key_list(THD *thd,
2024-08-27T05:11:48.3995054Z        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-08-27T05:11:48.3995613Z In file included from /root/rpmbuild/BUILD/MariaDB-11.4.3/mariadb-11.4.3/sql/log.h:20,
2024-08-27T05:11:48.3996383Z                  from /root/rpmbuild/BUILD/MariaDB-11.4.3/mariadb-11.4.3/sql/sql_class.h:29,
2024-08-27T05:11:48.3996884Z                  from mrn_mysql.h:57,
2024-08-27T05:11:48.3997212Z                  from ha_mroonga.cpp:25:
2024-08-27T05:11:48.3998378Z /root/rpmbuild/BUILD/MariaDB-11.4.3/mariadb-11.4.3/sql/handler.h:4488:3: error: 'virtual int handler::get_foreign_key_list(const THD*, List<st_foreign_key_info>*)' was hidden [-Werror=overloaded-virtual]
2024-08-27T05:11:48.3999489Z    get_foreign_key_list(const THD *thd, List<FOREIGN_KEY_INFO> *f_key_list)
2024-08-27T05:11:48.3999930Z    ^~~~~~~~~~~~~~~~~~~~
2024-08-27T05:11:48.4000374Z In file included from ha_mroonga.cpp:108:
2024-08-27T05:11:48.4001883Z ha_mroonga.hpp:841:7: error:   by 'int ha_mroonga::get_foreign_key_list(THD*, List<st_foreign_key_info>*)' [-Werror=overloaded-virtual]
2024-08-27T05:11:48.4003077Z    int get_foreign_key_list(THD *thd,
2024-08-27T05:11:48.4003597Z        ^~~~~~~~~~~~~~~~~~~~
```

The cause of this error by the following MaraiDB's modification.
https://github.com/MariaDB/server/commit/b3f988d2602d261aedeee63c0f5d8f3aba2ade5c