### PR TITLE
Fix keyread_time() argument type

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14987,7 +14987,7 @@ IO_AND_CPU_COST ha_mroonga::rnd_pos_time(ha_rows rows)
 }
 
 IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
-                                                 uint ranges,
+                                                 ulong ranges,
                                                  ha_rows rows,
                                                  ulonglong blocks)
 {
@@ -15018,7 +15018,7 @@ IO_AND_CPU_COST ha_mroonga::wrapper_keyread_time(uint index,
 }
 
 IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,
-                                                 uint ranges,
+                                                 ulong ranges,
                                                  ha_rows rows,
                                                  ulonglong blocks)
 {
@@ -15028,7 +15028,7 @@ IO_AND_CPU_COST ha_mroonga::storage_keyread_time(uint index,
 }
 
 IO_AND_CPU_COST ha_mroonga::keyread_time(uint index,
-                                         uint ranges,
+                                         ulong ranges,
                                          ha_rows rows,
                                          ulonglong blocks)
 {

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -887,7 +887,7 @@ protected:
 
 #if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
   IO_AND_CPU_COST keyread_time(uint index,
-                               uint ranges,
+                               ulong ranges,
                                ha_rows rows,
                                ulonglong blocks) mrn_override;
   IO_AND_CPU_COST rnd_pos_time(ha_rows rows) mrn_override;
@@ -1539,11 +1539,11 @@ private:
 
 #if defined(MRN_HANDLER_HAVE_KEYREAD_TIME) && defined(MRN_ENABLE_WRAPPER_MODE)
   IO_AND_CPU_COST wrapper_keyread_time(uint index,
-                                       uint ranges,
+                                       ulong ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
   IO_AND_CPU_COST storage_keyread_time(uint index,
-                                       uint ranges,
+                                       ulong ranges,
                                        ha_rows rows,
                                        ulonglong blocks);
   IO_AND_CPU_COST wrapper_rnd_pos_time(ha_rows rows);


### PR DESCRIPTION
`ranges` is `ulong` is correct.

https://github.com/MariaDB/server/blob/b66cdbd1eaeed7e96317a03a190c496fd062ec71/storage/mroonga/ha_mroonga.cpp#L13077-L13121