### PR TITLE
Implement "make update-document" by Ruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+require "tmpdir"
 
 def env_var(name, default=nil)
   value = ENV[name] || default
@@ -53,8 +54,6 @@ def new_plugin_version
   # 10.11 -> 10.11
   new_version.gsub(".0", ".")
 end
-
-require "tmpdir"
 
 namespace :release do
   namespace :document do

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 require "tmpdir"
 
 def env_var(name, default=nil)


### PR DESCRIPTION
We will drop support for GNU Autotools. This is a part of the work. We can use `rake release:document:update` instead of `make update-document`.

Usage:

```
$ rake release:document:update BUILD_DIR=../build-dir/mroonga MROONGA_ORG_DIR=../mroonga.org
```