### PR TITLE
packages mysql-community-server-minimal-8.0: add support for almalinux 9

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -223,7 +223,7 @@ jobs:
             package: mysql-community-8.4
             test-image: "images:ubuntu/24.04"
 
-          MySQL community minimal 8.0
+          # MySQL community minimal 8.0
           - os: almalinux-9
             package: mysql-community-minimal-8.0
             test-image: "images:almalinux/9"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -223,11 +223,10 @@ jobs:
             package: mysql-community-8.4
             test-image: "images:ubuntu/24.04"
 
-          # Source of version 8.0.38 isn't available yet.
-          # MySQL community minimal 8.0
-          #- os: almalinux-8
-          #  package: mysql-community-minimal-8.0
-          #  test-image: "images:almalinux/8"
+          MySQL community minimal 8.0
+          - os: almalinux-9
+            package: mysql-community-minimal-8.0
+            test-image: "images:almalinux/9"
 
           # Percona Server 8.0
           - os: almalinux-8

--- a/packages/mysql-community-minimal-8.0-mroonga/Rakefile
+++ b/packages/mysql-community-minimal-8.0-mroonga/Rakefile
@@ -15,7 +15,7 @@ class MySQLCommunityMinimalMroongaPackageTask < MroongaPackageTask
 
   def yum_targets_default
     [
-      "almalinux-8",
+      "almalinux-9",
     ]
   end
 end

--- a/packages/mysql-community-minimal-8.0-mroonga/yum/almalinux-9/Dockerfile
+++ b/packages/mysql-community-minimal-8.0-mroonga/yum/almalinux-9/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm \
     https://repo.mysql.com/mysql80-community-release-el9.rpm \
     https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
-  dnf install --disablerepo=appstream -y ${quiet} \
+  dnf install -y ${quiet} \
     mysql-community-devel && \
   dnf install --enablerepo=crb -y ${quiet} \
     https://repo.mysql.com/mysql-community-minimal-release-el9.rpm && \
@@ -27,10 +27,7 @@ RUN \
     ccache \
     groonga-devel \
     groonga-normalizer-mysql-devel \
-    intltool \
-    libcurl-devel \
-    libtool \
-    make \
+    ninja-build \
     pkgconfig \
     rpm-build \
     wget \

--- a/packages/mysql-community-minimal-8.0-mroonga/yum/almalinux-9/Dockerfile
+++ b/packages/mysql-community-minimal-8.0-mroonga/yum/almalinux-9/Dockerfile
@@ -1,26 +1,27 @@
-ARG FROM=almalinux:8
+ARG FROM=almalinux:9
 FROM ${FROM}
 
 ARG DEBUG
 
 ENV \
-  SCL=gcc-toolset-11
+  SCL=gcc-toolset-12
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf update -y ${quiet} && \
-  dnf install --enablerepo=powertools -y ${quiet} \
+  dnf install --enablerepo=crb -y ${quiet} \
     'dnf-command(builddep)' \
     'dnf-command(download)' \
-    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
-  dnf install -y ${quiet} https://repo.mysql.com/mysql80-community-release-el8.rpm && \
+    https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm \
+    https://repo.mysql.com/mysql80-community-release-el9.rpm \
+    https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
   dnf install --disablerepo=appstream -y ${quiet} \
     mysql-community-devel && \
-  dnf install --enablerepo=powertools -y ${quiet} \
-    https://repo.mysql.com/mysql-community-minimal-release-el8.rpm && \
-  dnf builddep --enablerepo=mysql80-community-minimal-source,powertools -y ${quiet} mysql-community-minimal && \
+  dnf install --enablerepo=crb -y ${quiet} \
+    https://repo.mysql.com/mysql-community-minimal-release-el9.rpm && \
+  dnf builddep --enablerepo=mysql80-community-minimal-source,crb -y ${quiet} mysql-community-minimal && \
   dnf download --enablerepo=mysql80-community-minimal-source -y ${quiet} --source mysql-community-minimal && \
-  dnf install --enablerepo=powertools -y ${quiet} \
+  dnf install --enablerepo=crb -y ${quiet} \
     ${SCL} \
     ${SCL}-annobin-plugin-gcc \
     ccache \

--- a/packages/mysql-community-minimal-8.0-mroonga/yum/mysql-community-minimal-8.0-mroonga.spec.in
+++ b/packages/mysql-community-minimal-8.0-mroonga/yum/mysql-community-minimal-8.0-mroonga.spec.in
@@ -10,8 +10,6 @@
 %define _mysql_dist %{?mysql_dist:%{mysql_dist}}%{!?mysql_dist:%{mysql_dist_default}}
 %define _mysql_spec_file %{?mysql_spec_file:%{mysql_spec_file}}%{!?mysql_spec_file:%{mysql_spec_file_default}}
 
-%define dnf_download dnf download
-
 %define groonga_required_version @REQUIRED_GROONGA_VERSION@
 
 Name:		mysql-community-minimal-8.0-mroonga
@@ -25,13 +23,15 @@ URL:		https://mroonga.org/
 Source0:	https://packages.groonga.org/source/mroonga/mroonga-%{version}.tar.gz
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
-BuildRequires:	libcurl-devel
+BuildRequires:	cmake
+BuildRequires:	dnf-command(download)
 BuildRequires:	groonga-devel >= %{groonga_required_version}
 BuildRequires:	groonga-normalizer-mysql-devel
+BuildRequires:	libcurl-devel
 BuildRequires:	mysql-community-devel = %{_mysql_version}-%{_mysql_release}.%{_mysql_dist}
+BuildRequires:	ninja-build
 BuildRequires:	rpm
 BuildRequires:	sed
-BuildRequires:	dnf-command(download)
 Requires:	mysql-community-server-minimal = %{_mysql_version}-%{_mysql_release}.%{_mysql_dist}
 Requires:	groonga-libs >= %{groonga_required_version}
 Requires:	groonga-normalizer-mysql
@@ -45,7 +45,7 @@ column store. Groonga is good at real-time update.
 %setup -q -n mroonga-%{version}
 
 if ! cp /mysql-community-*.src.rpm ./; then
-  %{dnf_download} -y ${quiet} --source mysql-community
+  dnf download -y ${quiet} --source mysql-community
 fi
 rpm -Uvh mysql-community-*.src.rpm
 sed -i'' -e 's/^  make /  # make /' ~/rpmbuild/SPECS/%{_mysql_spec_file}
@@ -55,20 +55,18 @@ sed -i'' -e 's/^  cmake3 /  cmake /' ~/rpmbuild/SPECS/%{_mysql_spec_file}
 rpmbuild -bc ~/rpmbuild/SPECS/%{_mysql_spec_file}
 mysql_source=$HOME/rpmbuild/BUILD/mysql-%{_mysql_version}/mysql-%{_mysql_version}
 mysql_build=$HOME/rpmbuild/BUILD/mysql-%{_mysql_version}/release
-%configure \
-  --disable-static \
-  --with-mysql-source=${mysql_source} \
-  --with-mysql-build=${mysql_build} \
-  --with-mysql-config=${mysql_build}/scripts/mysql_config \
-  --enable-fast-mutexes \
-  %{?mroonga_configure_options}
-make %{?_smp_mflags}
+make -C ${mysql_build}/utilities %{?_smp_mflags} GenError
+%cmake \
+  -DMYSQL_BUILD_DIR=${mysql_build} \
+  -DMYSQL_CONFIG=${mysql_build}/scripts/mysql_config \
+  -DMYSQL_SOURCE_DIR=${mysql_source} \
+  -GNinja \
+  %{?mroonga_cmake_options}
+cmake --build %{__cmake_builddir}
 
 %install
 rm -rf $RPM_BUILD_ROOT
-make install DESTDIR=$RPM_BUILD_ROOT
-rm $RPM_BUILD_ROOT%{_libdir}/mysql/plugin/*.la
-rm -rf  $RPM_BUILD_ROOT%{_datadir}/doc/mroonga
+%cmake_install
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -77,25 +75,6 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %{_libdir}/mysql/plugin/
 %{_datadir}/mroonga/*
-%{_datadir}/man/man1/*
-%{_datadir}/man/*/man1/*
-
-%package -n mysql80-community-minimal-mroonga
-Summary:	A fast fulltext searchable storage engine for MySQL (transitional)
-Group:		Applications/Databases
-License:	LGPLv2.1
-Requires:	mysql-community-minimal-8.0-mroonga = %{version}-%{release}
-
-%description -n mysql80-community-minimal-mroonga
-Mroonga is a fast fulltext searchable storage plugin for MySQL.
-It is based on Groonga that is a fast fulltext search engine and
-column store. Groonga is good at real-time update.
-
-This is a trnsitional package. This can safely be removed.
-
-%files -n mysql80-community-minimal-mroonga
-%defattr(-,root,root,-)
-%doc README COPYING
 
 %changelog
 * Fri Sep 06 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.07-1

--- a/packages/mysql-community-minimal-8.0-mroonga/yum/mysql-community-minimal-8.0-mroonga.spec.in
+++ b/packages/mysql-community-minimal-8.0-mroonga/yum/mysql-community-minimal-8.0-mroonga.spec.in
@@ -1,6 +1,6 @@
 # -*- sh-shell: rpm -*-
 
-%define mysql_version_default 8.0.38
+%define mysql_version_default 8.0.39
 %define mysql_release_default 1
 %define mysql_dist_default    el%{rhel}
 %define mysql_spec_file_default mysql.spec
@@ -99,37 +99,4 @@ This is a trnsitional package. This can safely be removed.
 
 %changelog
 * Fri Sep 06 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.07-1
-- New upstream release.
-
-* Fri Jul 05 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-2
-- build against MySQL 8.0.38.
-
-* Mon Jun 17 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.04-1
-- New upstream release.
-
-* Thu May 09 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-4
-- build against MySQL 8.0.37.
-
-* Fri Jan 19 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-3
-- build against MySQL 8.0.36.
-
-* Wed Oct 25 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-2
-- build against MySQL 8.0.35.
-
-* Tue Aug 01 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.05-1
-- New upstream release.
-
-* Fri Jul 28 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.04-1
-- New upstream release.
-
-* Thu Jul 20 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.01-3
-- build against MySQL 8.0.34.
-
-* Thu Apr 13 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.01-2
-- build against MySQL 8.0.33.
-
-* Thu Apr 13 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.01-1
-- New upstream release.
-
-* Thu Mar 23 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 13.00-1
 - New upstream release.


### PR DESCRIPTION
This package need to create Mroonga's Docker image.
Mroonga's Docker image base on MySQL official docker image( https://hub.docker.com/_/mysql ).

Currently, MySQL official docker image base on Oracle Linux 9.
Ref: https://github.com/docker-library/mysql/blob/3e6dfd03b956727c7fb5b30360512a11751a3e9d/8.0/Dockerfile.oracle

However, we are only providing mysql-community-minimal-8.0 for AlmaLinux 8 currently.
So, we need to provide mysql-community-minimal-8.0 for AlmaLinux 9 to update Mroonga's Docker image.