### PR TITLE
datetime fraction seconds: update index for NULL with `1970-01-01 00:00:00.0` to support index_column_diff

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7324,7 +7324,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
         ((field->real_type() != MYSQL_TYPE_TINY) &&
          (field->real_type() != MYSQL_TYPE_SHORT) &&
          (field->real_type() != MYSQL_TYPE_LONG) &&
-         (field->real_type() != MYSQL_TYPE_TIME2)))
+         (field->real_type() != MYSQL_TYPE_TIME2) &&
+         (field->real_type() != MYSQL_TYPE_DATETIME2)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS
@@ -12146,9 +12147,12 @@ int ha_mroonga::generic_store_bulk_datetime2(Field *field, grn_obj *buf)
   Field_datetimef *datetimef_field = (Field_datetimef *)field;
   MYSQL_TIME mysql_time;
   MRN_FIELD_GET_TIME(datetimef_field, &mysql_time, current_thd);
+  long long int time = 0;
   mrn::TimeConverter time_converter;
-  long long int time = time_converter.mysql_time_to_grn_time(&mysql_time,
-                                                             &truncated);
+  if (!field->is_null()) {
+    time = time_converter.mysql_time_to_grn_time(&mysql_time,
+                                                 &truncated);
+  }
   if (truncated) {
     if (ha_thd()->is_strict_mode()) {
       error = MRN_ERROR_CODE_DATA_TRUNCATE(ha_thd());

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS diaries;
+CREATE TABLE diaries (
+name VARCHAR(255),
+created_at DATETIME(1) NULL,
+KEY created_at_index(created_at)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
+INSERT INTO diaries VALUES ("null day", NULL);
+SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
+mroonga_command("index_column_diff --table diaries#created_at_index --name index")
+[]
+SELECT * FROM diaries WHERE created_at = "1970-01-01 00:00:00.0";
+name	created_at
+zero day	1970-01-01 00:00:00.0
+null day	1970-01-01 00:00:00.0
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
@@ -1,0 +1,42 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+CREATE TABLE diaries (
+  name VARCHAR(255),
+  created_at DATETIME(1) NULL,
+  KEY created_at_index(created_at)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
+INSERT INTO diaries VALUES ("null day", NULL);
+
+SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
+
+SELECT * FROM diaries WHERE created_at = "1970-01-01 00:00:00.0";
+
+DROP TABLE diaries;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores NULL. It means that we don't update index for NULL.
But it causes `index_column_diff` false positive.

`DATETIME` with fraction seconds' NULL is processed as `1970-01-01 00:00:00.0` in Groonga. Because Groonga uses the default value for NULL. `index_column_diff` uses `1970-01-01 00:00:00.0` for NULL in the expected posting lists. It causes false positive.

If we use `1970-01-01 00:00:00.0` instead of ignoring for NULL, we can avoid the false positive. It also enables that we can search NULL column value record by `1970-01-01 00:00:00.0`. In general, it'll be useful but this is an incompatible change. But it'll be acceptable because NULL behavior is undefined by definition.