### PR TITLE
test datetime fraction seconds: skip `1970-01-01 00:00:00.0` insert test on Windows

### DIFF
--- a/mysql-test/mroonga/include/mroonga/skip_windows.inc
+++ b/mysql-test/mroonga/include/mroonga/skip_windows.inc
@@ -1,0 +1,21 @@
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../include/mroonga/check_windows.inc
+
+if ($VERSION_COMPILE_OS_WIN) {
+  --skip This test is not for Windows
+}

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
@@ -4,7 +4,6 @@ name VARCHAR(255),
 created_at DATETIME(1) NULL,
 KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
-SET @@time_zone = '+00:00';
 INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
@@ -4,14 +4,11 @@ name VARCHAR(255),
 created_at DATETIME(1) NULL,
 KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
-SET @@time_zone = '+00:00';
-INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
 mroonga_command("index_column_diff --table diaries#created_at_index --name index")
 []
 SELECT * FROM diaries WHERE created_at = "1970-01-01 00:00:00.0";
 name	created_at
-zero day	1970-01-01 00:00:00.0
 null day	1970-01-01 00:00:00.0
 DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
@@ -4,6 +4,7 @@ name VARCHAR(255),
 created_at DATETIME(1) NULL,
 KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
+SET @@time_zone = '+00:00';
 INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/r/null.result
@@ -4,11 +4,14 @@ name VARCHAR(255),
 created_at DATETIME(1) NULL,
 KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
+SET @@time_zone = '+00:00';
+INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
 mroonga_command("index_column_diff --table diaries#created_at_index --name index")
 []
 SELECT * FROM diaries WHERE created_at = "1970-01-01 00:00:00.0";
 name	created_at
+zero day	1970-01-01 00:00:00.0
 null day	1970-01-01 00:00:00.0
 DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
@@ -29,6 +29,8 @@ CREATE TABLE diaries (
   KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
 
+SET @@time_zone = '+00:00';
+
 INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
@@ -16,6 +16,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+--source ../../../../../include/mroonga/skip_windows.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 --source ../../../../../include/mroonga/load_mroonga_functions.inc
 

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
@@ -29,6 +29,9 @@ CREATE TABLE diaries (
   KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
 
+SET @@time_zone = '+00:00';
+
+INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 
 SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
@@ -29,9 +29,6 @@ CREATE TABLE diaries (
   KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
 
-SET @@time_zone = '+00:00';
-
-INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 
 SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");

--- a/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/fractional_seconds/t/null.test
@@ -30,8 +30,6 @@ CREATE TABLE diaries (
   KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
 
-SET @@time_zone = '+00:00';
-
 INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0");
 INSERT INTO diaries VALUES ("null day", NULL);
 


### PR DESCRIPTION
The following "out of range" error occurred only on Windows' MariaDB when the datetime
value "1970-01-01 00:00:00.0" was set. So we decided to skip this test on only Windows.

```
mysqltest: At line 34: query 'INSERT INTO diaries VALUES ("zero day", "1970-01-01 00:00:00.0")' failed: 1264: Out of range value for column 'created_at' at row 1
```

Note that it might be a valid value because it's between `1000-01-01 00:00:00.000000` - `9999-12-31 23:59:59.999999`: https://mariadb.com/kb/en/datetime/#supported-values
But the error occurred.
