### PR TITLE
{float,double}: update index for `NULL` with `0.0` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7349,7 +7349,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_LONG) &&
                              (field->real_type() != MYSQL_TYPE_TIME2) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME2) &&
-                             (field->real_type() != MYSQL_TYPE_FLOAT)))
+                             (field->real_type() != MYSQL_TYPE_FLOAT) &&
+                             (field->real_type() != MYSQL_TYPE_DOUBLE)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12247,7 +12247,7 @@ int ha_mroonga::generic_store_bulk_float(Field* field, grn_obj* buf)
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  double value = 0;
+  double value = 0.0;
   if (!field->is_null()) {
     value = field->val_real();
   }

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7348,7 +7348,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_SHORT) &&
                              (field->real_type() != MYSQL_TYPE_LONG) &&
                              (field->real_type() != MYSQL_TYPE_TIME2) &&
-                             (field->real_type() != MYSQL_TYPE_DATETIME2)))
+                             (field->real_type() != MYSQL_TYPE_DATETIME2) &&
+                             (field->real_type() != MYSQL_TYPE_FLOAT)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS
@@ -12245,7 +12246,10 @@ int ha_mroonga::generic_store_bulk_float(Field* field, grn_obj* buf)
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  double value = field->val_real();
+  double value = 0;
+  if (!field->is_null()) {
+    value = field->val_real();
+  }
   uint32 size = field->pack_length();
   switch (size) {
   case 4:

--- a/mysql-test/mroonga/storage/column/double/r/null.result
+++ b/mysql-test/mroonga/storage/column/double/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS numbers;
+CREATE TABLE numbers (
+name VARCHAR(255),
+value DOUBLE NULL,
+KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO numbers VALUES ("zero", 0.0);
+INSERT INTO numbers VALUES ("null", NULL);
+INSERT INTO numbers VALUES ("pi", 3.14);
+SELECT mroonga_command("index_column_diff --table numbers#value_index --name index");
+mroonga_command("index_column_diff --table numbers#value_index --name index")
+[]
+SELECT * FROM numbers WHERE value = 0.0;
+name	value
+zero	0
+null	0
+DROP TABLE numbers;

--- a/mysql-test/mroonga/storage/column/double/t/null.test
+++ b/mysql-test/mroonga/storage/column/double/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS numbers;
+--enable_warnings
+
+CREATE TABLE numbers (
+  name VARCHAR(255),
+  value DOUBLE NULL,
+  KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO numbers VALUES ("zero", 0.0);
+INSERT INTO numbers VALUES ("null", NULL);
+INSERT INTO numbers VALUES ("pi", 3.14);
+
+SELECT mroonga_command("index_column_diff --table numbers#value_index --name index");
+
+SELECT * FROM numbers WHERE value = 0.0;
+
+DROP TABLE numbers;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/float/r/null.result
+++ b/mysql-test/mroonga/storage/column/float/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS numbers;
+CREATE TABLE numbers (
+name VARCHAR(255),
+value FLOAT NULL,
+KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO numbers VALUES ("zero", 0.0);
+INSERT INTO numbers VALUES ("null", NULL);
+INSERT INTO numbers VALUES ("pi", 3.14);
+SELECT mroonga_command("index_column_diff --table numbers#value_index --name index");
+mroonga_command("index_column_diff --table numbers#value_index --name index")
+[]
+SELECT * FROM numbers WHERE value = 0.0;
+name	value
+zero	0
+null	0
+DROP TABLE numbers;

--- a/mysql-test/mroonga/storage/column/float/t/null.test
+++ b/mysql-test/mroonga/storage/column/float/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS numbers;
+--enable_warnings
+
+CREATE TABLE numbers (
+  name VARCHAR(255),
+  value FLOAT NULL,
+  KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO numbers VALUES ("zero", 0.0);
+INSERT INTO numbers VALUES ("null", NULL);
+INSERT INTO numbers VALUES ("pi", 3.14);
+
+SELECT mroonga_command("index_column_diff --table numbers#value_index --name index");
+
+SELECT * FROM numbers WHERE value = 0.0;
+
+DROP TABLE numbers;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`.
But it causes `index_column_diff` false positive.

The `float` and `double` with `NULL` is processed as `0.0` in Groonga. Because Groonga uses the default value for `NULL`.
`index_column_diff` uses `0.0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0.0` instead of ignoring for `NULL`, we can avoid the false positive.
It also enables that we can search `NULL` column value record by `0.0`.
In general, it'll be useful but this is an incompatible change.
But it'll be acceptable because `NULL` behavior is undefined by definition.