### PR TITLE
timestamp fraction seconds: update index for `NULL` with `0000-00-00 00:00:00.0` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7350,7 +7350,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_TIME2) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME2) &&
                              (field->real_type() != MYSQL_TYPE_FLOAT) &&
-                             (field->real_type() != MYSQL_TYPE_DOUBLE)))
+                             (field->real_type() != MYSQL_TYPE_DOUBLE) &&
+                             (field->real_type() != MYSQL_TYPE_TIMESTAMP2)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS
@@ -12390,10 +12391,13 @@ int ha_mroonga::generic_store_bulk_timestamp2(Field* field, grn_obj* buf)
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
+  int64_t grn_time = 0;
+  Field_timestampf *timestamp_field = static_cast<Field_timestampf *>(field);
   mrn::TimestampFieldValueConverter<Field_timestampf> converter(
     timestamp_field);
-  int64_t grn_time = converter.convert();
+  if (!field->is_null()) {
+    grn_time = converter.convert();
+  }
   grn_obj_reinit(ctx, buf, GRN_DB_TIME, 0);
   GRN_TIME_SET(ctx, buf, grn_time);
   DBUG_RETURN(error);

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12392,10 +12392,10 @@ int ha_mroonga::generic_store_bulk_timestamp2(Field* field, grn_obj* buf)
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
   int64_t grn_time = 0;
-  Field_timestampf *timestamp_field = static_cast<Field_timestampf *>(field);
-  mrn::TimestampFieldValueConverter<Field_timestampf> converter(
-    timestamp_field);
   if (!field->is_null()) {
+    Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
+    mrn::TimestampFieldValueConverter<Field_timestampf> converter(
+      timestamp_field);
     grn_time = converter.convert();
   }
   grn_obj_reinit(ctx, buf, GRN_DB_TIME, 0);

--- a/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/r/null.result
+++ b/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS diaries;
+CREATE TABLE diaries (
+name VARCHAR(255),
+created_at TIMESTAMP(1) NULL,
+KEY created_at_index(created_at)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ("zero day", "0000-00-00 00:00:00.0");
+INSERT INTO diaries VALUES ("null day", NULL);
+INSERT INTO diaries VALUES ("Mroonga release day", "2010-8-19 00:00:00.0");
+SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
+mroonga_command("index_column_diff --table diaries#created_at_index --name index")
+[]
+SELECT * FROM diaries WHERE created_at = "0000-00-00 00:00:00.0";
+name	created_at
+zero day	0000-00-00 00:00:00.0
+null day	0000-00-00 00:00:00.0
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/r/null.result
+++ b/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/r/null.result
@@ -1,17 +1,17 @@
 DROP TABLE IF EXISTS diaries;
 CREATE TABLE diaries (
 name VARCHAR(255),
-created_at TIMESTAMP(1) NULL,
-KEY created_at_index(created_at)
+recorded_at TIMESTAMP(1) NULL,
+KEY recorded_at_index(recorded_at)
 ) DEFAULT CHARSET=utf8mb4;
-INSERT INTO diaries VALUES ("zero day", "0000-00-00 00:00:00.0");
-INSERT INTO diaries VALUES ("null day", NULL);
-INSERT INTO diaries VALUES ("Mroonga release day", "2010-8-19 00:00:00.0");
-SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
-mroonga_command("index_column_diff --table diaries#created_at_index --name index")
+INSERT INTO diaries VALUES ("zero time", "0000-00-00 00:00:00.0");
+INSERT INTO diaries VALUES ("null time", NULL);
+INSERT INTO diaries VALUES ("Mroonga release time", "2010-8-19 10:09:19.0");
+SELECT mroonga_command("index_column_diff --table diaries#recorded_at_index --name index");
+mroonga_command("index_column_diff --table diaries#recorded_at_index --name index")
 []
-SELECT * FROM diaries WHERE created_at = "0000-00-00 00:00:00.0";
-name	created_at
-zero day	0000-00-00 00:00:00.0
-null day	0000-00-00 00:00:00.0
+SELECT * FROM diaries WHERE recorded_at = "0000-00-00 00:00:00.0";
+name	recorded_at
+zero time	0000-00-00 00:00:00.0
+null time	0000-00-00 00:00:00.0
 DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/t/null.test
@@ -25,17 +25,17 @@ DROP TABLE IF EXISTS diaries;
 
 CREATE TABLE diaries (
   name VARCHAR(255),
-  created_at TIMESTAMP(1) NULL,
-  KEY created_at_index(created_at)
+  recorded_at TIMESTAMP(1) NULL,
+  KEY recorded_at_index(recorded_at)
 ) DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO diaries VALUES ("zero day", "0000-00-00 00:00:00.0");
-INSERT INTO diaries VALUES ("null day", NULL);
-INSERT INTO diaries VALUES ("Mroonga release day", "2010-8-19 00:00:00.0");
+INSERT INTO diaries VALUES ("zero time", "0000-00-00 00:00:00.0");
+INSERT INTO diaries VALUES ("null time", NULL);
+INSERT INTO diaries VALUES ("Mroonga release time", "2010-8-19 10:09:19.0");
 
-SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
+SELECT mroonga_command("index_column_diff --table diaries#recorded_at_index --name index");
 
-SELECT * FROM diaries WHERE created_at = "0000-00-00 00:00:00.0";
+SELECT * FROM diaries WHERE recorded_at = "0000-00-00 00:00:00.0";
 
 DROP TABLE diaries;
 

--- a/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../../include/mroonga/have_mroonga.inc
+--source ../../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+CREATE TABLE diaries (
+  name VARCHAR(255),
+  created_at TIMESTAMP(1) NULL,
+  KEY created_at_index(created_at)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO diaries VALUES ("zero day", "0000-00-00 00:00:00.0");
+INSERT INTO diaries VALUES ("null day", NULL);
+INSERT INTO diaries VALUES ("Mroonga release day", "2010-8-19 00:00:00.0");
+
+SELECT mroonga_command("index_column_diff --table diaries#created_at_index --name index");
+
+SELECT * FROM diaries WHERE created_at = "0000-00-00 00:00:00.0";
+
+DROP TABLE diaries;
+
+--source ../../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/t/null.test
+++ b/mysql-test/mroonga/storage/column/timestamp/fractional_seconds/t/null.test
@@ -16,6 +16,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+# MySQL enables STRICT_ALL_TABLES by default and it rejects "0000-00-00 00:00:00.0".
+--source ../../../../../include/mroonga/have_mariadb.inc
 --source ../../../../../include/mroonga/have_mroonga.inc
 --source ../../../../../include/mroonga/load_mroonga_functions.inc
 


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive.
`TIMESTAMP` with fraction seconds' `NULL` is processed as `0000-00-00 00:00:00.0` in Groonga. Because Groonga uses the default value for `NULL`. `index_column_diff` uses `0000-00-00 00:00:00.0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0000-00-00 00:00:00.0` instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `0000-00-00 00:00:00.0`. In general, it'll be useful but this is an incompatible change. But it'll be acceptable because `NULL` behavior is undefined by definition.