### PR TITLE
enum: update index for `NULL` with `0` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7351,7 +7351,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_DATETIME2) &&
                              (field->real_type() != MYSQL_TYPE_FLOAT) &&
                              (field->real_type() != MYSQL_TYPE_DOUBLE) &&
-                             (field->real_type() != MYSQL_TYPE_TIMESTAMP2)))
+                             (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
+                             (field->real_type() != MYSQL_TYPE_ENUM)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS

--- a/mysql-test/mroonga/storage/column/enum/r/null.result
+++ b/mysql-test/mroonga/storage/column/enum/r/null.result
@@ -10,7 +10,7 @@ INSERT INTO users VALUES ("bob", "guest");
 SELECT mroonga_command("index_column_diff --table users#role_index --name index");
 mroonga_command("index_column_diff --table users#role_index --name index")
 []
-SELECT * FROM users WHERE role = '';
+SELECT * FROM users WHERE role = "";
 name	role
 newbie	
 alice	

--- a/mysql-test/mroonga/storage/column/enum/r/null.result
+++ b/mysql-test/mroonga/storage/column/enum/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS users;
+CREATE TABLE users (
+name VARCHAR(255),
+role ENUM("guest") NULL,
+KEY role_index(role)
+) DEFAULT CHARSET=utf8mb4;
+INSERT IGNORE INTO users VALUES ("newbie", "");
+INSERT INTO users VALUES ("alice", NULL);
+INSERT INTO users VALUES ("bob", "guest");
+SELECT mroonga_command("index_column_diff --table users#role_index --name index");
+mroonga_command("index_column_diff --table users#role_index --name index")
+[]
+SELECT * FROM users WHERE role = '';
+name	role
+newbie	
+alice	
+DROP TABLE users;

--- a/mysql-test/mroonga/storage/column/enum/t/null.test
+++ b/mysql-test/mroonga/storage/column/enum/t/null.test
@@ -1,0 +1,45 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS users;
+--enable_warnings
+
+CREATE TABLE users (
+  name VARCHAR(255),
+  role ENUM("guest") NULL,
+  KEY role_index(role)
+) DEFAULT CHARSET=utf8mb4;
+
+--disable_warnings
+INSERT IGNORE INTO users VALUES ("newbie", "");
+--enable_warnings
+INSERT INTO users VALUES ("alice", NULL);
+INSERT INTO users VALUES ("bob", "guest");
+
+SELECT mroonga_command("index_column_diff --table users#role_index --name index");
+
+SELECT * FROM users WHERE role = '';
+
+DROP TABLE users;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/enum/t/null.test
+++ b/mysql-test/mroonga/storage/column/enum/t/null.test
@@ -37,7 +37,7 @@ INSERT INTO users VALUES ("bob", "guest");
 
 SELECT mroonga_command("index_column_diff --table users#role_index --name index");
 
-SELECT * FROM users WHERE role = '';
+SELECT * FROM users WHERE role = "";
 
 DROP TABLE users;
 


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive. `ENUM` with `NULL` is processed as `0` in Groonga. Because Groonga uses the default value for `NULL`. `ENUM` value is a string in user level but it's integer in MySQL/MariaDB internal. `NULL` `ENUM` value is `NULL` in MySQL/MariaDB internal and invalid `ENUM` value (`''`) is `0` in MySQL/MariaDB internal. We use `0` not `NULL` for Groonga because Groonga doesn't support `NULL`. The `index_column_diff` uses `0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0` instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `''` (or `0`).

In general, it'll be useful but this is an incompatible change. But it'll be acceptable because `NULL` behavior is undefined by definition.