### PR TITLE
set: update index for `NULL` with `0` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7352,7 +7352,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_FLOAT) &&
                              (field->real_type() != MYSQL_TYPE_DOUBLE) &&
                              (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
-                             (field->real_type() != MYSQL_TYPE_ENUM)))
+                             (field->real_type() != MYSQL_TYPE_ENUM) &&
+                             (field->real_type() != MYSQL_TYPE_SET)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS

--- a/mysql-test/mroonga/storage/column/set/r/null.test
+++ b/mysql-test/mroonga/storage/column/set/r/null.test
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS items;
+CREATE TABLE items (
+name VARCHAR(255),
+color SET('black') NULL,
+KEY color_index(color)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO items VALUES ('hat', '');
+INSERT INTO items VALUES ('t-shart', NULL);
+INSERT INTO items VALUES ('parka', 'black');
+SELECT mroonga_command('index_column_diff --table items#color_index --name index');
+mroonga_command('index_column_diff --table items#color_index --name index')
+[]
+SELECT * FROM items WHERE color = '';
+name	color
+hat	
+t-shart	
+DROP TABLE items;

--- a/mysql-test/mroonga/storage/column/set/t/null.test
+++ b/mysql-test/mroonga/storage/column/set/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS items;
+--enable_warnings
+
+CREATE TABLE items (
+  name VARCHAR(255),
+  color SET('black') NULL,
+  KEY color_index(color)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO items VALUES ('hat', '');
+INSERT INTO items VALUES ('t-shart', NULL);
+INSERT INTO items VALUES ('parka', 'black');
+
+SELECT mroonga_command('index_column_diff --table items#color_index --name index');
+
+SELECT * FROM items WHERE color = '';
+
+DROP TABLE items;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive. `SET` with `NULL` is processed as `0` in Groonga.
Because Groonga uses the default value for `NULL`. `SET` value is a string in user level, but it's integer in MySQL/MariaDB internal. `NULL` `SET` value is `NULL` in MySQL/MariaDB internal and  an empty `SET` value (`''`) is `0` in MySQL/MariaDB internal. We use `0` not `NULL` for Groonga because Groonga doesn't support `NULL`. The `index_column_diff` uses `0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0` instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `''` (or `0`).

In general, it'll be useful but this is an incompatible change. But it'll be acceptable because `NULL` behavior is undefined by definition.