### PR TITLE
year: update index for `NULL` with `1970` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7347,11 +7347,12 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
     if (field->is_null() && ((field->real_type() != MYSQL_TYPE_TINY) &&
                              (field->real_type() != MYSQL_TYPE_SHORT) &&
                              (field->real_type() != MYSQL_TYPE_LONG) &&
+                             (field->real_type() != MYSQL_TYPE_YEAR) &&
                              (field->real_type() != MYSQL_TYPE_TIME2) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME2) &&
+                             (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
                              (field->real_type() != MYSQL_TYPE_FLOAT) &&
                              (field->real_type() != MYSQL_TYPE_DOUBLE) &&
-                             (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
                              (field->real_type() != MYSQL_TYPE_ENUM) &&
                              (field->real_type() != MYSQL_TYPE_SET)))
       continue;
@@ -12359,11 +12360,13 @@ int ha_mroonga::generic_store_bulk_year(Field* field, grn_obj* buf)
   int error = 0;
   bool truncated = false;
 
-  int year;
-  if (field->field_length == 2) {
-    year = static_cast<int>(field->val_int() + 2000);
-  } else {
-    year = static_cast<int>(field->val_int());
+  int year = 1970;
+  if (!field->is_null()) {
+    if (field->field_length == 2) {
+      year = static_cast<int>(field->val_int() + 2000);
+    } else {
+      year = static_cast<int>(field->val_int());
+    }
   }
 
   DBUG_PRINT("info", ("mroonga: year=%d", year));

--- a/mysql-test/mroonga/storage/column/year/r/null.result
+++ b/mysql-test/mroonga/storage/column/year/r/null.result
@@ -4,13 +4,13 @@ name VARCHAR(255),
 year YEAR NULL,
 KEY year_index(year)
 ) DEFAULT CHARSET=utf8mb4;
-INSERT INTO anniversaries VALUES ("epoch year", "1970");
-INSERT INTO anniversaries VALUES ("null year", NULL);
-INSERT INTO anniversaries VALUES ("mroonga birth year", "2010");
-SELECT mroonga_command("index_column_diff --table anniversaries#year_index --name index");
-mroonga_command("index_column_diff --table anniversaries#year_index --name index")
+INSERT INTO anniversaries VALUES ('epoch year', '1970');
+INSERT INTO anniversaries VALUES ('null year', NULL);
+INSERT INTO anniversaries VALUES ('mroonga birth year', '2010');
+SELECT mroonga_command('index_column_diff --table anniversaries#year_index --name index');
+mroonga_command('index_column_diff --table anniversaries#year_index --name index')
 []
-SELECT * FROM anniversaries where year = "1970";
+SELECT * FROM anniversaries where year = '1970';
 name	year
 epoch year	1970
 null year	1970

--- a/mysql-test/mroonga/storage/column/year/r/null.result
+++ b/mysql-test/mroonga/storage/column/year/r/null.result
@@ -4,13 +4,13 @@ name VARCHAR(255),
 year YEAR NULL,
 KEY year_index(year)
 ) DEFAULT CHARSET=utf8mb4;
-INSERT INTO anniversaries VALUES ('epoch year', '1970');
+INSERT INTO anniversaries VALUES ('epoch year', 1970);
 INSERT INTO anniversaries VALUES ('null year', NULL);
-INSERT INTO anniversaries VALUES ('mroonga birth year', '2010');
+INSERT INTO anniversaries VALUES ('mroonga birth year', 2010);
 SELECT mroonga_command('index_column_diff --table anniversaries#year_index --name index');
 mroonga_command('index_column_diff --table anniversaries#year_index --name index')
 []
-SELECT * FROM anniversaries where year = '1970';
+SELECT * FROM anniversaries where year = 1970;
 name	year
 epoch year	1970
 null year	1970

--- a/mysql-test/mroonga/storage/column/year/r/null.result
+++ b/mysql-test/mroonga/storage/column/year/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS anniversaries;
+CREATE TABLE anniversaries (
+name VARCHAR(255),
+year YEAR NULL,
+KEY year_index(year)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO anniversaries VALUES ("epoch year", "1970");
+INSERT INTO anniversaries VALUES ("null year", NULL);
+INSERT INTO anniversaries VALUES ("mroonga birth year", "2010");
+SELECT mroonga_command("index_column_diff --table anniversaries#year_index --name index");
+mroonga_command("index_column_diff --table anniversaries#year_index --name index")
+[]
+SELECT * FROM anniversaries where year = "1970";
+name	year
+epoch year	1970
+null year	1970
+DROP TABLE anniversaries;

--- a/mysql-test/mroonga/storage/column/year/t/null.test
+++ b/mysql-test/mroonga/storage/column/year/t/null.test
@@ -30,13 +30,13 @@ CREATE TABLE anniversaries (
   KEY year_index(year)
 ) DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO anniversaries VALUES ('epoch year', '1970');
+INSERT INTO anniversaries VALUES ('epoch year', 1970);
 INSERT INTO anniversaries VALUES ('null year', NULL);
-INSERT INTO anniversaries VALUES ('mroonga birth year', '2010');
+INSERT INTO anniversaries VALUES ('mroonga birth year', 2010);
 
 SELECT mroonga_command('index_column_diff --table anniversaries#year_index --name index');
 
-SELECT * FROM anniversaries where year = '1970';
+SELECT * FROM anniversaries where year = 1970;
 
 DROP TABLE anniversaries;
 

--- a/mysql-test/mroonga/storage/column/year/t/null.test
+++ b/mysql-test/mroonga/storage/column/year/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS anniversaries;
+--enable_warnings
+
+CREATE TABLE anniversaries (
+  name VARCHAR(255),
+  year YEAR NULL,
+  KEY year_index(year)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO anniversaries VALUES ("epoch year", "1970");
+INSERT INTO anniversaries VALUES ("null year", NULL);
+INSERT INTO anniversaries VALUES ("mroonga birth year", "2010");
+
+SELECT mroonga_command("index_column_diff --table anniversaries#year_index --name index");
+
+SELECT * FROM anniversaries where year = "1970";
+
+DROP TABLE anniversaries;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/year/t/null.test
+++ b/mysql-test/mroonga/storage/column/year/t/null.test
@@ -16,6 +16,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+--source ../../../../include/mroonga/skip_windows.inc
 --source ../../../../include/mroonga/have_mroonga.inc
 --source ../../../../include/mroonga/load_mroonga_functions.inc
 

--- a/mysql-test/mroonga/storage/column/year/t/null.test
+++ b/mysql-test/mroonga/storage/column/year/t/null.test
@@ -30,13 +30,13 @@ CREATE TABLE anniversaries (
   KEY year_index(year)
 ) DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO anniversaries VALUES ("epoch year", "1970");
-INSERT INTO anniversaries VALUES ("null year", NULL);
-INSERT INTO anniversaries VALUES ("mroonga birth year", "2010");
+INSERT INTO anniversaries VALUES ('epoch year', '1970');
+INSERT INTO anniversaries VALUES ('null year', NULL);
+INSERT INTO anniversaries VALUES ('mroonga birth year', '2010');
 
-SELECT mroonga_command("index_column_diff --table anniversaries#year_index --name index");
+SELECT mroonga_command('index_column_diff --table anniversaries#year_index --name index');
 
-SELECT * FROM anniversaries where year = "1970";
+SELECT * FROM anniversaries where year = '1970';
 
 DROP TABLE anniversaries;
 


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive. `YEAR` with `NULL` is processed as `1970` in Groonga. Because Groonga uses the default value for `NULL`. `index_column_diff` uses `1970` for `NULL` in the expected posting lists. It causes false positive.

If we use `1970` instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `1970`.

In general, it'll be useful but this is an incompatible change. But it'll be acceptable because `NULL` behavior is undefined by definition.