### PR TITLE
datetime: update index for `NULL` with `1970-01-01 00:00:00` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7349,6 +7349,7 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_LONG) &&
                              (field->real_type() != MYSQL_TYPE_YEAR) &&
                              (field->real_type() != MYSQL_TYPE_TIME) &&
+                             (field->real_type() != MYSQL_TYPE_DATETIME) &&
                              (field->real_type() != MYSQL_TYPE_TIME2) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME2) &&
                              (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
@@ -12339,9 +12340,11 @@ int ha_mroonga::generic_store_bulk_datetime(Field* field, grn_obj* buf)
   Field_datetime* datetime_field = (Field_datetime*)field;
   MYSQL_TIME mysql_time;
   MRN_FIELD_GET_TIME(datetime_field, &mysql_time, current_thd);
-  mrn::TimeConverter time_converter;
-  long long int time =
-    time_converter.mysql_time_to_grn_time(&mysql_time, &truncated);
+  long long int time = 0;
+  if (!field->is_null()) {
+    mrn::TimeConverter time_converter;
+    time = time_converter.mysql_time_to_grn_time(&mysql_time, &truncated);
+  }
   if (truncated) {
     if (ha_thd()->is_strict_mode()) {
       error = MRN_ERROR_CODE_DATA_TRUNCATE(ha_thd());

--- a/mysql-test/mroonga/storage/column/datetime/r/null.result
+++ b/mysql-test/mroonga/storage/column/datetime/r/null.result
@@ -4,14 +4,14 @@ title TEXT,
 created_at DATETIME NULL,
 KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
-INSERT INTO diaries VALUES ('zero datetime', '1970-01-01 00:00:00');
+INSERT INTO diaries VALUES ('epoch datetime', '1970-01-01 00:00:00');
 INSERT INTO diaries VALUES ('null datetime', NULL);
-INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19 10:08:19');
+INSERT INTO diaries VALUES ('Mroonga release datetime', '2010-8-19 10:08:19');
 SELECT mroonga_command('index_column_diff --table diaries#created_at_index --name index');
 mroonga_command('index_column_diff --table diaries#created_at_index --name index')
 []
 SELECT * FROM diaries WHERE created_at = '1970-01-01 00:00:00';
 title	created_at
-zero datetime	1970-01-01 00:00:00
+epoch datetime	1970-01-01 00:00:00
 null datetime	1970-01-01 00:00:00
 DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/datetime/r/null.result
+++ b/mysql-test/mroonga/storage/column/datetime/r/null.result
@@ -1,12 +1,17 @@
 DROP TABLE IF EXISTS diaries;
 CREATE TABLE diaries (
-id INT PRIMARY KEY AUTO_INCREMENT,
 title TEXT,
-created_at DATETIME
-) DEFAULT CHARSET UTF8MB4;
-INSERT INTO diaries (title, created_at)
-VALUES ('NULL', NULL);
-SELECT * FROM diaries;
-id	title	created_at
-1	NULL	1970-01-01 00:00:00
+created_at DATETIME NULL,
+KEY created_at_index(created_at)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ('zero datetime', '1970-01-01 00:00:00');
+INSERT INTO diaries VALUES ('null datetime', NULL);
+INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19 10:08:19');
+SELECT mroonga_command('index_column_diff --table diaries#created_at_index --name index');
+mroonga_command('index_column_diff --table diaries#created_at_index --name index')
+[]
+SELECT * FROM diaries WHERE created_at = '1970-01-01 00:00:00';
+title	created_at
+zero datetime	1970-01-01 00:00:00
+null datetime	1970-01-01 00:00:00
 DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/datetime/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/t/null.test
@@ -14,23 +14,29 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+--source ../../../../include/mroonga/skip_windows.inc
 --source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS diaries;
 --enable_warnings
 
 CREATE TABLE diaries (
-  id INT PRIMARY KEY AUTO_INCREMENT,
   title TEXT,
-  created_at DATETIME
-) DEFAULT CHARSET UTF8MB4;
+  created_at DATETIME NULL,
+  KEY created_at_index(created_at)
+) DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO diaries (title, created_at)
-       VALUES ('NULL', NULL);
+INSERT INTO diaries VALUES ('zero datetime', '1970-01-01 00:00:00');
+INSERT INTO diaries VALUES ('null datetime', NULL);
+INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19 10:08:19');
 
-SELECT * FROM diaries;
+SELECT mroonga_command('index_column_diff --table diaries#created_at_index --name index');
+
+SELECT * FROM diaries WHERE created_at = '1970-01-01 00:00:00';
 
 DROP TABLE diaries;
 
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
 --source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/datetime/t/null.test
+++ b/mysql-test/mroonga/storage/column/datetime/t/null.test
@@ -28,9 +28,9 @@ CREATE TABLE diaries (
   KEY created_at_index(created_at)
 ) DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO diaries VALUES ('zero datetime', '1970-01-01 00:00:00');
+INSERT INTO diaries VALUES ('epoch datetime', '1970-01-01 00:00:00');
 INSERT INTO diaries VALUES ('null datetime', NULL);
-INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19 10:08:19');
+INSERT INTO diaries VALUES ('Mroonga release datetime', '2010-8-19 10:08:19');
 
 SELECT mroonga_command('index_column_diff --table diaries#created_at_index --name index');
 


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive.

`DATETIME` with `NULL` is processed as `0` in Unix time (`1970-01-01 00:00:00` in MySQL/MariaDB) in Groonga. Because Groonga uses the default value for `NULL`. `index_column_diff` uses `0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0` in Unix time (`1970-01-01 00:00:00` in MySQL/MariaDB) instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `1970-01-01 00:00:00`. In general, it'll be useful but this is an incompatible change. But it'll be acceptable because NULL behavior is undefined by definition.