### PR TITLE
time: update index for `NULL` with `00:00:00` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7348,6 +7348,7 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_SHORT) &&
                              (field->real_type() != MYSQL_TYPE_LONG) &&
                              (field->real_type() != MYSQL_TYPE_YEAR) &&
+                             (field->real_type() != MYSQL_TYPE_TIME) &&
                              (field->real_type() != MYSQL_TYPE_TIME2) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME2) &&
                              (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&

--- a/mysql-test/mroonga/storage/column/time/r/null.result
+++ b/mysql-test/mroonga/storage/column/time/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS schedule_times;
+CREATE TABLE schedule_times (
+name VARCHAR(255),
+time TIME NULL,
+KEY time_index(time)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO schedule_times VALUES ('midnight', '00:00:00');
+INSERT INTO schedule_times VALUES ('null time', NULL);
+INSERT INTO schedule_times VALUES ('sunrise', '05:43:10');
+SELECT mroonga_command('index_column_diff --table schedule_times#time_index --name index');
+mroonga_command('index_column_diff --table schedule_times#time_index --name index')
+[]
+SELECT * FROM schedule_times WHERE time = '00:00:00';
+name	time
+midnight	00:00:00
+null time	00:00:00
+DROP TABLE schedule_times;

--- a/mysql-test/mroonga/storage/column/time/t/null.test
+++ b/mysql-test/mroonga/storage/column/time/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS schedule_times;
+--enable_warnings
+
+CREATE TABLE schedule_times (
+  name VARCHAR(255),
+  time TIME NULL,
+  KEY time_index(time)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO schedule_times VALUES ('midnight', '00:00:00');
+INSERT INTO schedule_times VALUES ('null time', NULL);
+INSERT INTO schedule_times VALUES ('sunrise', '05:43:10');
+
+SELECT mroonga_command('index_column_diff --table schedule_times#time_index --name index');
+
+SELECT * FROM schedule_times WHERE time = '00:00:00';
+
+DROP TABLE schedule_times;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive.

`time` with `NULL` is processed as  `0` (`00:00:00`  in MySQL/MariaDB) in Groonga. Because Groonga uses the default value for `NULL`. `index_column_diff` uses `0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0`( `00:00:00`  in MySQL/MariaDB) instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `00:00:00`. In general, it'll be useful but this is an incompatible change. But it'll be acceptable because NULL behavior is undefined by definition.