### PR TITLE
timestamp: update index for `NULL` with `0000-00-00 00:00:00` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7360,6 +7360,7 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_YEAR) &&
                              (field->real_type() != MYSQL_TYPE_TIME) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME) &&
+                             (field->real_type() != MYSQL_TYPE_TIMESTAMP) &&
                              (field->real_type() != MYSQL_TYPE_TIME2) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME2) &&
                              (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
@@ -12296,9 +12297,13 @@ int ha_mroonga::generic_store_bulk_timestamp(Field* field, grn_obj* buf)
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  Field_timestamp* timestamp_field = static_cast<Field_timestamp*>(field);
-  mrn::TimestampFieldValueConverter<Field_timestamp> converter(timestamp_field);
-  int64_t grn_time = converter.convert();
+  int64_t grn_time = 0;
+  if (!field->is_null()) {
+    Field_timestamp* timestamp_field = static_cast<Field_timestamp*>(field);
+    mrn::TimestampFieldValueConverter<Field_timestamp> converter(
+      timestamp_field);
+    grn_time = converter.convert();
+  }
   grn_obj_reinit(ctx, buf, GRN_DB_TIME, 0);
   GRN_TIME_SET(ctx, buf, grn_time);
   DBUG_RETURN(error);

--- a/mysql-test/mroonga/storage/column/timestamp/r/null.result
+++ b/mysql-test/mroonga/storage/column/timestamp/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS diaries;
+CREATE TABLE diaries (
+name VARCHAR(255),
+recorded_at TIMESTAMP NULL,
+KEY recorded_at_index(recorded_at)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ('zero time', '0000-00-00 00:00:00');
+INSERT INTO diaries VALUES ('null time', NULL);
+INSERT INTO diaries VALUES ('Mroonga release time', '2010-8-19 10:09:19');
+SELECT mroonga_command('index_column_diff --table diaries#recorded_at_index --name index');
+mroonga_command('index_column_diff --table diaries#recorded_at_index --name index')
+[]
+SELECT * FROM diaries WHERE recorded_at = '0000-00-00 00:00:00';
+name	recorded_at
+zero time	0000-00-00 00:00:00
+null time	0000-00-00 00:00:00
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/timestamp/t/null.test
+++ b/mysql-test/mroonga/storage/column/timestamp/t/null.test
@@ -1,0 +1,45 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+# MySQL enables STRICT_ALL_TABLES by default and it rejects '0000-00-00 00:00:00.0'.
+--source ../../../../include/mroonga/have_mariadb.inc
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+CREATE TABLE diaries (
+  name VARCHAR(255),
+  recorded_at TIMESTAMP NULL,
+  KEY recorded_at_index(recorded_at)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO diaries VALUES ('zero time', '0000-00-00 00:00:00');
+INSERT INTO diaries VALUES ('null time', NULL);
+INSERT INTO diaries VALUES ('Mroonga release time', '2010-8-19 10:09:19');
+
+SELECT mroonga_command('index_column_diff --table diaries#recorded_at_index --name index');
+
+SELECT * FROM diaries WHERE recorded_at = '0000-00-00 00:00:00';
+
+DROP TABLE diaries;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive.

`timestamp` with `NULL` is processed as  `0` (`0000-00-00 00:00:00`  in MySQL/MariaDB) in Groonga. Because Groonga uses the default value for `NULL`. `index_column_diff` uses `0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0`( `0000-00-00 00:00:00`  in MySQL/MariaDB) instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `0000-00-00 00:00:00`. In general, it'll be useful but this is an incompatible change. But it'll be acceptable because NULL behavior is undefined by definition.

Note: MySQL enables STRICT_ALL_TABLES by default and it rejects `0000-00-00 00:00:00.0`.