### PR TITLE
bit: update index for `NULL` with `0` (`b'0'`) to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7367,7 +7367,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_FLOAT) &&
                              (field->real_type() != MYSQL_TYPE_DOUBLE) &&
                              (field->real_type() != MYSQL_TYPE_ENUM) &&
-                             (field->real_type() != MYSQL_TYPE_SET)))
+                             (field->real_type() != MYSQL_TYPE_SET) &&
+                             (field->real_type() != MYSQL_TYPE_BIT)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS
@@ -12224,7 +12225,10 @@ int ha_mroonga::generic_store_bulk_unsigned_integer(Field* field, grn_obj* buf)
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  long long signed_value = field->val_int();
+  long long signed_value = 0;
+  if (!field->is_null()) {
+    signed_value = field->val_int();
+  }
   unsigned long long unsigned_value = *((unsigned long long*)(&signed_value));
   uint32 size = field->pack_length();
   switch (size) {

--- a/mysql-test/mroonga/storage/column/bit/r/null.result
+++ b/mysql-test/mroonga/storage/column/bit/r/null.result
@@ -1,0 +1,21 @@
+DROP TABLE IF EXISTS roles;
+CREATE TABLE roles (
+name VARCHAR(255),
+flag BIT(1) NULL,
+KEY flag_index(flag)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO roles VALUES ('non-admin', b'0');
+INSERT INTO roles VALUES ('unknown', NULL);
+INSERT INTO roles VALUES ('admin', b'1');
+SELECT mroonga_command('index_column_diff --table roles#flag_index --name index');
+mroonga_command('index_column_diff --table roles#flag_index --name index')
+[]
+SELECT
+name,
+BIN(flag)
+FROM roles
+WHERE flag = b'0';
+name	BIN(flag)
+non-admin	0
+unknown	0
+DROP TABLE roles;

--- a/mysql-test/mroonga/storage/column/bit/t/null.test
+++ b/mysql-test/mroonga/storage/column/bit/t/null.test
@@ -1,0 +1,47 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS roles;
+--enable_warnings
+
+CREATE TABLE roles (
+  name VARCHAR(255),
+  flag BIT(1) NULL,
+  KEY flag_index(flag)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO roles VALUES ('non-admin', b'0');
+INSERT INTO roles VALUES ('unknown', NULL);
+INSERT INTO roles VALUES ('admin', b'1');
+
+SELECT mroonga_command('index_column_diff --table roles#flag_index --name index');
+
+SELECT
+  name,
+  BIN(flag)
+FROM roles
+WHERE flag = b'0';
+
+DROP TABLE roles;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive. `BIT` with `NULL` is processed as `0` in Groonga. Because Groonga uses the default value for `NULL`. `NULL` `BIT` value is `NULL` in MySQL/MariaDB internal. We use `0` not `NULL` for Groonga because Groonga doesn't support `NULL`. The `index_column_diff` uses `0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0` instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `b'0'`.

In general, it'll be useful but this is an incompatible change. But it'll be acceptable because `NULL` behavior is undefined by definition.