### PR TITLE
date: update index for `NULL` with `1970-01-01` to support `index_column_diff`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12496,12 +12496,12 @@ int ha_mroonga::generic_store_bulk_new_date(Field* field, grn_obj* buf)
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
   bool truncated = false;
-  Field_newdate* newdate_field = (Field_newdate*)field;
-  mrn::TimeConverter time_converter;
   long long int time = 0;
   if (!field->is_null()) {
+    Field_newdate* newdate_field = (Field_newdate*)field;
     MYSQL_TIME mysql_date;
     MRN_FIELD_GET_TIME(newdate_field, &mysql_date, current_thd);
+    mrn::TimeConverter time_converter;
     time = time_converter.mysql_time_to_grn_time(&mysql_date, &truncated);
   }
   if (truncated) {

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12498,7 +12498,7 @@ int ha_mroonga::generic_store_bulk_new_date(Field* field, grn_obj* buf)
   bool truncated = false;
   long long int time = 0;
   if (!field->is_null()) {
-    Field_newdate* newdate_field = (Field_newdate*)field;
+    auto newdate_field = static_cast<Field_newdate*>(field);
     MYSQL_TIME mysql_date;
     MRN_FIELD_GET_TIME(newdate_field, &mysql_date, current_thd);
     mrn::TimeConverter time_converter;

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7358,6 +7358,7 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_SHORT) &&
                              (field->real_type() != MYSQL_TYPE_LONG) &&
                              (field->real_type() != MYSQL_TYPE_YEAR) &&
+                             (field->real_type() != MYSQL_TYPE_NEWDATE) &&
                              (field->real_type() != MYSQL_TYPE_TIME) &&
                              (field->real_type() != MYSQL_TYPE_DATETIME) &&
                              (field->real_type() != MYSQL_TYPE_TIMESTAMP) &&
@@ -12496,11 +12497,13 @@ int ha_mroonga::generic_store_bulk_new_date(Field* field, grn_obj* buf)
   int error = 0;
   bool truncated = false;
   Field_newdate* newdate_field = (Field_newdate*)field;
-  MYSQL_TIME mysql_date;
-  MRN_FIELD_GET_TIME(newdate_field, &mysql_date, current_thd);
   mrn::TimeConverter time_converter;
-  long long int time =
-    time_converter.mysql_time_to_grn_time(&mysql_date, &truncated);
+  long long int time = 0;
+  if (!field->is_null()) {
+    MYSQL_TIME mysql_date;
+    MRN_FIELD_GET_TIME(newdate_field, &mysql_date, current_thd);
+    time = time_converter.mysql_time_to_grn_time(&mysql_date, &truncated);
+  }
   if (truncated) {
     if (ha_thd()->is_strict_mode()) {
       error = MRN_ERROR_CODE_DATA_TRUNCATE(ha_thd());

--- a/mysql-test/mroonga/storage/column/date/r/null.result
+++ b/mysql-test/mroonga/storage/column/date/r/null.result
@@ -6,7 +6,7 @@ KEY created_on_index(created_on)
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO diaries VALUES ('epoch date', '1970-01-01');
 INSERT INTO diaries VALUES ('null date', NULL);
-INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19');
+INSERT INTO diaries VALUES ('Mroonga release date', '2010-8-19');
 SELECT mroonga_command('index_column_diff --table diaries#created_on_index --name index');
 mroonga_command('index_column_diff --table diaries#created_on_index --name index')
 []

--- a/mysql-test/mroonga/storage/column/date/r/null.result
+++ b/mysql-test/mroonga/storage/column/date/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS diaries;
+CREATE TABLE diaries (
+name VARCHAR(255),
+created_on DATE NULL,
+KEY created_on_index(created_on)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ('epoch date', '1970-01-01');
+INSERT INTO diaries VALUES ('null date', NULL);
+INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19');
+SELECT mroonga_command('index_column_diff --table diaries#created_on_index --name index');
+mroonga_command('index_column_diff --table diaries#created_on_index --name index')
+[]
+SELECT * FROM diaries where created_on = '1970-01-01';
+name	created_on
+epoch date	1970-01-01
+null date	1970-01-01
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/date/t/null.test
+++ b/mysql-test/mroonga/storage/column/date/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+CREATE TABLE diaries (
+  name VARCHAR(255),
+  created_on DATE NULL,
+  KEY created_on_index(created_on)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO diaries VALUES ('epoch date', '1970-01-01');
+INSERT INTO diaries VALUES ('null date', NULL);
+INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19');
+
+SELECT mroonga_command('index_column_diff --table diaries#created_on_index --name index');
+
+SELECT * FROM diaries where created_on = '1970-01-01';
+
+DROP TABLE diaries;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/date/t/null.test
+++ b/mysql-test/mroonga/storage/column/date/t/null.test
@@ -31,7 +31,7 @@ CREATE TABLE diaries (
 
 INSERT INTO diaries VALUES ('epoch date', '1970-01-01');
 INSERT INTO diaries VALUES ('null date', NULL);
-INSERT INTO diaries VALUES ('Mroonga release day', '2010-8-19');
+INSERT INTO diaries VALUES ('Mroonga release date', '2010-8-19');
 
 SELECT mroonga_command('index_column_diff --table diaries#created_on_index --name index');
 


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `1970-01-01`. It means that we don't update index for `NULL`. But it causes `index_column_diff` false positive.

`DATE` with `NULL` is processed as `0` (`1970-01-01` in MySQL/MariaDB) in Groonga. Because Groonga uses the default value for `NULL`. `index_column_diff` uses `0` for `NULL` in the expected posting lists. It causes false positive.

If we use `0`( `1970-01-01` in MySQL/MariaDB) instead of ignoring for `NULL`, we can avoid the false positive. It also enables that we can search `NULL` column value record by `1970-01-01`. In general, it'll be useful but this is an incompatible change. But it'll be acceptable because NULL behavior is undefined by definition.