### PR TITLE
Removed redundant NULL checks for certain column types

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7352,25 +7352,6 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
   for (i = 0; i < n_columns; i++) {
     Field* field = table->field[i];
 
-    // TODO: Remove this when support for handling how to register NULLs
-    //       in the index is implemented for all columns.
-    if (field->is_null() && ((field->real_type() != MYSQL_TYPE_TINY) &&
-                             (field->real_type() != MYSQL_TYPE_SHORT) &&
-                             (field->real_type() != MYSQL_TYPE_LONG) &&
-                             (field->real_type() != MYSQL_TYPE_YEAR) &&
-                             (field->real_type() != MYSQL_TYPE_NEWDATE) &&
-                             (field->real_type() != MYSQL_TYPE_TIME) &&
-                             (field->real_type() != MYSQL_TYPE_DATETIME) &&
-                             (field->real_type() != MYSQL_TYPE_TIMESTAMP) &&
-                             (field->real_type() != MYSQL_TYPE_TIME2) &&
-                             (field->real_type() != MYSQL_TYPE_DATETIME2) &&
-                             (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
-                             (field->real_type() != MYSQL_TYPE_FLOAT) &&
-                             (field->real_type() != MYSQL_TYPE_DOUBLE) &&
-                             (field->real_type() != MYSQL_TYPE_ENUM) &&
-                             (field->real_type() != MYSQL_TYPE_SET)))
-      continue;
-
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS
     if (MRN_GENERATED_COLUMNS_FIELD_IS_VIRTUAL(field)) {
       continue;
@@ -7401,6 +7382,9 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
     if (error) {
       GRN_OBJ_FIN(ctx, &colbuf);
       goto err;
+    }
+    if (GRN_BULK_VSIZE(&colbuf) == 0) {
+      continue;
     }
 
     grn_obj* column = grn_columns[i];


### PR DESCRIPTION
GitHub: fix GH-789

This refactoring simplifies `NULL` handling by delegating `NULL` processing to each column's specific function. Previously, `NULL` checks were redundantly performed for each column in `storage_write_row()`, leading to verbose and hard-to-maintain code.

Since `NULL` checking is already handled within each column's processing function, we removed the redundant `NULL` checks in `storage_write_row()`. We now check the size of the column's value after processing. If the value is empty (size is zero), we skip further processing for that column.

By verifying the size of the column's value, we ensure that if there's no data after `NULL` processing, we skip unnecessary operations. This change improves performance and simplifies the codebase because `NULL` handling is already completed within each column.