### PR TITLE
date: skip the test about epoch date on Windows

### DIFF
--- a/mysql-test/mroonga/storage/column/date/t/null.test
+++ b/mysql-test/mroonga/storage/column/date/t/null.test
@@ -16,6 +16,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+--source ../../../../../include/mroonga/skip_windows.inc
 --source ../../../../include/mroonga/have_mroonga.inc
 --source ../../../../include/mroonga/load_mroonga_functions.inc
 

--- a/mysql-test/mroonga/storage/column/date/t/null.test
+++ b/mysql-test/mroonga/storage/column/date/t/null.test
@@ -16,7 +16,12 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
---source ../../../../../include/mroonga/skip_windows.inc
+# '1970-01-01' must be a valid in MySQL/MariaDB but it causes
+# an "out of range" error. It may be a problem in Mroonga.
+# Mroonga converts struct tm to Unix time for processing
+# 00700101 (this is '1970-01-01' representation in MySQL/MariaDB).
+# We should fix it but we skip this for now.
+--source ../../../../include/mroonga/skip_windows.inc
 --source ../../../../include/mroonga/have_mroonga.inc
 --source ../../../../include/mroonga/load_mroonga_functions.inc
 


### PR DESCRIPTION
This is a workaround for Windows.

MySQL/MariaDB accepts `'1000-01-01'` to `'9999-12-31'` as valid range for the `DATE` type. But Mroonga processes it as Unix time. Mroonga uses `struct tm` to convert `YYYY-MM-DD` value in MySQL/MariaDB to Unix time. It causes an "out of range" error for `1970-01-01` or older. We should fix it but we skip the case for now.

Here is the error message:

```
mroonga/storage/column/date.null         w3 [ fail ]
        Test ended at 2024-10-11 17:32:11

CURRENT_TEST: mroonga/storage/column/date.null
mysqltest: At line 32: query 'INSERT INTO diaries VALUES ('epoch date', '1970-01-01')' failed: 1264: Out of range value for column 'created_on' at row 1

The result from queries just before the failure was:
DROP TABLE IF EXISTS diaries;
CREATE TABLE diaries (
name VARCHAR(255),
created_on DATE NULL,
KEY created_on_index(created_on)
) DEFAULT CHARSET=utf8mb4;
INSERT INTO diaries VALUES ('epoch date', '1970-01-01');
```