### PR TITLE
char: use padded empty string for `NULL`

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12137,9 +12137,8 @@ int ha_mroonga::generic_store_bulk_fixed_size_string(Field* field, grn_obj* buf)
   int error = 0;
   grn_obj_reinit(ctx, buf, GRN_DB_SHORT_TEXT, 0);
   if (field->is_null()) {
-    char empty_string[field->field_length];
-    memset(&empty_string, ' ', field->field_length);
-    GRN_TEXT_SET(ctx, buf, empty_string, field->field_length);
+    grn_bulk_space(ctx, buf, field->field_length);
+    memset(GRN_TEXT_VALUE(buf), ' ', field->field_length);
   } else {
     GRN_TEXT_SET(ctx, buf, MRN_FIELD_FIELD_PTR(field), field->field_length);
   }

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7354,7 +7354,8 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
 
     // TODO: Remove this when support for handling how to register NULLs
     //       in the index is implemented for all columns.
-    if (field->is_null() && ((field->real_type() != MYSQL_TYPE_TINY) &&
+    if (field->is_null() && ((field->real_type() != MYSQL_TYPE_STRING) &&
+                             (field->real_type() != MYSQL_TYPE_TINY) &&
                              (field->real_type() != MYSQL_TYPE_SHORT) &&
                              (field->real_type() != MYSQL_TYPE_LONG) &&
                              (field->real_type() != MYSQL_TYPE_YEAR) &&
@@ -12135,7 +12136,13 @@ int ha_mroonga::generic_store_bulk_fixed_size_string(Field* field, grn_obj* buf)
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
   grn_obj_reinit(ctx, buf, GRN_DB_SHORT_TEXT, 0);
-  GRN_TEXT_SET(ctx, buf, MRN_FIELD_FIELD_PTR(field), field->field_length);
+  if (field->is_null()) {
+    char empty_string[field->field_length];
+    memset(&empty_string, ' ', field->field_length);
+    GRN_TEXT_SET(ctx, buf, empty_string, field->field_length);
+  } else {
+    GRN_TEXT_SET(ctx, buf, MRN_FIELD_FIELD_PTR(field), field->field_length);
+  }
   DBUG_RETURN(error);
 }
 

--- a/mysql-test/mroonga/storage/column/char/r/null.result
+++ b/mysql-test/mroonga/storage/column/char/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS users;
+CREATE TABLE users (
+id INT,
+name CHAR(5) NULL,
+KEY name_index(name)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO users VALUES (1, '');
+INSERT INTO users VALUES (2, NULL);
+INSERT INTO users VALUES (3, 'alice');
+SELECT mroonga_command('index_column_diff --table users#name_index --name index');
+mroonga_command('index_column_diff --table users#name_index --name index')
+[]
+SELECT id FROM users where name = '';
+id
+1
+2
+DROP TABLE users;

--- a/mysql-test/mroonga/storage/column/char/t/null.test
+++ b/mysql-test/mroonga/storage/column/char/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS users;
+--enable_warnings
+
+CREATE TABLE users (
+  id INT,
+  name CHAR(5) NULL,
+  KEY name_index(name)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users VALUES (1, '');
+INSERT INTO users VALUES (2, NULL);
+INSERT INTO users VALUES (3, 'alice');
+
+SELECT mroonga_command('index_column_diff --table users#name_index --name index');
+
+SELECT id FROM users where name = '';
+
+DROP TABLE users;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

Mroonga doesn't support `NULL`. So inserting `NULL` to Mroonga table is undefined by definition.

This change uses padded empty string for `NULL` for convenience. The current behavior just uses the default value, an empty (not padded) string. This is an incompatible change. But we can do it because this behavior was undefined. Users who depend on this behavior must not exist.
