### PR TITLE
blob: use empty string for `NULL` explicitly

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7370,7 +7370,10 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_DOUBLE) &&
                              (field->real_type() != MYSQL_TYPE_ENUM) &&
                              (field->real_type() != MYSQL_TYPE_SET) &&
-                             (field->real_type() != MYSQL_TYPE_BIT)))
+                             (field->real_type() != MYSQL_TYPE_BIT) &&
+                             (field->real_type() != MYSQL_TYPE_BLOB) &&
+                             (field->real_type() != MYSQL_TYPE_MEDIUM_BLOB) &&
+                             (field->real_type() != MYSQL_TYPE_LONG_BLOB)))
       continue;
 
 #ifdef MRN_SUPPORT_GENERATED_COLUMNS
@@ -12543,10 +12546,12 @@ int ha_mroonga::generic_store_bulk_blob(Field* field, grn_obj* buf)
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  StringBuffer<MAX_FIELD_WIDTH> buffer(field->charset());
-  auto value = field->val_str(&buffer, &buffer);
   grn_obj_reinit(ctx, buf, GRN_DB_TEXT, 0);
-  GRN_TEXT_SET(ctx, buf, value->ptr(), value->length());
+  if (!field->is_null()) {
+    StringBuffer<MAX_FIELD_WIDTH> buffer(field->charset());
+    auto value = field->val_str(&buffer, &buffer);
+    GRN_TEXT_SET(ctx, buf, value->ptr(), value->length());
+  }
   DBUG_RETURN(error);
 }
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7407,6 +7407,9 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
       GRN_OBJ_FIN(ctx, &colbuf);
       goto err;
     }
+    if (GRN_BULK_VSIZE(&colbuf) == 0) {
+      continue;
+    }
 
     grn_obj* column = grn_columns[i];
     if (is_foreign_key_field(table->s->table_name.str, field->field_name)) {

--- a/mysql-test/mroonga/storage/column/blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/blob/r/null.result
@@ -2,13 +2,13 @@ DROP TABLE IF EXISTS blobs;
 CREATE TABLE blobs (
 name VARCHAR(255),
 value BLOB NULL,
-KEY value_index(value)
+INDEX(value(5))
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
-SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
-mroonga_command('index_column_diff --table blobs#value_index --name index')
+SELECT mroonga_command('index_column_diff --table blobs#value --name index');
+mroonga_command('index_column_diff --table blobs#value --name index')
 []
 SELECT name FROM blobs WHERE value = '';
 name

--- a/mysql-test/mroonga/storage/column/blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/blob/r/null.result
@@ -5,7 +5,7 @@ value BLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('blob', 'blob');
+INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/blob/r/null.result
@@ -5,7 +5,7 @@ value BLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
+INSERT INTO blobs VALUES ('Groonga', 'Groonga');
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/blob/r/null.result
@@ -1,15 +1,11 @@
 DROP TABLE IF EXISTS blobs;
 CREATE TABLE blobs (
 name VARCHAR(255),
-value BLOB NULL,
-INDEX(value(5))
+value BLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
-SELECT mroonga_command('index_column_diff --table blobs#value --name index');
-mroonga_command('index_column_diff --table blobs#value --name index')
-[]
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/blob/r/null.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS blobs;
+CREATE TABLE blobs (
+name VARCHAR(255),
+value BLOB NULL,
+KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO blobs VALUES ('empty', '');
+INSERT INTO blobs VALUES ('null', NULL);
+INSERT INTO blobs VALUES ('blob', 'blob');
+SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
+mroonga_command('index_column_diff --table blobs#value_index --name index')
+[]
+SELECT name FROM blobs WHERE value = '';
+name
+empty
+null
+DROP TABLE blobs;

--- a/mysql-test/mroonga/storage/column/blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/blob/t/null.test
@@ -23,21 +23,17 @@
 DROP TABLE IF EXISTS blobs;
 --enable_warnings
 
-# Unspecifying a key length for BLOB columns raised a warning due
-# to the maximum key length being exceeded in MariaDB.
---disable_warnings
 CREATE TABLE blobs (
   name VARCHAR(255),
   value BLOB NULL,
-  KEY value_index(value)
+  INDEX(value(5))
 ) DEFAULT CHARSET=utf8mb4;
---enable_warnings
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
 
-SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
+SELECT mroonga_command('index_column_diff --table blobs#value --name index');
 
 SELECT name FROM blobs WHERE value = '';
 

--- a/mysql-test/mroonga/storage/column/blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/blob/t/null.test
@@ -1,0 +1,47 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS blobs;
+--enable_warnings
+
+# Unspecifying a key length for BLOB columns raised a warning due
+# to the maximum key length being exceeded in MariaDB.
+--disable_warnings
+CREATE TABLE blobs (
+  name VARCHAR(255),
+  value BLOB NULL,
+  KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+--enable_warnings
+
+INSERT INTO blobs VALUES ('empty', '');
+INSERT INTO blobs VALUES ('null', NULL);
+INSERT INTO blobs VALUES ('blob', 'blob');
+
+SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
+
+SELECT name FROM blobs WHERE value = '';
+
+DROP TABLE blobs;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/blob/t/null.test
@@ -29,7 +29,7 @@ CREATE TABLE blobs (
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
+INSERT INTO blobs VALUES ('Groonga', 'Groonga');
 
 SELECT name FROM blobs WHERE value = '';
 

--- a/mysql-test/mroonga/storage/column/blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/blob/t/null.test
@@ -29,7 +29,7 @@ CREATE TABLE blobs (
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('blob', 'blob');
+INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
 
 SELECT name FROM blobs WHERE value = '';
 

--- a/mysql-test/mroonga/storage/column/blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/blob/t/null.test
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source ../../../../include/mroonga/have_mroonga.inc
---source ../../../../include/mroonga/load_mroonga_functions.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS blobs;
@@ -25,19 +24,15 @@ DROP TABLE IF EXISTS blobs;
 
 CREATE TABLE blobs (
   name VARCHAR(255),
-  value BLOB NULL,
-  INDEX(value(5))
+  value BLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
 
-SELECT mroonga_command('index_column_diff --table blobs#value --name index');
-
 SELECT name FROM blobs WHERE value = '';
 
 DROP TABLE blobs;
 
---source ../../../../include/mroonga/unload_mroonga_functions.inc
 --source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/long_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/long_blob/r/null.result
@@ -1,17 +1,11 @@
 DROP TABLE IF EXISTS blobs;
 CREATE TABLE blobs (
 name VARCHAR(255),
-value LONGBLOB NULL,
-KEY value_index(value)
+value LONGBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
-Warnings:
-Note	1071	Specified key was too long; max key length is 3072 bytes
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
-SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
-mroonga_command('index_column_diff --table blobs#value_index --name index')
-[]
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/long_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/long_blob/r/null.result
@@ -5,7 +5,7 @@ value LONGBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('blob', 'blob');
+INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/long_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/long_blob/r/null.result
@@ -5,7 +5,7 @@ value LONGBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
+INSERT INTO blobs VALUES ('Groonga', 'Groonga');
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/long_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/long_blob/r/null.result
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS blobs;
+CREATE TABLE blobs (
+name VARCHAR(255),
+value LONGBLOB NULL,
+KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+Warnings:
+Note	1071	Specified key was too long; max key length is 3072 bytes
+INSERT INTO blobs VALUES ('empty', '');
+INSERT INTO blobs VALUES ('null', NULL);
+INSERT INTO blobs VALUES ('blob', 'blob');
+SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
+mroonga_command('index_column_diff --table blobs#value_index --name index')
+[]
+SELECT name FROM blobs WHERE value = '';
+name
+empty
+null
+DROP TABLE blobs;

--- a/mysql-test/mroonga/storage/column/long_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/long_blob/t/null.test
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source ../../../../include/mroonga/have_mroonga.inc
---source ../../../../include/mroonga/load_mroonga_functions.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS blobs;
@@ -25,19 +24,15 @@ DROP TABLE IF EXISTS blobs;
 
 CREATE TABLE blobs (
   name VARCHAR(255),
-  value LONGBLOB NULL,
-  KEY value_index(value)
+  value LONGBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
 
-SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
-
 SELECT name FROM blobs WHERE value = '';
 
 DROP TABLE blobs;
 
---source ../../../../include/mroonga/unload_mroonga_functions.inc
 --source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/long_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/long_blob/t/null.test
@@ -29,7 +29,7 @@ CREATE TABLE blobs (
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
+INSERT INTO blobs VALUES ('Groonga', 'Groonga');
 
 SELECT name FROM blobs WHERE value = '';
 

--- a/mysql-test/mroonga/storage/column/long_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/long_blob/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS blobs;
+--enable_warnings
+
+CREATE TABLE blobs (
+  name VARCHAR(255),
+  value LONGBLOB NULL,
+  KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO blobs VALUES ('empty', '');
+INSERT INTO blobs VALUES ('null', NULL);
+INSERT INTO blobs VALUES ('blob', 'blob');
+
+SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
+
+SELECT name FROM blobs WHERE value = '';
+
+DROP TABLE blobs;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/long_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/long_blob/t/null.test
@@ -29,7 +29,7 @@ CREATE TABLE blobs (
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('blob', 'blob');
+INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
 
 SELECT name FROM blobs WHERE value = '';
 

--- a/mysql-test/mroonga/storage/column/medium_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/medium_blob/r/null.result
@@ -1,17 +1,11 @@
 DROP TABLE IF EXISTS blobs;
 CREATE TABLE blobs (
 name VARCHAR(255),
-value MEDIUMBLOB NULL,
-KEY value_index(value)
+value MEDIUMBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
-Warnings:
-Note	1071	Specified key was too long; max key length is 3072 bytes
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
-SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
-mroonga_command('index_column_diff --table blobs#value_index --name index')
-[]
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/medium_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/medium_blob/r/null.result
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS blobs;
+CREATE TABLE blobs (
+name VARCHAR(255),
+value MEDIUMBLOB NULL,
+KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+Warnings:
+Note	1071	Specified key was too long; max key length is 3072 bytes
+INSERT INTO blobs VALUES ('empty', '');
+INSERT INTO blobs VALUES ('null', NULL);
+INSERT INTO blobs VALUES ('blob', 'blob');
+SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
+mroonga_command('index_column_diff --table blobs#value_index --name index')
+[]
+SELECT name FROM blobs WHERE value = '';
+name
+empty
+null
+DROP TABLE blobs;

--- a/mysql-test/mroonga/storage/column/medium_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/medium_blob/r/null.result
@@ -5,7 +5,7 @@ value MEDIUMBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('blob', 'blob');
+INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/medium_blob/r/null.result
+++ b/mysql-test/mroonga/storage/column/medium_blob/r/null.result
@@ -5,7 +5,7 @@ value MEDIUMBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
+INSERT INTO blobs VALUES ('Groonga', 'Groonga');
 SELECT name FROM blobs WHERE value = '';
 name
 empty

--- a/mysql-test/mroonga/storage/column/medium_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/medium_blob/t/null.test
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source ../../../../include/mroonga/have_mroonga.inc
---source ../../../../include/mroonga/load_mroonga_functions.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS blobs;
@@ -25,19 +24,15 @@ DROP TABLE IF EXISTS blobs;
 
 CREATE TABLE blobs (
   name VARCHAR(255),
-  value MEDIUMBLOB NULL,
-  KEY value_index(value)
+  value MEDIUMBLOB NULL
 ) DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
 INSERT INTO blobs VALUES ('blob', 'blob');
 
-SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
-
 SELECT name FROM blobs WHERE value = '';
 
 DROP TABLE blobs;
 
---source ../../../../include/mroonga/unload_mroonga_functions.inc
 --source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/medium_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/medium_blob/t/null.test
@@ -1,0 +1,43 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS blobs;
+--enable_warnings
+
+CREATE TABLE blobs (
+  name VARCHAR(255),
+  value MEDIUMBLOB NULL,
+  KEY value_index(value)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO blobs VALUES ('empty', '');
+INSERT INTO blobs VALUES ('null', NULL);
+INSERT INTO blobs VALUES ('blob', 'blob');
+
+SELECT mroonga_command('index_column_diff --table blobs#value_index --name index');
+
+SELECT name FROM blobs WHERE value = '';
+
+DROP TABLE blobs;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/medium_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/medium_blob/t/null.test
@@ -29,7 +29,7 @@ CREATE TABLE blobs (
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
+INSERT INTO blobs VALUES ('Groonga', 'Groonga');
 
 SELECT name FROM blobs WHERE value = '';
 

--- a/mysql-test/mroonga/storage/column/medium_blob/t/null.test
+++ b/mysql-test/mroonga/storage/column/medium_blob/t/null.test
@@ -29,7 +29,7 @@ CREATE TABLE blobs (
 
 INSERT INTO blobs VALUES ('empty', '');
 INSERT INTO blobs VALUES ('null', NULL);
-INSERT INTO blobs VALUES ('blob', 'blob');
+INSERT INTO blobs VALUES ('Groonga', 0x47726F6F6E6761);
 
 SELECT name FROM blobs WHERE value = '';
 


### PR DESCRIPTION
GitHub: GH-789

The current Mroonga ignores `NULL` values for `{,MEDIUM,LARGE}BLOB`. This doesn't change the current behavior. This still ignores `NULL` values but `NULL` check code is moved to `generic_store_bulk_blob()` from `storage_write_row()` like other types. `storage_write_row()` ignores empty bulk after `generic_store_bulk_blob()` call. So this doesn't change the current behavior.

We want to remove `if (field->is_null() && ...) continue` for `grn_obj_set_value()` entirely in `storage_write_row()` eventually. This is a step for it. 
