### PR TITLE
varchar: use empty string for NULL explicitly

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7355,6 +7355,7 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
     // TODO: Remove this when support for handling how to register NULLs
     //       in the index is implemented for all columns.
     if (field->is_null() && ((field->real_type() != MYSQL_TYPE_STRING) &&
+                             (field->real_type() != MYSQL_TYPE_VARCHAR) &&
                              (field->real_type() != MYSQL_TYPE_TINY) &&
                              (field->real_type() != MYSQL_TYPE_SHORT) &&
                              (field->real_type() != MYSQL_TYPE_LONG) &&
@@ -12150,13 +12151,15 @@ int ha_mroonga::generic_store_bulk_variable_size_string(Field* field,
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  StringBuffer<MAX_FIELD_WIDTH> buffer(field->charset());
-  auto value = field->val_str(&buffer, &buffer);
   grn_obj_reinit(ctx, buf, GRN_DB_SHORT_TEXT, 0);
-  DBUG_PRINT("info",
-             ("mroonga: length=%" MRN_FORMAT_STRING_LENGTH, value->length()));
-  DBUG_PRINT("info", ("mroonga: value=%s", value->c_ptr_safe()));
-  GRN_TEXT_SET(ctx, buf, value->ptr(), value->length());
+  if (!field->is_null()) {
+    StringBuffer<MAX_FIELD_WIDTH> buffer(field->charset());
+    auto value = field->val_str(&buffer, &buffer);
+    DBUG_PRINT("info",
+               ("mroonga: length=%" MRN_FORMAT_STRING_LENGTH, value->length()));
+    DBUG_PRINT("info", ("mroonga: value=%s", value->c_ptr_safe()));
+    GRN_TEXT_SET(ctx, buf, value->ptr(), value->length());
+  }
   DBUG_RETURN(error);
 }
 

--- a/mysql-test/mroonga/storage/column/varchar/r/null.result
+++ b/mysql-test/mroonga/storage/column/varchar/r/null.result
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS users;
+CREATE TABLE users (
+id INT,
+name VARCHAR(5) NULL
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO users VALUES (1, '');
+INSERT INTO users VALUES (2, NULL);
+INSERT INTO users VALUES (3, 'alice');
+SELECT id FROM users where name = '';
+id
+1
+2
+DROP TABLE users;

--- a/mysql-test/mroonga/storage/column/varchar/t/null.test
+++ b/mysql-test/mroonga/storage/column/varchar/t/null.test
@@ -1,0 +1,38 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS users;
+--enable_warnings
+
+CREATE TABLE users (
+  id INT,
+  name VARCHAR(5) NULL
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users VALUES (1, '');
+INSERT INTO users VALUES (2, NULL);
+INSERT INTO users VALUES (3, 'alice');
+
+SELECT id FROM users where name = '';
+
+DROP TABLE users;
+
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current Mroonga ignores `NULL` values for `VARCHAR`. This doesn't change the current behavior.
This still ignores `NULL` values but `NULL` check code is moved to `generic_store_bulk_variable_size_string()` from `storage_write_row()` like other types. `storage_write_row()` ignores empty bulk after `generic_store_bulk_variable_size_string()` call. So this doesn't change the current behavior.

We want to remove `if (field->is_null() && ...) continue` for `grn_obj_set_value()` entirely in `storage_write_row()` eventually. This is a step for it.