### PR TITLE
decimal: use `0.0`(zero padding depending on scale) for NULL explicitly

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12539,12 +12539,13 @@ int ha_mroonga::generic_store_bulk_new_decimal(Field* field, grn_obj* buf)
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
   grn_obj_reinit(ctx, buf, GRN_DB_SHORT_TEXT, 0);
-  if (!field->is_null()) {
-    String value;
-    Field_new_decimal* new_decimal_field = (Field_new_decimal*)field;
-    new_decimal_field->val_str(&value, NULL);
-    GRN_TEXT_SET(ctx, buf, value.ptr(), value.length());
-  }
+  String value;
+  Field_new_decimal* new_decimal_field = (Field_new_decimal*)field;
+  // If the field is NULL, val_str() returns a zero-padded string based on the
+  // column's scale. For example: DECIMAL(3,2) -> "0.00". This ensures
+  // consistent formatting for NULL values in indexes and queries like zero.
+  new_decimal_field->val_str(&value, NULL);
+  GRN_TEXT_SET(ctx, buf, value.ptr(), value.length());
   DBUG_RETURN(error);
 }
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -7368,6 +7368,7 @@ int ha_mroonga::storage_write_row(mrn_write_row_buf_t buf)
                              (field->real_type() != MYSQL_TYPE_TIMESTAMP2) &&
                              (field->real_type() != MYSQL_TYPE_FLOAT) &&
                              (field->real_type() != MYSQL_TYPE_DOUBLE) &&
+                             (field->real_type() != MYSQL_TYPE_NEWDECIMAL) &&
                              (field->real_type() != MYSQL_TYPE_ENUM) &&
                              (field->real_type() != MYSQL_TYPE_SET) &&
                              (field->real_type() != MYSQL_TYPE_BIT) &&
@@ -12537,11 +12538,13 @@ int ha_mroonga::generic_store_bulk_new_decimal(Field* field, grn_obj* buf)
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
-  String value;
-  Field_new_decimal* new_decimal_field = (Field_new_decimal*)field;
-  new_decimal_field->val_str(&value, NULL);
   grn_obj_reinit(ctx, buf, GRN_DB_SHORT_TEXT, 0);
-  GRN_TEXT_SET(ctx, buf, value.ptr(), value.length());
+  if (!field->is_null()) {
+    String value;
+    Field_new_decimal* new_decimal_field = (Field_new_decimal*)field;
+    new_decimal_field->val_str(&value, NULL);
+    GRN_TEXT_SET(ctx, buf, value.ptr(), value.length());
+  }
   DBUG_RETURN(error);
 }
 

--- a/mysql-test/mroonga/storage/column/decimal/r/null.result
+++ b/mysql-test/mroonga/storage/column/decimal/r/null.result
@@ -1,11 +1,15 @@
 DROP TABLE IF EXISTS diaries;
 CREATE TABLE diaries (
 weather TEXT,
-temperature DECIMAL(3,1) NULL
+temperature DECIMAL(3,1) NULL,
+KEY temperature_index(temperature)
 ) DEFAULT CHARSET UTF8MB4;
 INSERT INTO diaries VALUES ("snow", 0.0);
 INSERT INTO diaries VALUES ("unknown", NULL);
 INSERT INTO diaries VALUES ("sunny", 30.1);
+SELECT mroonga_command('select --table diaries#temperature_index');
+mroonga_command('select --table diaries#temperature_index')
+[[[2],[["_id","UInt32"],["_key","ShortText"],["index","UInt32"]],[1,"0.0",4],[2,"30.1",1]]]
 SELECT * FROM diaries;
 weather	temperature
 snow	0.0

--- a/mysql-test/mroonga/storage/column/decimal/r/null.result
+++ b/mysql-test/mroonga/storage/column/decimal/r/null.result
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS diaries;
+CREATE TABLE diaries (
+weather TEXT,
+temperature DECIMAL(3,1) NULL
+) DEFAULT CHARSET UTF8MB4;
+INSERT INTO diaries VALUES ("snow", 0.0);
+INSERT INTO diaries VALUES ("unknown", NULL);
+INSERT INTO diaries VALUES ("sunny", 30.1);
+SELECT * FROM diaries;
+weather	temperature
+snow	0.0
+unknown	0.0
+sunny	30.1
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/column/decimal/t/null.test
+++ b/mysql-test/mroonga/storage/column/decimal/t/null.test
@@ -1,0 +1,38 @@
+# -*- mode: sql; sql-product: mysql -*-
+#
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+CREATE TABLE diaries (
+  weather TEXT,
+  temperature DECIMAL(3,1) NULL
+) DEFAULT CHARSET UTF8MB4;
+
+INSERT INTO diaries VALUES ("snow", 0.0);
+INSERT INTO diaries VALUES ("unknown", NULL);
+INSERT INTO diaries VALUES ("sunny", 30.1);
+
+SELECT * FROM diaries;
+
+DROP TABLE diaries;
+
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/column/decimal/t/null.test
+++ b/mysql-test/mroonga/storage/column/decimal/t/null.test
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 --source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS diaries;
@@ -24,15 +25,20 @@ DROP TABLE IF EXISTS diaries;
 
 CREATE TABLE diaries (
   weather TEXT,
-  temperature DECIMAL(3,1) NULL
+  temperature DECIMAL(3,1) NULL,
+  KEY temperature_index(temperature)
 ) DEFAULT CHARSET UTF8MB4;
 
 INSERT INTO diaries VALUES ("snow", 0.0);
 INSERT INTO diaries VALUES ("unknown", NULL);
 INSERT INTO diaries VALUES ("sunny", 30.1);
 
+# TODO: After resolving the DECIMAL type index search issue,
+# verify that NULL values are matched as 0.0 (zero-padded based on scale) in index searches.
+SELECT mroonga_command('select --table diaries#temperature_index');
 SELECT * FROM diaries;
 
 DROP TABLE diaries;
 
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
 --source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-789

The current implementation ignores `NULL`. It means that we don't update index for `NULL`.
`DECIMALl` with `NULL` is processed as `''` (`0.0` (zero-padding) in MySQL/MariaDB) in Groonga.
Because Groonga uses the default value for `NULL`. `index_column_diff` uses `''` for `NULL`
in the expected posting lists.

If we use `0.0`(`0.0` in MySQL/MariaDB) instead of ignoring for `NULL`, we can avoid the inconcsitency
between Groonga and MySQL layers. It also enables that we can search `NULL`` column value record by `0.0`.
This behavior is the same as the other columns (like `FLOAT`and  `DOUBLE`).

In general, it'll be useful but this is an incompatible change. But defining behavior will be better
and acceptable for users because `NULL` behavior was undefined in the past.

Notice: In Mroonga, we cannot get expected result using index search because there is an issue for it.
We will deal with this issue in GH-811 . So after fixing this issue, we can search `NULL` column value by `0.0` too.
