### PR TITLE
doc: update the generated file list by Shpinx v8.1.3

### DIFF
--- a/doc/files.am
+++ b/doc/files.am
@@ -564,28 +564,23 @@ html_files_relative_from_locale_dir = \
 	html/_static/scripts/bootstrap.js \
 	html/_static/scripts/bootstrap.js.LICENSE.txt \
 	html/_static/scripts/bootstrap.js.map \
+	html/_static/scripts/fontawesome.js \
+	html/_static/scripts/fontawesome.js.LICENSE.txt \
+	html/_static/scripts/fontawesome.js.map \
 	html/_static/scripts/pydata-sphinx-theme.js \
 	html/_static/scripts/pydata-sphinx-theme.js.map \
 	html/_static/searchtools.js \
 	html/_static/sphinx_highlight.js \
-	html/_static/styles/bootstrap.css \
-	html/_static/styles/bootstrap.css.map \
 	html/_static/styles/pydata-sphinx-theme.css \
 	html/_static/styles/pydata-sphinx-theme.css.map \
 	html/_static/styles/theme.css \
 	html/_static/switcher.json \
-	html/_static/vendor/fontawesome/6.5.2/LICENSE.txt \
-	html/_static/vendor/fontawesome/6.5.2/css/all.min.css \
-	html/_static/vendor/fontawesome/6.5.2/js/all.min.js \
-	html/_static/vendor/fontawesome/6.5.2/js/all.min.js.LICENSE.txt \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2 \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2 \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2 \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.woff2 \
+	html/_static/vendor/fontawesome/webfonts/fa-brands-400.ttf \
+	html/_static/vendor/fontawesome/webfonts/fa-brands-400.woff2 \
+	html/_static/vendor/fontawesome/webfonts/fa-regular-400.ttf \
+	html/_static/vendor/fontawesome/webfonts/fa-regular-400.woff2 \
+	html/_static/vendor/fontawesome/webfonts/fa-solid-900.ttf \
+	html/_static/vendor/fontawesome/webfonts/fa-solid-900.woff2 \
 	html/_static/webpack-macros.html \
 	html/characteristic.html \
 	html/community.html \

--- a/doc/files.cmake
+++ b/doc/files.cmake
@@ -90,28 +90,23 @@ set(MRN_DOC_HTML_FILES
     _static/scripts/bootstrap.js
     _static/scripts/bootstrap.js.LICENSE.txt
     _static/scripts/bootstrap.js.map
+    _static/scripts/fontawesome.js
+    _static/scripts/fontawesome.js.LICENSE.txt
+    _static/scripts/fontawesome.js.map
     _static/scripts/pydata-sphinx-theme.js
     _static/scripts/pydata-sphinx-theme.js.map
     _static/searchtools.js
     _static/sphinx_highlight.js
-    _static/styles/bootstrap.css
-    _static/styles/bootstrap.css.map
     _static/styles/pydata-sphinx-theme.css
     _static/styles/pydata-sphinx-theme.css.map
     _static/styles/theme.css
     _static/switcher.json
-    _static/vendor/fontawesome/6.5.2/LICENSE.txt
-    _static/vendor/fontawesome/6.5.2/css/all.min.css
-    _static/vendor/fontawesome/6.5.2/js/all.min.js
-    _static/vendor/fontawesome/6.5.2/js/all.min.js.LICENSE.txt
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.woff2
+    _static/vendor/fontawesome/webfonts/fa-brands-400.ttf
+    _static/vendor/fontawesome/webfonts/fa-brands-400.woff2
+    _static/vendor/fontawesome/webfonts/fa-regular-400.ttf
+    _static/vendor/fontawesome/webfonts/fa-regular-400.woff2
+    _static/vendor/fontawesome/webfonts/fa-solid-900.ttf
+    _static/vendor/fontawesome/webfonts/fa-solid-900.woff2
     _static/webpack-macros.html
     characteristic.html
     community.html


### PR DESCRIPTION
This change fixed the following CI error because the generated file list has been changed from Sphinx 8.1.3.

```
cp: cannot stat './html/_static/styles/bootstrap.css': No such file or directory
```

ref: https://github.com/mroonga/mroonga/actions/runs/11470945099/job/31921042894#step:11:3614

## How we updated the file list

We have updated the following commands.

```console
$ cmake \
   -Smroonga\
   -Bmroonga.doc \
   --preset=doc \
   -DMYSQL_BUILD_DIR=$HOME/work/cpp/mariadb-11.4.3.build \
   -DMYSQL_CONFIG=$HOME/work/cpp/mariadb-11.4.3.build/scripts/mysql_config \
   -DMYSQL_SOURCE_DIR=$HOME/work/cpp/mariadb-11.4.3
$ ninja doc_update_files -C ./mroonga.doc
```