### PR TITLE
mariadb 11.4: follow referenced_by_foreign_key() API change

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -19384,10 +19384,12 @@ int ha_mroonga::get_parent_foreign_key_list(
 }
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-uint ha_mroonga::wrapper_referenced_by_foreign_key()
+mrn_return_type_referenced_by_foreign_key
+ha_mroonga::wrapper_referenced_by_foreign_key()
+  MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
 {
   MRN_DBUG_ENTER_METHOD();
-  uint res;
+  mrn_return_type_referenced_by_foreign_key res;
   MRN_SET_WRAP_SHARE_KEY(share, table->s);
   MRN_SET_WRAP_TABLE_KEY(this, table);
   res = wrap_handler->referenced_by_foreign_key();
@@ -19397,17 +19399,22 @@ uint ha_mroonga::wrapper_referenced_by_foreign_key()
 }
 #  endif
 
-uint ha_mroonga::storage_referenced_by_foreign_key()
+mrn_return_type_referenced_by_foreign_key
+ha_mroonga::storage_referenced_by_foreign_key()
+  MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
 {
   MRN_DBUG_ENTER_METHOD();
-  uint res = handler::referenced_by_foreign_key();
+  mrn_return_type_referenced_by_foreign_key res =
+    handler::referenced_by_foreign_key();
   DBUG_RETURN(res);
 }
 
-uint ha_mroonga::referenced_by_foreign_key()
+mrn_return_type_referenced_by_foreign_key
+ha_mroonga::referenced_by_foreign_key()
+  MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
 {
   MRN_DBUG_ENTER_METHOD();
-  uint res;
+  mrn_return_type_referenced_by_foreign_key res;
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   if (share->wrapper_mode) {
     res = wrapper_referenced_by_foreign_key();

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -19410,8 +19410,7 @@ ha_mroonga::storage_referenced_by_foreign_key()
 }
 
 mrn_return_type_referenced_by_foreign_key
-ha_mroonga::referenced_by_foreign_key()
-  MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
+ha_mroonga::referenced_by_foreign_key() MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
 {
   MRN_DBUG_ENTER_METHOD();
   mrn_return_type_referenced_by_foreign_key res;

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -19386,7 +19386,7 @@ int ha_mroonga::get_parent_foreign_key_list(
 #  ifdef MRN_ENABLE_WRAPPER_MODE
 mrn_return_type_referenced_by_foreign_key
 ha_mroonga::wrapper_referenced_by_foreign_key()
-  MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
+  MRN_REFERENCED_BY_FOREIGN_KEY_CONST_NOEXCEPT
 {
   MRN_DBUG_ENTER_METHOD();
   mrn_return_type_referenced_by_foreign_key res;
@@ -19401,7 +19401,7 @@ ha_mroonga::wrapper_referenced_by_foreign_key()
 
 mrn_return_type_referenced_by_foreign_key
 ha_mroonga::storage_referenced_by_foreign_key()
-  MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
+  MRN_REFERENCED_BY_FOREIGN_KEY_CONST_NOEXCEPT
 {
   MRN_DBUG_ENTER_METHOD();
   mrn_return_type_referenced_by_foreign_key res =
@@ -19410,7 +19410,8 @@ ha_mroonga::storage_referenced_by_foreign_key()
 }
 
 mrn_return_type_referenced_by_foreign_key
-ha_mroonga::referenced_by_foreign_key() MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
+ha_mroonga::referenced_by_foreign_key()
+  MRN_REFERENCED_BY_FOREIGN_KEY_CONST_NOEXCEPT
 {
   MRN_DBUG_ENTER_METHOD();
   mrn_return_type_referenced_by_foreign_key res;

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -854,8 +854,8 @@ protected:
   int get_parent_foreign_key_list(mrn_handler_get_foreign_key_list_thread* thd,
                                   List<FOREIGN_KEY_INFO>* f_key_list)
     mrn_override;
-  mrn_return_type_referenced_by_foreign_key
-  referenced_by_foreign_key() MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT mrn_override;
+  mrn_return_type_referenced_by_foreign_key referenced_by_foreign_key()
+    MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT mrn_override;
   void free_foreign_key_create_info(char* str) mrn_override;
 #endif
   void init_table_handle_for_HANDLER();
@@ -2015,11 +2015,11 @@ private:
     mrn_handler_get_foreign_key_list_thread* thd,
     List<FOREIGN_KEY_INFO>* f_key_list);
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-  mrn_return_type_referenced_by_foreign_key wrapper_referenced_by_foreign_key()
-    MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT;
+  mrn_return_type_referenced_by_foreign_key
+  wrapper_referenced_by_foreign_key() MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT;
 #  endif
-  mrn_return_type_referenced_by_foreign_key storage_referenced_by_foreign_key()
-    MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT;
+  mrn_return_type_referenced_by_foreign_key
+  storage_referenced_by_foreign_key() MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT;
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   void wrapper_free_foreign_key_create_info(char* str);
 #  endif

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -854,7 +854,8 @@ protected:
   int get_parent_foreign_key_list(mrn_handler_get_foreign_key_list_thread* thd,
                                   List<FOREIGN_KEY_INFO>* f_key_list)
     mrn_override;
-  uint referenced_by_foreign_key() mrn_override;
+  mrn_return_type_referenced_by_foreign_key
+  referenced_by_foreign_key() MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT mrn_override;
   void free_foreign_key_create_info(char* str) mrn_override;
 #endif
   void init_table_handle_for_HANDLER();
@@ -2014,9 +2015,11 @@ private:
     mrn_handler_get_foreign_key_list_thread* thd,
     List<FOREIGN_KEY_INFO>* f_key_list);
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-  uint wrapper_referenced_by_foreign_key();
+  mrn_return_type_referenced_by_foreign_key wrapper_referenced_by_foreign_key()
+    MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT;
 #  endif
-  uint storage_referenced_by_foreign_key();
+  mrn_return_type_referenced_by_foreign_key storage_referenced_by_foreign_key()
+    MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT;
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   void wrapper_free_foreign_key_create_info(char* str);
 #  endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -995,7 +995,7 @@ typedef uint mrn_srid;
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
   (warn_deprecated<999999>(thd, what, to))
   using mrn_return_type_referenced_by_foreign_key = bool;
-#  define MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT const noexcept
+#  define MRN_REFERENCED_BY_FOREIGN_KEY_CONST_NOEXCEPT const noexcept
 #else
   using mrn_io_and_cpu_cost = double;
   using mrn_handler_get_foreign_key_list_thread = THD;
@@ -1008,5 +1008,5 @@ typedef uint mrn_srid;
                         what,                                        \
                         to))
   using mrn_return_type_referenced_by_foreign_key = uint;
-#  define MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
+#  define MRN_REFERENCED_BY_FOREIGN_KEY_CONST_NOEXCEPT
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -994,6 +994,8 @@ typedef uint mrn_srid;
 // for details.
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
   (warn_deprecated<999999>(thd, what, to))
+  using mrn_return_type_referenced_by_foreign_key = bool;
+#  define MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT const noexcept
 #else
   using mrn_io_and_cpu_cost = double;
   using mrn_handler_get_foreign_key_list_thread = THD;
@@ -1005,4 +1007,6 @@ typedef uint mrn_srid;
                         MRN_GET_ERR_MSG(ER_WARN_DEPRECATED_SYNTAX),  \
                         what,                                        \
                         to))
+  using mrn_return_type_referenced_by_foreign_key = uint;
+#  define MRN_REFERENCED_BY_FOREIGN_KEY_NOEXCEPT
 #endif


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.4.4 LTS.

Fix: GH-822
See: MariaDB/server@45298b730b

