### PR TITLE
mariadb 11.4: follow get_foreign_key_list()/get_parent_foreign_key_list() API change

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -19189,8 +19189,7 @@ char* ha_mroonga::get_foreign_key_create_info()
 }
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-int ha_mroonga::wrapper_get_foreign_key_list(
-  mrn_handler_get_foreign_key_list_thread* thd,
+int ha_mroonga::wrapper_get_foreign_key_list(THD* thd,
   List<FOREIGN_KEY_INFO>* f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -19204,8 +19203,7 @@ int ha_mroonga::wrapper_get_foreign_key_list(
 }
 #  endif
 
-int ha_mroonga::storage_get_foreign_key_list(
-  mrn_handler_get_foreign_key_list_thread* thd,
+int ha_mroonga::storage_get_foreign_key_list(THD* thd,
   List<FOREIGN_KEY_INFO>* f_key_list)
 {
   int error;
@@ -19322,8 +19320,7 @@ int ha_mroonga::storage_get_foreign_key_list(
   DBUG_RETURN(0);
 }
 
-int ha_mroonga::get_foreign_key_list(
-  mrn_handler_get_foreign_key_list_thread* thd,
+int ha_mroonga::get_foreign_key_list(THD* thd,
   List<FOREIGN_KEY_INFO>* f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -19341,8 +19338,7 @@ int ha_mroonga::get_foreign_key_list(
 }
 
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-int ha_mroonga::wrapper_get_parent_foreign_key_list(
-  mrn_handler_get_foreign_key_list_thread* thd,
+int ha_mroonga::wrapper_get_parent_foreign_key_list(THD* thd,
   List<FOREIGN_KEY_INFO>* f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -19356,8 +19352,7 @@ int ha_mroonga::wrapper_get_parent_foreign_key_list(
 }
 #  endif
 
-int ha_mroonga::storage_get_parent_foreign_key_list(
-  mrn_handler_get_foreign_key_list_thread* thd,
+int ha_mroonga::storage_get_parent_foreign_key_list(THD* thd,
   List<FOREIGN_KEY_INFO>* f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();
@@ -19365,8 +19360,7 @@ int ha_mroonga::storage_get_parent_foreign_key_list(
   DBUG_RETURN(res);
 }
 
-int ha_mroonga::get_parent_foreign_key_list(
-  mrn_handler_get_foreign_key_list_thread* thd,
+int ha_mroonga::get_parent_foreign_key_list(THD* thd,
   List<FOREIGN_KEY_INFO>* f_key_list)
 {
   MRN_DBUG_ENTER_METHOD();

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -849,9 +849,9 @@ protected:
 #ifdef MRN_HANDLER_HAVE_FOREIGN_KEY_INFO
   bool is_fk_defined_on_table_or_index(uint index) mrn_override;
   char* get_foreign_key_create_info() mrn_override;
-  int get_foreign_key_list(mrn_handler_get_foreign_key_list_thread* thd,
+  int get_foreign_key_list(THD* thd,
                            List<FOREIGN_KEY_INFO>* f_key_list) mrn_override;
-  int get_parent_foreign_key_list(mrn_handler_get_foreign_key_list_thread* thd,
+  int get_parent_foreign_key_list(THD* thd,
                                   List<FOREIGN_KEY_INFO>* f_key_list)
     mrn_override;
   uint referenced_by_foreign_key() mrn_override;
@@ -2002,17 +2002,15 @@ private:
 #  endif
   char* storage_get_foreign_key_create_info();
 #  ifdef MRN_ENABLE_WRAPPER_MODE
-  int wrapper_get_foreign_key_list(mrn_handler_get_foreign_key_list_thread* thd,
+  int wrapper_get_foreign_key_list(THD* thd,
                                    List<FOREIGN_KEY_INFO>* f_key_list);
-  int wrapper_get_parent_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread* thd,
-    List<FOREIGN_KEY_INFO>* f_key_list);
+  int wrapper_get_parent_foreign_key_list(THD* thd,
+                                          List<FOREIGN_KEY_INFO>* f_key_list);
 #  endif
-  int storage_get_foreign_key_list(mrn_handler_get_foreign_key_list_thread* thd,
+  int storage_get_foreign_key_list(THD* thd,
                                    List<FOREIGN_KEY_INFO>* f_key_list);
-  int storage_get_parent_foreign_key_list(
-    mrn_handler_get_foreign_key_list_thread* thd,
-    List<FOREIGN_KEY_INFO>* f_key_list);
+  int storage_get_parent_foreign_key_list(THD* thd,
+                                          List<FOREIGN_KEY_INFO>* f_key_list);
 #  ifdef MRN_ENABLE_WRAPPER_MODE
   uint wrapper_referenced_by_foreign_key();
 #  endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -980,7 +980,6 @@ typedef uint mrn_srid;
 #if defined(MRN_MARIADB_P) &&                                        \
     (MYSQL_VERSION_ID >= 110400 && MYSQL_VERSION_ID < 110500)
   using mrn_io_and_cpu_cost = IO_AND_CPU_COST;
-  using mrn_handler_get_foreign_key_list_thread = const THD;
 #  define MRN_HANDLER_HAVE_MULTI_RANGE_READ_INFO_CONST_LIMIT
 #  define MRN_HANDLER_HAVE_KEYREAD_TIME
 // warn_deprecated<>() requires deprecated version. MariaDB will report an error
@@ -996,7 +995,6 @@ typedef uint mrn_srid;
   (warn_deprecated<999999>(thd, what, to))
 #else
   using mrn_io_and_cpu_cost = double;
-  using mrn_handler_get_foreign_key_list_thread = THD;
 #  define MRN_HANDLER_HAVE_READ_TIME
 #  define MRN_WARN_DEPRECATED(thd, what, to)                         \
    (push_warning_printf(thd,                                         \


### PR DESCRIPTION
This PR is the part of support for MariaDB 11.4.4 LTS.

See:
https://github.com/MariaDB/server/commit/12a91b57e27b979819924cf89614e6e51f24b37b
https://jira.mariadb.org/browse/MDEV-35351