### PR TITLE
docs: Add `:orphan:` to `install/centos.md`

### DIFF
--- a/doc/source/install/centos.md
+++ b/doc/source/install/centos.md
@@ -1,3 +1,5 @@
+:orphan:
+
 # CentOS
 
 Support for Mroonga has ended from version 14.04 because of CentOS 7's EOL.


### PR DESCRIPTION
The following warning:

```
checking consistency... doc/source/install/centos.md: WARNING: document isn't included in any toctre
```