### PR TITLE
ci: Add install test for AlmaLinux 8 with Mariadb 10.5

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,4 +1,4 @@
-name: Install to Ubuntu
+name: Install Mroonga
 on:
   schedule:
     - cron: |
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   install:
-    name: Install to Ubuntu
+    name: Install Mroonga
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,7 @@
 name: Install Mroonga
 on:
   schedule:
+    push:
     - cron: |
         0 0 * * *
 concurrency:
@@ -61,18 +62,15 @@ jobs:
           case ${{ matrix.image }} in
             images:ubuntu/*)
               package_type=apt
-              options=(${{ matrix.package }}-mroonga)
               ;;
             *)
               package_type=yum
-              os_version=$(echo ${{ matrix.image }} | awk -F "/" '{print $2}')
-              options=(${{ matrix.package }}-mroonga ${os_version})
               ;;
           esac
           sudo incus exec target \
             -- \
             /host/packages/${package_type}/install_test.sh \
-              ${options[@]}
+              ${{ matrix.package }}-mroonga
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -51,9 +51,12 @@ jobs:
           sudo incus admin init --auto
           sudo incus launch ${{ matrix.image }} target
           sudo incus config device add target host disk source=$PWD path=/host
-          # Wait for network services stabilizing
-          sleep 1 # Wait for systemd ready
-          sudo incus exec target -- sudo systemctl is-system-running --wait
+          # Ideally, we would use systemctl is-system-running --wait to ensure all services are fully operational.
+          # However, this option doesn't work in AlmaLinux 8 and results in an error.
+          # As a workaround, we introduced a 10-second sleep delay to allow network services time to stabilize,
+          # preventing DNS resolution errors when attempting to dnf install command.
+          # ref: https://discuss.linuxcontainers.org/t/network-issue-with-almalinux-8-9-on-github-actions-using-incus/20046
+          sleep 10
       - name: Install Mroonga
         run: |
           case ${{ matrix.image }} in

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -19,21 +19,21 @@ jobs:
           - image: "images:almalinux/8"
             package: mariadb-10.5
 
-          # Ubuntu 20.04
-          - image: "images:ubuntu/20.04"
-            package: mysql
-
-          # Ubuntu 22.04
-          - image: "images:ubuntu/22.04"
-            package: mariadb
-          - image: "images:ubuntu/22.04"
-            package: mysql
-
-          # Ubuntu 24.04
-          - image: "images:ubuntu/24.04"
-            package: mariadb
-          - image: "images:ubuntu/24.04"
-            package: mysql
+#          # Ubuntu 20.04
+#          - image: "images:ubuntu/20.04"
+#            package: mysql
+#
+#          # Ubuntu 22.04
+#          - image: "images:ubuntu/22.04"
+#            package: mariadb
+#          - image: "images:ubuntu/22.04"
+#            package: mysql
+#
+#          # Ubuntu 24.04
+#          - image: "images:ubuntu/24.04"
+#            package: mariadb
+#          - image: "images:ubuntu/24.04"
+#            package: mysql
     steps:
       - uses: actions/checkout@v4
       - name: Install Incus

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -15,6 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # AlmaLinux with MariaDB 10.5
+          - image: "images:almalinux/8"
+            package: mariadb-10.5
+
           # Ubuntu 20.04
           - image: "images:ubuntu/20.04"
             package: mysql
@@ -30,10 +34,6 @@ jobs:
             package: mariadb
           - image: "images:ubuntu/24.04"
             package: mysql
-
-          # AlmaLinux with MariaDB 10.5
-          - image: "images:almalinux/8"
-            package: mariadb-10.5
     steps:
       - uses: actions/checkout@v4
       - name: Install Incus

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install Mroonga
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -65,7 +65,6 @@ jobs:
               package_type=yum
               ;;
           esac
-
           sudo incus exec target \
             -- \
             /host/packages/${package_type}/install_test.sh \

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install Mroonga
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,12 +14,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Ubuntu 20.04
           - image: "images:ubuntu/20.04"
             package: mysql
+
+          # Ubuntu 22.04
           - image: "images:ubuntu/22.04"
             package: mariadb
           - image: "images:ubuntu/22.04"
             package: mysql
+
+          # Ubuntu 24.04
           - image: "images:ubuntu/24.04"
             package: mariadb
           - image: "images:ubuntu/24.04"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -19,21 +19,21 @@ jobs:
           - image: "images:almalinux/8"
             package: mariadb-10.5
 
-#          # Ubuntu 20.04
-#          - image: "images:ubuntu/20.04"
-#            package: mysql
-#
-#          # Ubuntu 22.04
-#          - image: "images:ubuntu/22.04"
-#            package: mariadb
-#          - image: "images:ubuntu/22.04"
-#            package: mysql
-#
-#          # Ubuntu 24.04
-#          - image: "images:ubuntu/24.04"
-#            package: mariadb
-#          - image: "images:ubuntu/24.04"
-#            package: mysql
+          # Ubuntu 20.04
+          - image: "images:ubuntu/20.04"
+            package: mysql
+
+          # Ubuntu 22.04
+          - image: "images:ubuntu/22.04"
+            package: mariadb
+          - image: "images:ubuntu/22.04"
+            package: mysql
+
+          # Ubuntu 24.04
+          - image: "images:ubuntu/24.04"
+            package: mariadb
+          - image: "images:ubuntu/24.04"
+            package: mysql
     steps:
       - uses: actions/checkout@v4
       - name: Install Incus
@@ -56,10 +56,21 @@ jobs:
           sudo incus exec target -- sudo systemctl is-system-running --wait
       - name: Install Mroonga
         run: |
+          case ${{ matrix.image }} in
+            images:ubuntu/*)
+              package_type=apt
+              os_version=$(echo ${{ matrix.image }} | awk -F "/" '{print $2}')
+              options=(${{ matrix.package }}-mroonga ${os_version})
+              ;;
+            *)
+              package_type=yum
+              options=(${{ matrix.package }}-mroonga)
+              ;;
+          esac
           sudo incus exec target \
             -- \
-            /host/packages/yum/install_test.sh \
-              ${{ matrix.package }}-mroonga
+            /host/packages/${package_type}/install_test.sh \
+              ${options[@]}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -15,22 +15,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # Ubuntu 20.04
-#          - image: "images:ubuntu/20.04"
-#            package: mysql
-#
-#          # Ubuntu 22.04
-#          - image: "images:ubuntu/22.04"
-#            package: mariadb
-#          - image: "images:ubuntu/22.04"
-#            package: mysql
-#
-#          # Ubuntu 24.04
-#          - image: "images:ubuntu/24.04"
-#            package: mariadb
-#          - image: "images:ubuntu/24.04"
-#            package: mysql
-#
+          # Ubuntu 20.04
+          - image: "images:ubuntu/20.04"
+            package: mysql
+
+          # Ubuntu 22.04
+          - image: "images:ubuntu/22.04"
+            package: mariadb
+          - image: "images:ubuntu/22.04"
+            package: mysql
+
+          # Ubuntu 24.04
+          - image: "images:ubuntu/24.04"
+            package: mariadb
+          - image: "images:ubuntu/24.04"
+            package: mysql
+
           # AlmaLinux with MariaDB 10.5
           - image: "images:almalinux/8"
             package: mariadb-10.5

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -15,22 +15,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu 20.04
-          - image: "images:ubuntu/20.04"
-            package: mysql
-
-          # Ubuntu 22.04
-          - image: "images:ubuntu/22.04"
-            package: mariadb
-          - image: "images:ubuntu/22.04"
-            package: mysql
-
-          # Ubuntu 24.04
-          - image: "images:ubuntu/24.04"
-            package: mariadb
-          - image: "images:ubuntu/24.04"
-            package: mysql
-
+#          # Ubuntu 20.04
+#          - image: "images:ubuntu/20.04"
+#            package: mysql
+#
+#          # Ubuntu 22.04
+#          - image: "images:ubuntu/22.04"
+#            package: mariadb
+#          - image: "images:ubuntu/22.04"
+#            package: mysql
+#
+#          # Ubuntu 24.04
+#          - image: "images:ubuntu/24.04"
+#            package: mariadb
+#          - image: "images:ubuntu/24.04"
+#            package: mysql
+#
           # AlmaLinux with MariaDB 10.5
           - image: "images:almalinux/8"
             package: mariadb-10.5
@@ -56,19 +56,10 @@ jobs:
           sudo incus exec target -- sudo systemctl is-system-running --wait
       - name: Install Mroonga
         run: |
-          case ${{ matrix.image }} in
-            images:ubuntu/*)
-              package_type=apt
-              os_version=$(echo ${{ matrix.image }} | awk -F "/" '{print $2}')
-              ;;
-            *)
-              package_type=yum
-              ;;
-          esac
           sudo incus exec target \
             -- \
-            /host/packages/${package_type}/install_test.sh \
-              ${{ matrix.package }}-mroonga ${os_version}
+            /host/packages/yum/install_test.sh \
+              ${{ matrix.package }}-mroonga
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *
@@ -48,7 +49,7 @@ jobs:
         run: |
           set -x
           sudo incus admin init --auto
-          sudo incus launch ${{ matrix.image }} target
+          sudo incus launch "${{ matrix.image }}" target
           sudo incus config device add target host disk source=$PWD path=/host
           # Ideally, we would use systemctl is-system-running --wait to ensure all services are fully operational.
           # However, this option doesn't work in AlmaLinux 8 and results in an error.
@@ -58,7 +59,7 @@ jobs:
           sleep 10
       - name: Install Mroonga
         run: |
-          case ${{ matrix.image }} in
+          case "${{ matrix.image }}" in
             images:ubuntu/*)
               package_type=apt
               ;;
@@ -68,8 +69,8 @@ jobs:
           esac
           sudo incus exec target \
             -- \
-            /host/packages/${package_type}/install_test.sh \
-              ${{ matrix.package }}-mroonga
+            "/host/packages/${package_type}/install_test.sh" \
+              "${{ matrix.package }}-mroonga"
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -29,6 +29,10 @@ jobs:
             package: mariadb
           - image: "images:ubuntu/24.04"
             package: mysql
+
+          # AlmaLinux with MariaDB 10.5
+          - image: "images:almalinux/8"
+            package: mariadb-10.5
     steps:
       - uses: actions/checkout@v4
       - name: Install Incus
@@ -51,10 +55,20 @@ jobs:
           sudo incus exec target -- sudo systemctl is-system-running --wait
       - name: Install Mroonga
         run: |
+          case ${{ matrix.image }} in
+            images:ubuntu/*)
+              package_type=apt
+              os_version=$(echo ${{ matrix.image }} | awk -F "/" '{print $2}')
+              ;;
+            *)
+              package_type=yum
+              ;;
+          esac
+
           sudo incus exec target \
             -- \
-            /host/packages/apt/install_test.sh \
-              ${{ matrix.package }}-mroonga
+            /host/packages/${package_type}/install_test.sh \
+              ${{ matrix.package }}-mroonga ${os_version}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -62,18 +62,18 @@ jobs:
           case ${{ matrix.image }} in
             images:ubuntu/*)
               package_type=apt
-              os_version=$(echo ${{ matrix.image }} | awk -F "/" '{print $2}')
-              options="${{ matrix.package }}-mroonga ${os_version}"
+              options=(${{ matrix.package }}-mroonga)
               ;;
             *)
               package_type=yum
-              options=${{ matrix.package }}-mroonga
+              os_version=$(echo ${{ matrix.image }} | awk -F "/" '{print $2}')
+              options=(${{ matrix.package }}-mroonga ${os_version})
               ;;
           esac
           sudo incus exec target \
             -- \
             /host/packages/${package_type}/install_test.sh \
-              ${options}
+              ${options[@]}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -73,7 +73,7 @@ jobs:
           sudo incus exec target \
             -- \
             /host/packages/${package_type}/install_test.sh \
-              ${options[@]}
+              ${options[*]}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,4 +1,4 @@
-name: Install Mroonga
+name: Install
 on:
   schedule:
     - cron: |
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   install:
-    name: Install Mroonga
+    name: Install
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,7 +1,7 @@
 name: Install Mroonga
 on:
+  push:
   schedule:
-    push:
     - cron: |
         0 0 * * *
 concurrency:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -63,17 +63,17 @@ jobs:
             images:ubuntu/*)
               package_type=apt
               os_version=$(echo ${{ matrix.image }} | awk -F "/" '{print $2}')
-              options=(${{ matrix.package }}-mroonga ${os_version})
+              options="${{ matrix.package }}-mroonga ${os_version}"
               ;;
             *)
               package_type=yum
-              options=(${{ matrix.package }}-mroonga)
+              options=${{ matrix.package }}-mroonga
               ;;
           esac
           sudo incus exec target \
             -- \
             /host/packages/${package_type}/install_test.sh \
-              ${options[*]}
+              ${options}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -11,8 +11,8 @@ cat > /etc/yum.repos.d/MariaDB.repo <<EOF
 [mariadb]
 name = MariaDB
 baseurl = "http://yum.mariadb.org/${mariadb_version}/centos${os_version}-amd64"
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1
+gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck = 1
 EOF
 
 sudo dnf install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -10,8 +10,8 @@ mariadb_version=$(echo "${package}" | cut -d'-' -f2)
 cat > /etc/yum.repos.d/MariaDB.repo <<EOF
 [mariadb]
 name = MariaDB
-baseurl = "http://yum.mariadb.org/${mariadb_version}/centos${os_version}-amd64"
-gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+baseurl = "https://rpm.mariadb.org/${mariadb_version}/rhel/\$releasever/\$basearch"
+gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck = 1
 EOF
 

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -2,23 +2,23 @@
 
 set -exu
 
-package=$1
+package="$1"
 
 os_version=$(cat /etc/almalinux-release | cut -f3 -d' ' | cut -f1 -d'.')
-mariadb_version=$(echo ${package} | awk -F "-" '{print $2}')
+mariadb_version=$(echo "${package}" | awk -F "-" '{print $2}')
 
 cat > /etc/yum.repos.d/MariaDB.repo <<EOF
 [mariadb]
 name = MariaDB
-baseurl = http://yum.mariadb.org/${mariadb_version}/centos${os_version}-amd64
+baseurl = "http://yum.mariadb.org/${mariadb_version}/centos${os_version}-amd64"
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1
 EOF
 
-sudo dnf install -y https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm
+sudo dnf install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
 sudo dnf module -y disable mariadb
 sudo dnf module -y disable mysql
 sudo dnf install -y --enablerepo=powertools mariadb-server
 sudo systemctl start mariadb
-sudo dnf install -y --enablerepo=powertools ${package}
+sudo dnf install -y --enablerepo=powertools "${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -4,7 +4,7 @@ set -exu
 
 package="$1"
 
-os_version=$(cat /etc/almalinux-release | cut -f3 -d' ' | cut -f1 -d'.')
+os_version=$(cut -d: -f5 /etc/system-release-cpe)
 mariadb_version=$(echo "${package}" | awk -F "-" '{print $2}')
 
 cat > /etc/yum.repos.d/MariaDB.repo <<EOF

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -exu
+
+package=$1
+os_version=$2
+
+mariadb_version=$(echo ${package} | awk -F "-" '{print $2}')
+
+cat > /etc/yum.repos.d/MariaDB.repo <<EOF
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/${mariadb_version}/centos${os_version}-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+EOF
+
+sudo dnf install -y https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm
+sudo dnf module -y disable mariadb
+sudo dnf module -y disable mysql
+sudo dnf install -y --enablerepo=powertools mariadb-server
+sudo systemctl start mariadb
+sudo dnf install -y --enablerepo=powertools ${package}
+sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -20,5 +20,5 @@ sudo dnf module -y disable mariadb
 sudo dnf module -y disable mysql
 sudo dnf install -y --enablerepo=powertools mariadb-server
 sudo systemctl start mariadb
-sudo dnf install -y --enablerepo=powertools "${package}"
+#sudo dnf install -y --enablerepo=powertools "${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -20,5 +20,5 @@ sudo dnf module -y disable mariadb
 sudo dnf module -y disable mysql
 sudo dnf install -y --enablerepo=powertools mariadb-server
 sudo systemctl start mariadb
-#sudo dnf install -y --enablerepo=powertools "${package}"
+sudo dnf install -y --enablerepo=powertools "${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -7,13 +7,13 @@ package="$1"
 os_version=$(cut -d: -f5 /etc/system-release-cpe)
 mariadb_version=$(echo "${package}" | cut -d'-' -f2)
 
-cat <<EOF | sudo tee /etc/yum.repos.d/MariaDB.repo
+cat <<REPO | sudo tee /etc/yum.repos.d/MariaDB.repo
 [mariadb]
 name = MariaDB
 baseurl = "https://rpm.mariadb.org/${mariadb_version}/rhel/\$releasever/\$basearch"
 gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck = 1
-EOF
+REPO
 
 sudo dnf install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
 sudo dnf module -y disable mariadb

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -5,7 +5,7 @@ set -exu
 package="$1"
 
 os_version=$(cut -d: -f5 /etc/system-release-cpe)
-mariadb_version=$(echo "${package}" | cut -f2 -d'-')
+mariadb_version=$(echo "${package}" | cut -d'-' -f2)
 
 cat > /etc/yum.repos.d/MariaDB.repo <<EOF
 [mariadb]

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -3,8 +3,8 @@
 set -exu
 
 package=$1
-os_version=$2
 
+os_version=$(cat /etc/almalinux-release | cut -f3 -d' ' | cut -f1 -d'.')
 mariadb_version=$(echo ${package} | awk -F "-" '{print $2}')
 
 cat > /etc/yum.repos.d/MariaDB.repo <<EOF

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -7,7 +7,7 @@ package="$1"
 os_version=$(cut -d: -f5 /etc/system-release-cpe)
 mariadb_version=$(echo "${package}" | cut -d'-' -f2)
 
-cat > /etc/yum.repos.d/MariaDB.repo <<EOF
+cat <<EOF | sudo tee /etc/yum.repos.d/MariaDB.repo
 [mariadb]
 name = MariaDB
 baseurl = "https://rpm.mariadb.org/${mariadb_version}/rhel/\$releasever/\$basearch"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -5,7 +5,7 @@ set -exu
 package="$1"
 
 os_version=$(cut -d: -f5 /etc/system-release-cpe)
-mariadb_version=$(echo "${package}" | awk -F "-" '{print $2}')
+mariadb_version=$(echo "${package}" | cut -f2 -d'-')
 
 cat > /etc/yum.repos.d/MariaDB.repo <<EOF
 [mariadb]


### PR DESCRIPTION
Related: GitHub GH-837.

This adds support for only AlmaLinux 8 and Mariadb 10.5.