### PR TITLE
ci: add install test for AlmaLinux 9 with MariaDB 10.5

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,9 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # AlmaLinux with MariaDB 10.5
+          # AlmaLinux 8
           - image: "images:almalinux/8"
             package: mariadb-10.5
+
+          # AlmaLinux 9
           - image: "images:almalinux/9"
             package: mariadb-10.5
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *
@@ -16,6 +17,8 @@ jobs:
         include:
           # AlmaLinux with MariaDB 10.5
           - image: "images:almalinux/8"
+            package: mariadb-10.5
+          - image: "images:almalinux/9"
             package: mariadb-10.5
 
           # Ubuntu 20.04

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -15,20 +15,21 @@ gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck = 1
 REPO
 
+DNF_MODULE="dnf module -y"
 case "${os_version}" in
   9)
-    DNF="dnf"
-    sudo "${DNF}" install -y "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
+    DNF_INSTALL="dnf install -y"
+    sudo "${DNF_INSTALL}" "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
     ;;
   *)
-    DNF="dnf --enablerepo=powertools"
-    sudo "${DNF}" module -y disable mysql
+    DNF_INSTALL="dnf install -y --enablerepo=powertools"
+    sudo "${DNF_MODULE}" disable mysql
     ;;
 esac
 
-sudo "${DNF}" install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
-sudo "${DNF}" module -y disable mariadb
-sudo "${DNF}" install -y --enablerepo=powertools mariadb-server
+sudo "${DNF_INSTALL}" "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
+sudo "${DNF_MODULE}" disable mariadb
+sudo "${DNF_INSTALL}" mariadb-server
 sudo systemctl start mariadb
-sudo "${DNF}" install -y --enablerepo=powertools "${package}"
+sudo "${DNF_INSTALL} ${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -19,17 +19,17 @@ DNF_MODULE="dnf module -y"
 case "${os_version}" in
   9)
     DNF_INSTALL="dnf install -y"
-    sudo "${DNF_INSTALL}" "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
+    sudo ${DNF_INSTALL} "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
     ;;
   *)
     DNF_INSTALL="dnf install -y --enablerepo=powertools"
-    sudo "${DNF_MODULE}" disable mysql
+    sudo ${DNF_MODULE} disable mysql
     ;;
 esac
 
-sudo "${DNF_INSTALL}" "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
+sudo ${DNF_INSTALL} "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
 sudo "${DNF_MODULE}" disable mariadb
-sudo "${DNF_INSTALL}" mariadb-server
+sudo ${DNF_INSTALL} mariadb-server
 sudo systemctl start mariadb
-sudo "${DNF_INSTALL} ${package}"
+sudo ${DNF_INSTALL} "${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -19,11 +19,13 @@ case "{$os_version}" in
   9)
     sudo dnf install -y "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
     ;;
+  *)
+    sudo dnf module -y disable mysql
+    ;;
 esac
 
 sudo dnf install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
 sudo dnf module -y disable mariadb
-sudo dnf module -y disable mysql
 sudo dnf install -y --enablerepo=powertools mariadb-server
 sudo systemctl start mariadb
 sudo dnf install -y --enablerepo=powertools "${package}"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -15,7 +15,6 @@ gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck = 1
 REPO
 
-DNF_MODULE="dnf module -y"
 case "${os_version}" in
   9)
     DNF_INSTALL="dnf install -y"
@@ -23,12 +22,12 @@ case "${os_version}" in
     ;;
   *)
     DNF_INSTALL="dnf install -y --enablerepo=powertools"
-    sudo ${DNF_MODULE} disable mysql
+    sudo dnf module -y disable mysql
     ;;
 esac
 
 sudo ${DNF_INSTALL} "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
-sudo ${DNF_MODULE} disable mariadb
+sudo dnf module -y disable mariadb
 sudo ${DNF_INSTALL} mariadb-server
 sudo systemctl start mariadb
 sudo ${DNF_INSTALL} "${package}"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -15,6 +15,12 @@ gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck = 1
 REPO
 
+case "{$os_version}" in
+  9)
+    sudo dnf install -y "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
+    ;;
+esac
+
 sudo dnf install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
 sudo dnf module -y disable mariadb
 sudo dnf module -y disable mysql

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -17,16 +17,18 @@ REPO
 
 case "${os_version}" in
   9)
-    sudo dnf install -y "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
+    DNF="dnf"
+    sudo "${DNF}" install -y "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
     ;;
   *)
-    sudo dnf module -y disable mysql
+    DNF="dnf --enablerepo=powertools"
+    sudo "${DNF}" module -y disable mysql
     ;;
 esac
 
-sudo dnf install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
-sudo dnf module -y disable mariadb
-sudo dnf install -y --enablerepo=powertools mariadb-server
+sudo "${DNF}" install -y "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
+sudo "${DNF}" module -y disable mariadb
+sudo "${DNF}" install -y --enablerepo=powertools mariadb-server
 sudo systemctl start mariadb
-sudo dnf install -y --enablerepo=powertools "${package}"
+sudo "${DNF}" install -y --enablerepo=powertools "${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -16,13 +16,13 @@ gpgcheck = 1
 REPO
 
 case "${os_version}" in
-  9)
-    DNF_INSTALL="dnf install -y"
-    sudo ${DNF_INSTALL} "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
-    ;;
-  *)
+  8)
     DNF_INSTALL="dnf install -y --enablerepo=powertools"
     sudo dnf module -y disable mysql
+    ;;
+  *)
+    DNF_INSTALL="dnf install -y"
+    sudo ${DNF_INSTALL} "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
     ;;
 esac
 

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -28,7 +28,7 @@ case "${os_version}" in
 esac
 
 sudo ${DNF_INSTALL} "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
-sudo "${DNF_MODULE}" disable mariadb
+sudo ${DNF_MODULE} disable mariadb
 sudo ${DNF_INSTALL} mariadb-server
 sudo systemctl start mariadb
 sudo ${DNF_INSTALL} "${package}"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -15,7 +15,7 @@ gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck = 1
 REPO
 
-case "{$os_version}" in
+case "${os_version}" in
   9)
     sudo dnf install -y "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
     ;;


### PR DESCRIPTION
Related: GitHub GH-837.
This adds support for only AlmaLinux 9 and Mariadb 10.5.

This modification passed CI in the following URL.
https://github.com/komainu8/mroonga/actions/runs/12706476645