### PR TITLE
ci: add install test for AlmaLinux 8 with MariaDB 10.11

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *
@@ -19,6 +20,8 @@ jobs:
             package: mariadb-10.5
           - image: "images:almalinux/8"
             package: mariadb-10.6
+          - image: "images:almalinux/8"
+            package: mariadb-10.11
 
           # AlmaLinux 9
           - image: "images:almalinux/9"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 8 and Mariadb 10.11.