### PR TITLE
ci: add install test for AlmaLinux 9 with MariaDB 11.4

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *
@@ -31,6 +32,8 @@ jobs:
             package: mariadb-10.6
           - image: "images:almalinux/9"
             package: mariadb-10.11
+          - image: "images:almalinux/9"
+            package: mariadb-11.4
 
           # Ubuntu 20.04
           - image: "images:ubuntu/20.04"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 9 and Mariadb 11.4.