### PR TITLE
ci: add install test for AlmaLinux 8 with MySQL Community Server 8.0

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -23,6 +23,8 @@ jobs:
             package: mariadb-10.11
           - image: "images:almalinux/8"
             package: mariadb-11.4
+          - image: "images:almalinux/8"
+            package: mysql-community-8.0
 
           # AlmaLinux 9
           - image: "images:almalinux/9"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -46,10 +46,11 @@ esac
 
 sudo ${DNF_INSTALL} "${package}"
 sudo systemctl start "${service_name}"
+mysql="mysql -u root"
 if [ "${have_auto_generated_password}" = "yes" ]; then
   auto_generated_password=$(sudo awk '/root@localhost/{print $NF}' /var/log/mysqld.log | tail -n 1)
   mysql="mysql -u root -p${auto_generated_password}"
   sudo ${mysql} --connect-expired-password -e "ALTER USER user() IDENTIFIED BY '$auto_generated_password'"
 fi
 
-sudo mysql -e "SHOW ENGINES" | grep Mroonga
+sudo ${mysql} -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -8,7 +8,7 @@ os_version=$(cut -d: -f5 /etc/system-release-cpe)
 
 case "${os_version}" in
   8)
-    DNF_INSTALL="dnf install -y --enablerepo=epel,powertools --disablerepo=AppStream"
+    DNF_INSTALL="dnf install -y --enablerepo=powertools --disablerepo=AppStream"
     sudo dnf module -y disable mysql
     ;;
   *)

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -43,6 +43,6 @@ REPO
          "https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${os_version}.rpm"
 esac
 
-sudo systemctl start "${service_name}"
 sudo ${DNF_INSTALL} "${package}"
+sudo systemctl start "${service_name}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -22,6 +22,7 @@ sudo ${DNF_INSTALL} "https://packages.groonga.org/almalinux/${os_version}/groong
 case "${package}" in
   mariadb-*)
     mariadb_version=$(echo "${package}" | cut -d'-' -f2)
+    service_name=mariadb
 
     cat <<REPO | sudo tee /etc/yum.repos.d/MariaDB.repo
 [mariadb]
@@ -32,15 +33,16 @@ gpgcheck = 1
 REPO
     sudo dnf module -y disable mariadb
     sudo ${DNF_INSTALL} mariadb-server
-    sudo systemctl start mariadb
     ;;
   mysql-community-*)
     mysql_version=$(echo "${package}" | cut -d'-' -f3)
     mysql_package_version=$(echo "${mysql_version}" | sed -e 's/\.//g')
+    service_name=mysqld
 
     sudo ${DNF_INSTALL} \
          "https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${os_version}.rpm"
 esac
 
+sudo systemctl start "${service_name}"
 sudo ${DNF_INSTALL} "${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -32,7 +32,6 @@ gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck = 1
 REPO
     sudo dnf module -y disable mariadb
-    sudo ${DNF_INSTALL} mariadb-server
     ;;
   mysql-community-*)
     mysql_version=$(echo "${package}" | cut -d'-' -f3)

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -8,7 +8,7 @@ os_version=$(cut -d: -f5 /etc/system-release-cpe)
 
 case "${os_version}" in
   8)
-    DNF_INSTALL="dnf install -y --enablerepo=powertools --disablerepo=AppStream"
+    DNF_INSTALL="dnf install -y --enablerepo=powertools"
     sudo dnf module -y disable mysql
     ;;
   *)

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -48,7 +48,7 @@ sudo ${DNF_INSTALL} "${package}"
 sudo systemctl start "${service_name}"
 if [ "${have_auto_generated_password}" = "yes" ]; then
   auto_generated_password=$(sudo awk '/root@localhost/{print $NF}' /var/log/mysqld.log | tail -n 1)
-  mysql="${mysql} -p${auto_generated_password}"
+  mysql="mysql -u root -p${auto_generated_password}"
   sudo ${mysql} --connect-expired-password -e "ALTER USER user() IDENTIFIED BY '$auto_generated_password'"
 fi
 

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -5,19 +5,10 @@ set -exu
 package="$1"
 
 os_version=$(cut -d: -f5 /etc/system-release-cpe)
-mariadb_version=$(echo "${package}" | cut -d'-' -f2)
-
-cat <<REPO | sudo tee /etc/yum.repos.d/MariaDB.repo
-[mariadb]
-name = MariaDB
-baseurl = "https://rpm.mariadb.org/${mariadb_version}/rhel/\$releasever/\$basearch"
-gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck = 1
-REPO
 
 case "${os_version}" in
   8)
-    DNF_INSTALL="dnf install -y --enablerepo=powertools"
+    DNF_INSTALL="dnf install -y --enablerepo=epel,powertools --disablerepo=AppStream"
     sudo dnf module -y disable mysql
     ;;
   *)
@@ -27,8 +18,29 @@ case "${os_version}" in
 esac
 
 sudo ${DNF_INSTALL} "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
-sudo dnf module -y disable mariadb
-sudo ${DNF_INSTALL} mariadb-server
-sudo systemctl start mariadb
+
+case "${package}" in
+  mariadb-*)
+    mariadb_version=$(echo "${package}" | cut -d'-' -f2)
+
+    cat <<REPO | sudo tee /etc/yum.repos.d/MariaDB.repo
+[mariadb]
+name = MariaDB
+baseurl = "https://rpm.mariadb.org/${mariadb_version}/rhel/\$releasever/\$basearch"
+gpgkey = https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck = 1
+REPO
+    sudo dnf module -y disable mariadb
+    sudo ${DNF_INSTALL} mariadb-server
+    sudo systemctl start mariadb
+    ;;
+  mysql-community-*)
+    mysql_version=$(echo "${package}" | cut -d'-' -f3)
+    mysql_package_version=$(echo "${mysql_version}" | sed -e 's/\.//g')
+
+    sudo ${DNF_INSTALL} \
+         "https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${os_version}.rpm"
+esac
+
 sudo ${DNF_INSTALL} "${package}"
 sudo mysql -e "SHOW ENGINES" | grep Mroonga


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 8 and MySQL Community Server 8.0.