### PR TITLE
ci: add install test for AlmaLinux 9 with MySQL Community Server 8.0

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *
@@ -35,6 +36,8 @@ jobs:
             package: mariadb-10.11
           - image: "images:almalinux/9"
             package: mariadb-11.4
+          - image: "images:almalinux/9"
+            package: mysql-community-8.0
 
           # Ubuntu 20.04
           - image: "images:ubuntu/20.04"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 9 and MySQL Community Server 8.0.