### PR TITLE
ci: add install test for AlmaLinux 8 with MySQL Community Server 8.4

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *
@@ -25,6 +26,8 @@ jobs:
             package: mariadb-11.4
           - image: "images:almalinux/8"
             package: mysql-community-8.0
+          - image: "images:almalinux/8"
+            package: mysql-community-8.4
 
           # AlmaLinux 9
           - image: "images:almalinux/9"


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 8 and MySQL Community Server 8.4.