### PR TITLE
ci: add install test for AlmaLinux 9 with MySQL Community Server 8.4

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,5 @@
 name: Install
 on:
-  push:
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,6 @@
 name: Install
 on:
+  push:
   schedule:
     - cron: |
         0 0 * * *
@@ -39,6 +40,8 @@ jobs:
             package: mariadb-11.4
           - image: "images:almalinux/9"
             package: mysql-community-8.0
+          - image: "images:almalinux/9"
+            package: mysql-community-8.4
 
           # Ubuntu 20.04
           - image: "images:ubuntu/20.04"


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 9 and MySQL Community Server 8.4.