### PR TITLE
ci: add install test for AlmaLinux 9 with MySQL Community Server minimal 8.0

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -49,6 +49,8 @@ jobs:
             package: mysql-community-8.0
           - image: "images:almalinux/9"
             package: mysql-community-8.4
+          - image: "images:almalinux/9"
+            package: mysql-community-minimal-8.0
 
           # Ubuntu 20.04
           - image: "images:ubuntu/20.04"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -61,6 +61,14 @@ case "${package}" in
     sudo chown mysql:mysql /var/lib/mysql /var/run/mysqld
     sudo chmod 1777 /var/lib/mysql /var/run/mysqld
 
+    # mysql --initialize output the following log to stderror.
+    # 2025-01-20T02:57:06.620776Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.40) initializing of server in progress as process 593
+    # 2025-01-20T02:57:06.631994Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+    # 2025-01-20T02:57:06.852935Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+    # 2025-01-20T02:57:07.484688Z 6 [Note] [MY-010454] [Server] A temporary password is generated for root@localhost: xxxxxxxxxxxx
+    #
+    # We can connect stderror of a command to stdin of the other command through the pipe by using "&|".
+    # So, we can get the temporary password by using "|&" and "awk 'END{print $NF}'".
     auto_generated_password=$(mysqld --initialize |& awk 'END{print $NF}')
     mysql="mysql -u root -p${auto_generated_password}"
     "${service_name}" &

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -74,7 +74,7 @@ case "${package}" in
     #
     # Execution example:
     #   $ mysqld --initialize |& awk 'END{print $NF}'
-    #   $ xxxxxxxxxxxx
+    #   xxxxxxxxxxxx
     auto_generated_password=$(mysqld --initialize |& awk 'END{print $NF}')
     mysql="mysql -u root -p${auto_generated_password}"
     "${service_name}" &

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -61,11 +61,12 @@ case "${package}" in
     sudo chown mysql:mysql /var/lib/mysql /var/run/mysqld
     sudo chmod 1777 /var/lib/mysql /var/run/mysqld
 
-    # mysql --initialize output the following log to stderror.
-    # 2025-01-20T02:57:06.620776Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.40) initializing of server in progress as process 593
-    # 2025-01-20T02:57:06.631994Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
-    # 2025-01-20T02:57:06.852935Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
-    # 2025-01-20T02:57:07.484688Z 6 [Note] [MY-010454] [Server] A temporary password is generated for root@localhost: xxxxxxxxxxxx
+    # mysql --initialize outputs the following logs to stderror:
+    #
+    #   2025-01-20T02:57:06.620776Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.40) initializing of server in progress as process 593
+    #   2025-01-20T02:57:06.631994Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+    #   2025-01-20T02:57:06.852935Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+    #   2025-01-20T02:57:07.484688Z 6 [Note] [MY-010454] [Server] A temporary password is generated for root@localhost: xxxxxxxxxxxx
     #
     # We can connect stderror of a command to stdin of the other command through the pipe by using "|&".
     # So, we can get the temporary password by using "|&" and "awk 'END{print $NF}'".

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -68,8 +68,9 @@ case "${package}" in
     #   2025-01-20T02:57:06.852935Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
     #   2025-01-20T02:57:07.484688Z 6 [Note] [MY-010454] [Server] A temporary password is generated for root@localhost: xxxxxxxxxxxx
     #
-    # We can connect stderror of a command to stdin of the other command through the pipe by using "|&".
-    # So, we can get the temporary password by using "|&" and "awk 'END{print $NF}'".
+    # We can connect stderror of a command to stdin of the other
+    # command through the pipe by using "|&".  So, we can get the
+    # temporary password by using "|&" and "awk 'END{print $NF}'".
     #
     # Execution example:
     #   $ mysqld --initialize |& awk 'END{print $NF}'

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -68,8 +68,6 @@ case "${package}" in
       sudo ${mysql} \
            --connect-expired-password \
            -e "ALTER USER user() IDENTIFIED BY '$auto_generated_password'"
-
-      sudo ${mysql} < /usr/share/mroonga/install.sql
       ;;
   *)
     sudo systemctl start "${service_name}"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -69,6 +69,10 @@ case "${package}" in
     #
     # We can connect stderror of a command to stdin of the other command through the pipe by using "&|".
     # So, we can get the temporary password by using "|&" and "awk 'END{print $NF}'".
+    #
+    # Execution example:
+    #   $ mysqld --initialize |& awk 'END{print $NF}'
+    #   $ xxxxxxxxxxxx
     auto_generated_password=$(mysqld --initialize |& awk 'END{print $NF}')
     mysql="mysql -u root -p${auto_generated_password}"
     "${service_name}" &

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -40,6 +40,8 @@ REPO
 
     sudo ${DNF_INSTALL} \
          "https://repo.mysql.com/mysql-community-minimal-release-el${os_version}.rpm"
+    echo "module_hotfixes=true" | sudo tee -a /etc/yum.repos.d/mysql-community-minimal.repo
+    sudo sed -i -e 's/^enabled=0/enabled=1/g' /etc/yum.repos.d/mysql-community-minimal.repo
     ;;
   mysql-community-*)
     mysql_version=$(echo "${package}" | cut -d'-' -f3)

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -72,7 +72,9 @@ case "${package}" in
     auto_generated_password=$(mysqld --initialize |& awk 'END{print $NF}')
     mysql="mysql -u root -p${auto_generated_password}"
     "${service_name}" &
-    while ! mysqladmin ping -hlocalhost --silent; do sleep 1; done
+    while ! mysqladmin ping -hlocalhost --silent; do
+      sleep 1
+    done
     sudo ${mysql} \
          --connect-expired-password \
          -e "ALTER USER user() IDENTIFIED BY '$auto_generated_password'"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -36,7 +36,6 @@ REPO
     ;;
   mysql-community-minimal-*)
     service_name=mysqld
-    have_auto_generated_password="yes"
 
     sudo ${DNF_INSTALL} \
          "https://repo.mysql.com/mysql-community-minimal-release-el${os_version}.rpm"
@@ -64,7 +63,7 @@ case "${package}" in
 
       auto_generated_password=$(mysqld --initialize |& awk 'END{print $NF}')
       mysql="mysql -u root -p${auto_generated_password}"
-      mysqld &
+      "${service_name}" &
       while ! mysqladmin ping -hlocalhost --silent; do sleep 1; done
       sudo ${mysql} \
            --connect-expired-password \

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -57,19 +57,19 @@ sudo ${DNF_INSTALL} "${package}"
 
 case "${package}" in
   mysql-community-minimal-*)
-      sudo mkdir -p /var/lib/mysql /var/run/mysqld
-      sudo chown mysql:mysql /var/lib/mysql /var/run/mysqld
-      sudo chmod 1777 /var/lib/mysql /var/run/mysqld
+    sudo mkdir -p /var/lib/mysql /var/run/mysqld
+    sudo chown mysql:mysql /var/lib/mysql /var/run/mysqld
+    sudo chmod 1777 /var/lib/mysql /var/run/mysqld
 
-      auto_generated_password=$(mysqld --initialize |& awk 'END{print $NF}')
-      mysql="mysql -u root -p${auto_generated_password}"
-      "${service_name}" &
-      while ! mysqladmin ping -hlocalhost --silent; do sleep 1; done
-      sudo ${mysql} \
-           --connect-expired-password \
-           -e "ALTER USER user() IDENTIFIED BY '$auto_generated_password'"
-      sudo ${mysql} < /usr/share/mroonga/install.sql
-      ;;
+    auto_generated_password=$(mysqld --initialize |& awk 'END{print $NF}')
+    mysql="mysql -u root -p${auto_generated_password}"
+    "${service_name}" &
+    while ! mysqladmin ping -hlocalhost --silent; do sleep 1; done
+    sudo ${mysql} \
+         --connect-expired-password \
+         -e "ALTER USER user() IDENTIFIED BY '$auto_generated_password'"
+    sudo ${mysql} < /usr/share/mroonga/install.sql
+    ;;
   *)
     sudo systemctl start "${service_name}"
     mysql="mysql -u root"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -67,7 +67,7 @@ case "${package}" in
     # 2025-01-20T02:57:06.852935Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
     # 2025-01-20T02:57:07.484688Z 6 [Note] [MY-010454] [Server] A temporary password is generated for root@localhost: xxxxxxxxxxxx
     #
-    # We can connect stderror of a command to stdin of the other command through the pipe by using "&|".
+    # We can connect stderror of a command to stdin of the other command through the pipe by using "|&".
     # So, we can get the temporary password by using "|&" and "awk 'END{print $NF}'".
     #
     # Execution example:

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -42,6 +42,13 @@ REPO
 
     sudo ${DNF_INSTALL} \
          "https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${os_version}.rpm"
+    ;;
+  mysql-community-minimal-*)
+    service_name=mysqld
+    have_auto_generated_password="yes"
+
+    sudo ${DNF_INSTALL} \
+         "https://repo.mysql.com/mysql-community-minimal-release-el${os_version}.rpm"
 esac
 
 sudo ${DNF_INSTALL} "${package}"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -68,6 +68,7 @@ case "${package}" in
       sudo ${mysql} \
            --connect-expired-password \
            -e "ALTER USER user() IDENTIFIED BY '$auto_generated_password'"
+      sudo ${mysql} < /usr/share/mroonga/install.sql
       ;;
   *)
     sudo systemctl start "${service_name}"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -34,6 +34,13 @@ gpgcheck = 1
 REPO
     sudo dnf module -y disable mariadb
     ;;
+  mysql-community-minimal-*)
+    service_name=mysqld
+    have_auto_generated_password="yes"
+
+    sudo ${DNF_INSTALL} \
+         "https://repo.mysql.com/mysql-community-minimal-release-el${os_version}.rpm"
+    ;;
   mysql-community-*)
     mysql_version=$(echo "${package}" | cut -d'-' -f3)
     mysql_package_version=$(echo "${mysql_version}" | sed -e 's/\.//g')
@@ -43,12 +50,6 @@ REPO
     sudo ${DNF_INSTALL} \
          "https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${os_version}.rpm"
     ;;
-  mysql-community-minimal-*)
-    service_name=mysqld
-    have_auto_generated_password="yes"
-
-    sudo ${DNF_INSTALL} \
-         "https://repo.mysql.com/mysql-community-minimal-release-el${os_version}.rpm"
 esac
 
 sudo ${DNF_INSTALL} "${package}"


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 9 and MySQL Community Server minimal 8.0.