### PR TITLE
ci: add install test for AlmaLinux 8 with Percona Server 8.0

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -35,6 +35,8 @@ jobs:
             package: mysql-community-8.0
           - image: "images:almalinux/8"
             package: mysql-community-8.4
+          - image: "images:almalinux/8"
+            package: percona-server-8.0
 
           # AlmaLinux 9
           - image: "images:almalinux/9"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -51,6 +51,15 @@ REPO
     sudo ${DNF_INSTALL} \
          "https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${os_version}.rpm"
     ;;
+  percona-*)
+    service_name=mysqld
+    have_auto_generated_password=yes
+    sudo ${DNF_INSTALL} install -y \
+         https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    percona_package_version=$(echo ${mysql_version} | sed -e 's/\.//g')
+    sudo percona-release setup ps${percona_package_version}
+    sudo ${DNF_INSTALL} install -y percona-icu-data-files
+    ;;
 esac
 
 sudo ${DNF_INSTALL} "${package}"

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -54,11 +54,11 @@ REPO
   percona-*)
     service_name=mysqld
     have_auto_generated_password=yes
-    sudo ${DNF_INSTALL} install -y \
+    sudo ${DNF_INSTALL} \
          https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     percona_package_version=$(echo ${mysql_version} | sed -e 's/\.//g')
     sudo percona-release setup ps${percona_package_version}
-    sudo ${DNF_INSTALL} install -y percona-icu-data-files
+    sudo ${DNF_INSTALL} percona-icu-data-files
     ;;
 esac
 

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -55,6 +55,7 @@ REPO
     percona_server_version=$(echo "${package}" | cut -d'-' -f3)
     service_name=mysqld
     have_auto_generated_password=yes
+
     sudo ${DNF_INSTALL} \
          https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     percona_package_version=$(echo ${percona_server_version} | sed -e 's/\.//g')

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -52,11 +52,12 @@ REPO
          "https://repo.mysql.com/mysql${mysql_package_version}-community-release-el${os_version}.rpm"
     ;;
   percona-*)
+    percona_server_version=$(echo "${package}" | cut -d'-' -f3)
     service_name=mysqld
     have_auto_generated_password=yes
     sudo ${DNF_INSTALL} \
          https://repo.percona.com/yum/percona-release-latest.noarch.rpm
-    percona_package_version=$(echo ${mysql_version} | sed -e 's/\.//g')
+    percona_package_version=$(echo ${percona_server_version} | sed -e 's/\.//g')
     sudo percona-release setup ps${percona_package_version}
     sudo ${DNF_INSTALL} percona-icu-data-files
     ;;


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 8 and Percona Server 8.0.