### PR TITLE
ci: add install test for AlmaLinux 9 with Percona Server 8.0

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -53,6 +53,8 @@ jobs:
             package: mysql-community-8.4
           - image: "images:almalinux/9"
             package: mysql-community-minimal-8.0
+          - image: "images:almalinux/9"
+            package: percona-server-8.0
 
           # Ubuntu 20.04
           - image: "images:ubuntu/20.04"


### PR DESCRIPTION
Related: GitHub: GH-837
This adds support for only AlmaLinux 9 and Percona Server 8.0.