### PR TITLE
doc: Add the `--quiet` and `--fail-on-warning` options to `sphinx-build`

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -67,9 +67,10 @@ function(mrn_sphinx SOURCE_DIR LOCALE SOURCES HTML_FILES)
       COMMAND
         ${CMAKE_COMMAND} -E env DOCUMENT_VERSION=${MRN_VERSION_FULL}
         DOCUMENT_VERSION_FULL=${MRN_VERSION_FULL} LOCALE=${LOCALE}
-	PACKAGE_MROONGA_VERSION=${MRN_VERSION_FULL}
-        ${SPHINX_BUILD} -j auto -D language=${LOCALE} -b ${BUILDER} -d
-        ${LOCALE}/doctrees/${BUILDER} ${SOURCE_DIR} ${LOCALE}/${BUILDER}
+        PACKAGE_MROONGA_VERSION=${MRN_VERSION_FULL}
+        ${SPHINX_BUILD} $<$<CONFIG:Debug>:--fail-on-warning> --quiet -j auto -D
+        language=${LOCALE} -b ${BUILDER} -d ${LOCALE}/doctrees/${BUILDER}
+        ${SOURCE_DIR} ${LOCALE}/${BUILDER}
       COMMAND ${CMAKE_COMMAND} -E touch ${LOCALE}-${BUILDER}.time_stamp
       DEPENDS ${TARGET_SOURCES})
     if("${BUILDER}" STREQUAL "html")

--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -17,3 +17,4 @@
 source "https://rubygems.org"
 
 gem "gettext"
+gem "red-datasets"


### PR DESCRIPTION
* `--quiet`
  * It is easier to see output related to errors
* `--fail-on-warning`
  * This option causes the build to fail on warnings
  * It makes it easier to notice mistakes
* Added `red-datasets` to Gemfile because of warning output at build

These are the same as the settings for building documents in groonga/groonga.