### PR TITLE
docs: Remove unnecessary character from the URL of the link

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/others.po
+++ b/doc/locale/ja/LC_MESSAGES/install/others.po
@@ -70,11 +70,14 @@ msgstr "ライブラリー"
 msgid "Here are required libraries."
 msgstr "必須のライブラリー"
 
-msgid "[Groonga](https://groonga.org/). (If you use package, install development package such as `libgroonga-dev` for deb or `groonga-devel` for RPM.)"
-msgstr "[Groonga](https://groonga.org/ja/) 。（もしパッケージを使うなら、開発用パッケージをインストールしてください。debなら `libgroonga-dev` で、RPMなら `groonga-devel` です。）"
+msgid "[Groonga](https://groonga.org/)"
+msgstr ""
 
-msgid "[groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql)."
-msgstr "[groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql) 。"
+msgid "If you use package, install development package such as `libgroonga-dev` for deb or `groonga-devel` for RPM"
+msgstr "もしパッケージを使うなら、開発用パッケージをインストールしてください。debなら `libgroonga-dev` で、RPMなら `groonga-devel` です"
+
+msgid "[groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql)"
+msgstr ""
 
 msgid "Here are optional libraries."
 msgstr "あるとよいライブラリー"

--- a/doc/locale/ja/LC_MESSAGES/install/others.po
+++ b/doc/locale/ja/LC_MESSAGES/install/others.po
@@ -74,7 +74,7 @@ msgid "[Groonga](https://groonga.org/). (If you use package, install development
 msgstr "[Groonga](https://groonga.org/ja/) 。（もしパッケージを使うなら、開発用パッケージをインストールしてください。debなら `libgroonga-dev` で、RPMなら `groonga-devel` です。）"
 
 msgid "[groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql)."
-msgstr "[groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql>) 。"
+msgstr "[groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql) 。"
 
 msgid "Here are optional libraries."
 msgstr "あるとよいライブラリー"

--- a/doc/source/install/others.md
+++ b/doc/source/install/others.md
@@ -31,8 +31,9 @@ Here are optional tools.
 
 Here are required libraries.
 
-- [Groonga](https://groonga.org/). (If you use package, install development package such as `libgroonga-dev` for deb or `groonga-devel` for RPM.)
-- [groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql).
+- [Groonga](https://groonga.org/)
+  - If you use package, install development package such as `libgroonga-dev` for deb or `groonga-devel` for RPM
+- [groonga-normalizer-mysql](https://github.com/groonga/groonga-normalizer-mysql)
 
 Here are optional libraries.
 


### PR DESCRIPTION
No need for tail `>`.