### PR TITLE
packages: donwload soruce archive automatically

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -156,6 +156,11 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def define_archive_task
+    file original_archive_path.to_s do
+      source_archive_url = built_package_url(:source, @original_archive_name)
+      download(source_archive_url, "../..")
+    end
+
     [@archive_name, deb_archive_name, rpm_archive_name].each do |archive_name|
       file archive_name => original_archive_path.to_s do
         sh("tar", "xf", original_archive_path.to_s)

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -158,7 +158,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   def define_archive_task
     file original_archive_path.to_s do
       source_archive_url = built_package_url(:source, @original_archive_name)
-      download(source_archive_url, "../..")
+      download(source_archive_url, original_archive_path.to_s)
     end
 
     [@archive_name, deb_archive_name, rpm_archive_name].each do |archive_name|


### PR DESCRIPTION
During the Mroonga release, an following error occurred because the rake task for downloading source archives was not defined.

This PR introduces the necessary rake task to handle the downloading of source archives.

```
$ rake ubuntu DPUT_CONFIGURATION_NAME=groonga-ppa-nightly DPUT_INCOMING="~groonga/ubuntu/nightly"
cd mariadb-10.5-mroonga
/home/otegami/.rbenv/versions/3.3.7/bin/ruby -S rake ubuntu
cd -
cd mariadb-10.6-mroonga
/home/otegami/.rbenv/versions/3.3.7/bin/ruby -S rake ubuntu
rake aborted!
Don't know how to build task '/home/otegami/work/cpp/mroonga.clean/mroonga-14.13.tar.gz' (See the list of available tasks with `rake --tasks`)

Tasks: TOP => ubuntu => ubuntu:upload => ubuntu:upload:jammy => mariadb-10.6-mroonga-14.13.tar.gz
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [/home/otegami/.rbenv/versions/3.3.7/bin/ruby -S rake ubuntu]
/home/otegami/work/cpp/mroonga.clean/packages/Rakefile:61:in `block (4 levels) in <top (required)>'
/home/otegami/work/cpp/mroonga.clean/packages/Rakefile:60:in `block (3 levels) in <top (required)>'
/home/otegami/work/cpp/mroonga.clean/packages/Rakefile:59:in `each'
/home/otegami/work/cpp/mroonga.clean/packages/Rakefile:59:in `block (2 levels) in <top (required)>'
Tasks: TOP => ubuntu
(See full trace by running task with --trace)
```