### PR TITLE
docs install: remove a needless dependency package

### DIFF
--- a/doc/source/install/debian.rst
+++ b/doc/source/install/debian.rst
@@ -10,7 +10,6 @@ bookworm (MariaDB)
 Install::
 
   % sudo apt update
-  % sudo apt install -y -V apt-transport-https
   % sudo apt install -y -V wget
   % wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   % sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
@@ -31,7 +30,6 @@ bookworm (with the Oracle MySQL 8.0 package)
 Install::
 
   % sudo apt update
-  % sudo apt install -y -V apt-transport-https
   % sudo apt install -y -V wget
   % wget https://packages.groonga.org/debian/groonga-apt-source-latest-bookworm.deb
   % wget https://repo.mysql.com/mysql-apt-config.deb


### PR DESCRIPTION
Fix: GH-867
apt-transport-https is a transitional package.