### PR TITLE
docs install/debian: don't use lsb_release

### DIFF
--- a/doc/source/install/debian.rst
+++ b/doc/source/install/debian.rst
@@ -11,8 +11,8 @@ Install::
 
   % sudo apt update
   % sudo apt install -y -V wget lsb-release
-  % wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-  % sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+  % wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-bookworm.deb
+  % sudo apt install -y -V ./apache-arrow-apt-source-latest-bookworm.deb
   % wget https://packages.groonga.org/debian/groonga-apt-source-latest-bookworm.deb
   % sudo apt install -y -V ./groonga-apt-source-latest-bookworm.deb
   % sudo apt update

--- a/doc/source/install/debian.rst
+++ b/doc/source/install/debian.rst
@@ -10,7 +10,7 @@ bookworm (MariaDB)
 Install::
 
   % sudo apt update
-  % sudo apt install -y -V wget
+  % sudo apt install -y -V wget lsb-release
   % wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   % sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   % wget https://packages.groonga.org/debian/groonga-apt-source-latest-bookworm.deb

--- a/doc/source/install/debian.rst
+++ b/doc/source/install/debian.rst
@@ -10,8 +10,8 @@ bookworm (MariaDB)
 Install::
 
   % sudo apt update
-  % sudo apt install -y -V wget lsb-release
-  % wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-bookworm.deb
+  % sudo apt install -y -V wget
+  % wget https://apache.jfrog.io/artifactory/arrow/debian/apache-arrow-apt-source-latest-bookworm.deb
   % sudo apt install -y -V ./apache-arrow-apt-source-latest-bookworm.deb
   % wget https://packages.groonga.org/debian/groonga-apt-source-latest-bookworm.deb
   % sudo apt install -y -V ./groonga-apt-source-latest-bookworm.deb


### PR DESCRIPTION
Fix: GH-868

We can use codename directly like we did for groonga-apt-source.
So, we don't need to use lsb_release for apache-arrow-apt-source.