### PR TITLE
Use "DEBIAN_FRONTEND=noninteractive" when we install mysql-community-8.0-mroonga

### DIFF
--- a/doc/source/install/debian.rst
+++ b/doc/source/install/debian.rst
@@ -38,7 +38,7 @@ Install::
   % sudo apt install -y -V ./groonga-apt-source-latest-bookworm.deb
   % sudo env DEBIAN_FRONTEND=noninteractive MYSQL_SERVER_VERSION=mysql-8.0 apt install -y ./mysql-apt-config.deb
   % sudo apt update
-  % sudo apt install -y -V mysql-community-8.0-mroonga
+  % sudo env DEBIAN_FRONTEND=noninteractive apt install -y -V mysql-community-8.0-mroonga
 
 If you want to use `MeCab <https://taku910.github.io/mecab/>`_ as a tokenizer, install groonga-tokenizer-mecab package.
 


### PR DESCRIPTION
If we don't specify "DEBIAN_FRONTEND=noninteractive", we input MySQL's root password forcibly.

If we set root password, we can't install Mroonga automatically as below.

---

ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: NO) Run the following command line to register Mroonga:
  mysql -u root < /usr/share/mroonga/install.sql
Run the following command lines to update Mroonga:
  mysql -u root < /usr/share/mroonga/update.sql