### PR TITLE
Revert "packages apt test: disable upgrade test temporally until next release (#818)"

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -233,11 +233,7 @@ case ${package} in
     ;;
 esac
 
-if [ ${package} = "mysql-community-8.0-mroonga" ] || \
-   [ ${package} = "mysql-community-8.4-mroonga" ]; then
-  echo "Skip because 14.08 packages aren't updated yet."
-  echo "We should remove this after we release 14.09."
-elif apt show ${package} > /dev/null 2>&1; then
+if apt show ${package} > /dev/null 2>&1; then
   sudo apt install -V -y ${package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/
   sudo apt update


### PR DESCRIPTION
This reverts commit a3169a8f197cd731c5a55c42193f37e73b054553.
Because we have already released Mroonga 14.10.