### PR TITLE
ci test: skip upgrade tests on release

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -302,7 +302,7 @@ jobs:
             -- \
             /host/packages/${PACKAGE_TYPE}/test.sh \
               ${{ matrix.package }}-mroonga \
-              ${{ github.ref }}
+              ${{ github.ref_type }}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -302,7 +302,7 @@ jobs:
             -- \
             /host/packages/${PACKAGE_TYPE}/test.sh \
               ${{ matrix.package }}-mroonga \
-              ${{ github.ref_type }}
+              ${GITHUB_REF_TYPE}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -301,7 +301,8 @@ jobs:
           sudo incus exec target \
             -- \
             /host/packages/${PACKAGE_TYPE}/test.sh \
-              ${{ matrix.package }}-mroonga
+              ${{ matrix.package }}-mroonga \
+              ${{ github.ref }}
       - name: Delete container
         run: |
           sudo incus stop target

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -221,12 +221,6 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade test"
-if [[ "${triggered_ref_type}" == "tag" ]]; then
-  echo "Skipping upgrade tests on release."
-  echo "::endgroup::"
-  exit 0
-fi
-
 sudo apt purge -V -y \
   ${package} \
   "${mysql_package_prefix}-*"
@@ -240,7 +234,9 @@ case ${package} in
     ;;
 esac
 
-if apt show ${package} > /dev/null 2>&1; then
+if [[ "${triggered_ref_type}" == "tag" ]]; then
+  echo "Skip on release because external dependency updates of old package cause test failures."
+elif apt show ${package} > /dev/null 2>&1; then
   sudo apt install -V -y ${package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/
   sudo apt update

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -235,7 +235,8 @@ case ${package} in
 esac
 
 if [ "${triggered_ref_type}" == "tag" ]; then
-  echo "Skip on release because external dependency updates of old package cause test failures."
+  echo "Skip on release because external dependency updates of old package " \
+       "cause test failures."
 elif apt show ${package} > /dev/null 2>&1; then
   sudo apt install -V -y ${package}
   sudo mv /tmp/${package}.list /etc/apt/sources.list.d/

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -234,7 +234,7 @@ case ${package} in
     ;;
 esac
 
-if [ "${triggered_ref_type}" == "tag" ]; then
+if [ "${triggered_ref_type}" = "tag" ]; then
   echo "Skip on release because external dependency updates of old package " \
        "cause test failures."
 elif apt show ${package} > /dev/null 2>&1; then

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -3,6 +3,7 @@
 set -exu
 
 package=$1
+triggered_branch=$2
 
 echo "::group::Prepare repository"
 
@@ -220,6 +221,12 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade test"
+if [[ "${triggered_branch}" =~ ^refs/tags/ ]]; then
+  echo "Skipping upgrade tests on release."
+  echo "::endgroup::"
+  exit 0
+fi
+
 sudo apt purge -V -y \
   ${package} \
   "${mysql_package_prefix}-*"

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -3,7 +3,7 @@
 set -exu
 
 package=$1
-triggered_branch=$2
+triggered_ref_type=$2
 
 echo "::group::Prepare repository"
 
@@ -221,7 +221,7 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade test"
-if [[ "${triggered_branch}" =~ ^refs/tags/ ]]; then
+if [[ "${triggered_ref_type}" == "tag" ]]; then
   echo "Skipping upgrade tests on release."
   echo "::endgroup::"
   exit 0

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -234,7 +234,7 @@ case ${package} in
     ;;
 esac
 
-if [[ "${triggered_ref_type}" == "tag" ]]; then
+if [ "${triggered_ref_type}" == "tag" ]; then
   echo "Skip on release because external dependency updates of old package cause test failures."
 elif apt show ${package} > /dev/null 2>&1; then
   sudo apt install -V -y ${package}

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -276,7 +276,8 @@ echo "::endgroup::"
 
 echo "::group::Upgrade"
 if [ "${triggered_ref_type}" == "tag" ]; then
-  echo "Skip on release because external dependency updates of old package cause test failures."
+  echo "Skip on release because external dependency updates of old package " \
+       "cause test failures."
 elif [ -n "${old_package}" ]; then
   # TODO: Remove this after we release a new version. Old Mroonga package
   # requires "which" in rpm/post.sh.

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -275,7 +275,7 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade"
-if [[ "${triggered_ref_type}" == "tags" ]]; then
+if [[ "${triggered_ref_type}" == "tag" ]]; then
   echo "Skip on release because external dependency updates of old package cause test failures."
 elif [ -n "${old_package}" ]; then
   # TODO: Remove this after we release a new version. Old Mroonga package

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -275,7 +275,7 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade"
-if [ "${triggered_ref_type}" == "tag" ]; then
+if [ "${triggered_ref_type}" = "tag" ]; then
   echo "Skip on release because external dependency updates of old package " \
        "cause test failures."
 elif [ -n "${old_package}" ]; then

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -3,7 +3,7 @@
 set -exu
 
 package=$1
-triggered_branch=$2
+triggered_ref_type=$2
 
 echo "::group::Prepare repository"
 
@@ -275,7 +275,7 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade"
-if [[ "${triggered_branch}" =~ ^refs/tags/ ]]; then
+if [[ "${triggered_ref_type}" == "tags" ]]; then
   echo "Skipping upgrade tests on release."
   echo "::endgroup::"
   exit 0

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -3,6 +3,7 @@
 set -exu
 
 package=$1
+triggered_branch=$2
 
 echo "::group::Prepare repository"
 
@@ -274,6 +275,12 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade"
+if [[ "${triggered_branch}" =~ ^refs/tags/ ]]; then
+  echo "Skipping upgrade tests on release."
+  echo "::endgroup::"
+  exit 0
+fi
+
 if [ -n "${old_package}" ]; then
   # TODO: Remove this after we release a new version. Old Mroonga package
   # requires "which" in rpm/post.sh.

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -275,7 +275,7 @@ echo "::endgroup::"
 
 
 echo "::group::Upgrade"
-if [[ "${triggered_ref_type}" == "tag" ]]; then
+if [ "${triggered_ref_type}" == "tag" ]; then
   echo "Skip on release because external dependency updates of old package cause test failures."
 elif [ -n "${old_package}" ]; then
   # TODO: Remove this after we release a new version. Old Mroonga package

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -276,12 +276,8 @@ echo "::endgroup::"
 
 echo "::group::Upgrade"
 if [[ "${triggered_ref_type}" == "tags" ]]; then
-  echo "Skipping upgrade tests on release."
-  echo "::endgroup::"
-  exit 0
-fi
-
-if [ -n "${old_package}" ]; then
+  echo "Skip on release because external dependency updates of old package cause test failures."
+elif [ -n "${old_package}" ]; then
   # TODO: Remove this after we release a new version. Old Mroonga package
   # requires "which" in rpm/post.sh.
   sudo ${DNF} install -y which

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -279,9 +279,6 @@ if [ "${triggered_ref_type}" == "tag" ]; then
   echo "Skip on release because external dependency updates of old package " \
        "cause test failures."
 elif [ -n "${old_package}" ]; then
-  # TODO: Remove this after we release a new version. Old Mroonga package
-  # requires "which" in rpm/post.sh.
-  sudo ${DNF} install -y which
   sudo ${DNF} erase -y \
        ${package} \
        "${mysql_package_prefix}-*"


### PR DESCRIPTION
## Issue

Upgrade tests could fail in due to the existed package's external dependency updates (e.g. new versions of MariaDB/MySQL) that do not affect the functionality of the release package. And also, we have confirmed that package upgrades work correctly in non-release testing environments.

## Solution

To avoid blocking new package releases due to irrelevant upgrade test failures, we skip upgrade test on only release.