### PR TITLE
Add `mroonga_n_workers` to the system variables

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1217,9 +1217,7 @@ static void mrn_n_workers_update(THD* thd,
 
   *old_value_ptr = new_value;
   grn_set_default_n_workers(new_value);
-
-  grn_ctx* ctx = mrn_context_pool->pull();
-  grn_ctx_set_n_workers(ctx, new_value);
+  mrn_context_pool->set_n_workers(new_value);
 
   DBUG_VOID_RETURN;
 }

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1229,7 +1229,7 @@ static MYSQL_SYSVAR_INT(n_workers,
                         "0: The default. It disables parallel workers. "
                         "-1: Use the all CPUs in the environment. "
                         "1 or larger: Use the specified number of CPUs.",
-                        NULL,
+                        nullptr,
                         mrn_n_workers_update,
                         grn_get_default_n_workers(),
                         -1,

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -730,6 +730,7 @@ static char* mrn_query_log_file_path = NULL;
 char* mrn_default_tokenizer = NULL;
 char* mrn_default_wrapper_engine = NULL;
 static int mrn_lock_timeout = grn_get_lock_timeout();
+static int mrn_n_workers = grn_get_default_n_workers();
 static char* mrn_libgroonga_version = const_cast<char*>(grn_get_version());
 static char* mrn_version = const_cast<char*>(MRN_VERSION_FULL);
 static char* mrn_vector_column_delimiter = NULL;
@@ -1205,6 +1206,38 @@ static MYSQL_SYSVAR_INT(lock_timeout,
                         INT_MAX,
                         1);
 
+static void mrn_n_workers_update(THD* thd,
+                                 mrn_sys_var* var,
+                                 void* var_ptr,
+                                 const void* save)
+{
+  MRN_DBUG_ENTER_FUNCTION();
+  const int new_value = *static_cast<const int*>(save);
+  int* old_value_ptr = static_cast<int*>(var_ptr);
+
+  *old_value_ptr = new_value;
+  grn_set_default_n_workers(new_value);
+
+  grn_ctx* ctx = mrn_context_pool->pull();
+  grn_ctx_set_n_workers(ctx, new_value);
+
+  DBUG_VOID_RETURN;
+}
+
+static MYSQL_SYSVAR_INT(n_workers,
+                        mrn_n_workers,
+                        PLUGIN_VAR_RQCMDARG,
+                        "Number of workers in Groonga."
+                        "0: The default. It disables parallel workers."
+                        "-1: Use the all CPUs in the environment."
+                        "1 or larger: Use the specified number of CPUs.",
+                        NULL,
+                        mrn_n_workers_update,
+                        grn_get_default_n_workers(),
+                        -1,
+                        INT_MAX,
+                        0);
+
 static MYSQL_SYSVAR_STR(libgroonga_version,
                         mrn_libgroonga_version,
                         PLUGIN_VAR_NOCMDOPT | PLUGIN_VAR_READONLY,
@@ -1399,6 +1432,7 @@ static mrn_sys_var* mrn_system_variables[] = {
   MYSQL_SYSVAR(default_wrapper_engine),
   MYSQL_SYSVAR(action_on_fulltext_query_error),
   MYSQL_SYSVAR(lock_timeout),
+  MYSQL_SYSVAR(n_workers),
   MYSQL_SYSVAR(libgroonga_version),
   MYSQL_SYSVAR(version),
   MYSQL_SYSVAR(vector_column_delimiter),
@@ -2363,6 +2397,7 @@ static int mrn_init(void* p)
   }
 
   grn_set_lock_timeout(mrn_lock_timeout);
+  grn_set_default_n_workers(mrn_n_workers);
 
   mrn_init_encoding_map();
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1225,9 +1225,9 @@ static void mrn_n_workers_update(THD* thd,
 static MYSQL_SYSVAR_INT(n_workers,
                         mrn_n_workers,
                         PLUGIN_VAR_RQCMDARG,
-                        "Number of workers in Groonga."
-                        "0: The default. It disables parallel workers."
-                        "-1: Use the all CPUs in the environment."
+                        "Number of workers in Groonga. "
+                        "0: The default. It disables parallel workers. "
+                        "-1: Use the all CPUs in the environment. "
                         "1 or larger: Use the specified number of CPUs.",
                         NULL,
                         mrn_n_workers_update,

--- a/lib/mrn_context_pool.cpp
+++ b/lib/mrn_context_pool.cpp
@@ -101,6 +101,19 @@ namespace mrn {
       DBUG_VOID_RETURN;
     }
 
+    void set_n_workers(int n_workers) {
+      MRN_DBUG_ENTER_METHOD();
+
+      for (std::vector<grn_ctx *>::iterator it = pool_.begin();
+           it != pool_.end();
+           ++it) {
+        grn_ctx *ctx = *it;
+        grn_ctx_set_n_workers(ctx, n_workers);
+      }
+
+      DBUG_VOID_RETURN;
+    }
+
   private:
     static const int CLEAR_THREATHOLD_IN_SECONDS = 60 * 5;
 
@@ -151,6 +164,12 @@ namespace mrn {
   void ContextPool::clear(void) {
     MRN_DBUG_ENTER_METHOD();
     impl_->clear();
+    DBUG_VOID_RETURN;
+  }
+
+  void ContextPool::set_n_workers(int n_workers) {
+    MRN_DBUG_ENTER_METHOD();
+    impl_->set_n_workers(n_workers);
     DBUG_VOID_RETURN;
   }
 }

--- a/lib/mrn_context_pool.cpp
+++ b/lib/mrn_context_pool.cpp
@@ -104,10 +104,7 @@ namespace mrn {
     void set_n_workers(int n_workers) {
       MRN_DBUG_ENTER_METHOD();
 
-      for (std::vector<grn_ctx *>::iterator it = pool_.begin();
-           it != pool_.end();
-           ++it) {
-        grn_ctx *ctx = *it;
+      for (auto ctx : pool_) {
         grn_ctx_set_n_workers(ctx, n_workers);
       }
 
@@ -124,10 +121,7 @@ namespace mrn {
 
     void clear_without_lock(void) {
       MRN_DBUG_ENTER_METHOD();
-      for (std::vector<grn_ctx *>::iterator it = pool_.begin();
-           it != pool_.end();
-           ++it) {
-        grn_ctx *ctx = *it;
+      for (auto ctx : pool_) {
         grn_ctx_close(ctx);
         --(*n_pooling_contexts_);
       }

--- a/lib/mrn_context_pool.hpp
+++ b/lib/mrn_context_pool.hpp
@@ -33,6 +33,7 @@ namespace mrn {
     grn_ctx *pull(void);
     void release(grn_ctx *context);
     void clear(void);
+    void set_n_workers(int n_workers);
 
   private:
     class Impl;

--- a/mysql-test/mroonga/storage/variable/n_workers/r/2_cpu.result
+++ b/mysql-test/mroonga/storage/variable/n_workers/r/2_cpu.result
@@ -1,0 +1,9 @@
+SET GLOBAL mroonga_n_workers = 2;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+Variable_name	Value
+mroonga_n_workers	2
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+2	2

--- a/mysql-test/mroonga/storage/variable/n_workers/r/2_cpu.result
+++ b/mysql-test/mroonga/storage/variable/n_workers/r/2_cpu.result
@@ -1,3 +1,8 @@
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+0	0
 SET GLOBAL mroonga_n_workers = 2;
 SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
 Variable_name	Value

--- a/mysql-test/mroonga/storage/variable/n_workers/r/all_cpu.result
+++ b/mysql-test/mroonga/storage/variable/n_workers/r/all_cpu.result
@@ -1,3 +1,8 @@
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+0	0
 SET GLOBAL mroonga_n_workers = -1;
 SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
 Variable_name	Value

--- a/mysql-test/mroonga/storage/variable/n_workers/r/all_cpu.result
+++ b/mysql-test/mroonga/storage/variable/n_workers/r/all_cpu.result
@@ -1,0 +1,9 @@
+SET GLOBAL mroonga_n_workers = -1;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+Variable_name	Value
+mroonga_n_workers	-1
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+-1	-1

--- a/mysql-test/mroonga/storage/variable/n_workers/r/global.result
+++ b/mysql-test/mroonga/storage/variable/n_workers/r/global.result
@@ -1,0 +1,25 @@
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+Variable_name	Value
+mroonga_n_workers	0
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+0	0
+SET GLOBAL mroonga_n_workers = -1;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+Variable_name	Value
+mroonga_n_workers	-1
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+-1	-1
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+Variable_name	Value
+mroonga_n_workers	-1
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+-1	-1

--- a/mysql-test/mroonga/storage/variable/n_workers/r/no_parallel.result
+++ b/mysql-test/mroonga/storage/variable/n_workers/r/no_parallel.result
@@ -1,0 +1,9 @@
+SET GLOBAL mroonga_n_workers = 0;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+Variable_name	Value
+mroonga_n_workers	0
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+0	0

--- a/mysql-test/mroonga/storage/variable/n_workers/r/startup.result
+++ b/mysql-test/mroonga/storage/variable/n_workers/r/startup.result
@@ -1,0 +1,8 @@
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+Variable_name	Value
+mroonga_n_workers	-1
+SELECT
+JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+default_n_workers	n_workers
+-1	-1

--- a/mysql-test/mroonga/storage/variable/n_workers/t/2_cpu.test
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/2_cpu.test
@@ -1,0 +1,31 @@
+# Copyright (C) 2025  Abe Tomoaki <abe@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+SET GLOBAL mroonga_n_workers = 2;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
+-- disable_query_log
+SET GLOBAL mroonga_n_workers = DEFAULT;
+-- enable_query_log
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/variable/n_workers/t/2_cpu.test
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/2_cpu.test
@@ -17,6 +17,10 @@
 --source ../../../../include/mroonga/have_mroonga.inc
 --source ../../../../include/mroonga/load_mroonga_functions.inc
 
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
 SET GLOBAL mroonga_n_workers = 2;
 SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
 SELECT

--- a/mysql-test/mroonga/storage/variable/n_workers/t/all_cpu.test
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/all_cpu.test
@@ -1,0 +1,31 @@
+# Copyright (C) 2025  Abe Tomoaki <abe@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+SET GLOBAL mroonga_n_workers = -1;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
+-- disable_query_log
+SET GLOBAL mroonga_n_workers = DEFAULT;
+-- enable_query_log
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/variable/n_workers/t/all_cpu.test
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/all_cpu.test
@@ -17,6 +17,10 @@
 --source ../../../../include/mroonga/have_mroonga.inc
 --source ../../../../include/mroonga/load_mroonga_functions.inc
 
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
 SET GLOBAL mroonga_n_workers = -1;
 SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
 SELECT

--- a/mysql-test/mroonga/storage/variable/n_workers/t/global.test
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/global.test
@@ -1,0 +1,46 @@
+# Copyright (C) 2025  Abe Tomoaki <abe@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
+SET GLOBAL mroonga_n_workers = -1;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
+-- disable_query_log
+CONNECT (new_connection, localhost, root, ,);
+CONNECTION new_connection;
+-- enable_query_log
+
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
+-- disable_query_log
+SET GLOBAL mroonga_n_workers = DEFAULT;
+-- enable_query_log
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/variable/n_workers/t/no_parallel.test
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/no_parallel.test
@@ -1,0 +1,31 @@
+# Copyright (C) 2025  Abe Tomoaki <abe@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+SET GLOBAL mroonga_n_workers = 0;
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
+-- disable_query_log
+SET GLOBAL mroonga_n_workers = DEFAULT;
+-- enable_query_log
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/variable/n_workers/t/startup-master.opt
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/startup-master.opt
@@ -1,0 +1,1 @@
+--loose-mroonga-n-workers=-1

--- a/mysql-test/mroonga/storage/variable/n_workers/t/startup.test
+++ b/mysql-test/mroonga/storage/variable/n_workers/t/startup.test
@@ -1,0 +1,26 @@
+# Copyright (C) 2025  Abe Tomoaki <abe@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/load_mroonga_functions.inc
+
+SHOW GLOBAL VARIABLES LIKE 'mroonga_n_workers';
+SELECT
+  JSON_EXTRACT(mroonga_command('status'), '$.default_n_workers') AS default_n_workers,
+  JSON_EXTRACT(mroonga_command('status'), '$.n_workers') AS n_workers;
+
+--source ../../../../include/mroonga/unload_mroonga_functions.inc
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
By setting the value of `mroonga_n_workers` to Groonga, we can use Groonga's parallel processing.