### PR TITLE
packages mariadb-10.5: specify all related MariaDB packges with version explicitly

### DIFF
--- a/packages/mariadb-10.5-mroonga/yum/mariadb-10.5-mroonga.spec.in
+++ b/packages/mariadb-10.5-mroonga/yum/mariadb-10.5-mroonga.spec.in
@@ -1,7 +1,6 @@
 # -*- sh-shell: rpm -*-
 
 %define mariadb_package MariaDB
-%define mariadb_client_package %{mariadb_package}-client
 #%%define mariadb_epoch_default
 %define mariadb_version_default @MARIADB_VERSION@
 %define mariadb_release_default @MARIADB_RELEASE@
@@ -34,8 +33,10 @@ BuildRequires:	rpm
 BuildRequires:	sed
 BuildRequires:	which
 BuildRequires:	dnf-command(download)
+Requires:	%{mariadb_package}-client = %{_mariadb_epoch_with_suffix}%{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+Requires:	%{mariadb_package}-common = %{_mariadb_epoch_with_suffix}%{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
 Requires:	%{mariadb_package}-server = %{_mariadb_epoch_with_suffix}%{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
-Requires:	%{mariadb_client_package} = %{_mariadb_epoch_with_suffix}%{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+Requires:	%{mariadb_package}-shared = %{_mariadb_epoch_with_suffix}%{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
 Requires:	groonga-libs >= %{groonga_required_version}
 Requires:	groonga-normalizer-mysql
 


### PR DESCRIPTION
If we specify only MariaDB-client and MariaDB-server, different versions of depended MariaDB-common and MariaDB-shared packages may be installed:

```
Installing:
 mariadb-10.5-mroonga       x86_64  14.14-1.el8                             groonga-almalinux  191 k
Installing dependencies:
 MariaDB-client             x86_64  10.5.27-1.el8                           mariadb             14 M
 MariaDB-common             x86_64  10.5.28-1.el8                           mariadb             88 k
 MariaDB-server             x86_64  10.5.27-1.el8                           mariadb             27 M
 MariaDB-shared             x86_64  10.5.28-1.el8                           mariadb            115 k
```