### PR TITLE
packages mariadb-10.11: specify all related MariaDB packges with version explicitly

### DIFF
--- a/packages/mariadb-10.11-mroonga/yum/mariadb-10.11-mroonga.spec.in
+++ b/packages/mariadb-10.11-mroonga/yum/mariadb-10.11-mroonga.spec.in
@@ -30,8 +30,10 @@ BuildRequires:	rpm
 BuildRequires:	sed
 BuildRequires:	which
 BuildRequires:	dnf-command(download)
-Requires:	MariaDB-server = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
 Requires:	MariaDB-client = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+Requires:	MariaDB-common = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+Requires:	MariaDB-server = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
+Requires:	MariaDB-shared = %{_mariadb_version}-%{_mariadb_release}.%{_mariadb_dist}
 Requires:	groonga-libs >= %{groonga_required_version}
 Requires:	groonga-normalizer-mysql
 


### PR DESCRIPTION
If we specify only MariaDB-client and MariaDB-server, different versions of depended MariaDB-common and MariaDB-shared packages may be installed:

```
Installing:
 mariadb-10.11-mroonga      x86_64  14.14-1.el8                             groonga-almalinux  185 k
Installing dependencies:
 MariaDB-client             x86_64  10.11.10-1.el8                          mariadb             16 M
 MariaDB-common             x86_64  10.11.11-1.el8                          mariadb             88 k
 MariaDB-server             x86_64  10.11.10-1.el8                          mariadb             28 M
 MariaDB-shared             x86_64  10.11.11-1.el8                          mariadb            128 k
```