### PR TITLE
Add a missing include

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -100,6 +100,7 @@
 #endif
 
 #include <cstring>
+#include <string>
 
 #include "mrn_err.h"
 #include "mrn_table.hpp"


### PR DESCRIPTION
We use std::string in ha_mroonga.cpp.
However, we don't include <string>. So, Mroonga occurs error as below.

```
2025-03-25T01:19:11.1307332Z D:\a\mroonga\mroonga\mariadb\storage\mroonga\ha_mroonga.cpp(4452,8): error C2039: 'string': is not a member of 'std'
2025-03-25T01:19:11.1308280Z   std::string mrn_name_normalize(const mrn_foreign_key_name& name)
```

This PR resolve the above error.