### PR TITLE
docs: release: Update command to run in mroonga/mroonga.org

### DIFF
--- a/doc/source/developer/release.rst
+++ b/doc/source/developer/release.rst
@@ -109,7 +109,7 @@ Execute the following commands::
 
     $ export GROONGA_ORG_REPOSITORY=${HOME}/work/groonga.org
     $ git clone git@github.com:groonga/groonga.org.git ${GROONGA_ORG_REPOSITORY}
-    $ rake -C ${MROONGA_ORG_DIR} release:version:update
+    $ rake -C ${MROONGA_ORG_DIR} release
 
 Announce release for X(Twitter)
 -------------------------------


### PR DESCRIPTION
Can be released by `rake release` as well as mroonga/mroonga.
https://github.com/groonga/groonga.org/pull/97