### PR TITLE
ci mariadb: enable ccache

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -48,6 +48,19 @@ jobs:
         with:
           path: mariadb/storage/mroonga
           repository: mroonga/mroonga
+      - name: Install ccache
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache
+      - name: Prepare ccache
+        run: |
+          echo "CCACHE_DIR=${PWD}/mariadb/ccache" >> ${GITHUB_ENV}
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: mariadb/ccache
+          key: cmake-linux-ccache-${{ hashFiles('**/*.cpp', '**/*.h', '**/*.hpp') }}
+          restore-keys:  cmake-linux-ccache-
       - name: Configure MariaDB
         # To reduce build time, we build only the MariaDB core and Mroonga.
         # The following options disable all other storage engines, module-type
@@ -57,11 +70,14 @@ jobs:
         # To list available plugins, you can run:
         #   cmake -L $MARIADB_SOURCE_DIR | grep PLUGIN_
         run: |
+          ccache --show-stats --verbose --version || :
           cmake \
             -Smariadb \
             -Bmariadb.build \
             -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCONC_WITH_UNITTEST=OFF \
             -DMYSQL_MAINTAINER_MODE=OFF \
             -DPLUGIN_ARCHIVE=NO \
@@ -115,3 +131,4 @@ jobs:
       - name: Build MariaDB
         run: |
           cmake --build mariadb.build
+          ccache --show-stats --verbose --version || :

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -61,9 +61,6 @@ jobs:
           path: ccache
           key: mariadb-linux-ccache-${{ hashFiles('mariadb/**/*.cpp', 'mariadb/**/*.h', 'mariadb/**/*.hpp') }}
           restore-keys: mariadb-linux-ccache-
-      - name: Show ccache stats (before configuration)
-        run: |
-          ccache --show-stats --verbose --version || :
       - name: Configure MariaDB
         # To reduce build time, we build only the MariaDB core and Mroonga.
         # The following options disable all other storage engines, module-type
@@ -130,6 +127,9 @@ jobs:
             -DWITH_MARIABACKUP=OFF \
             -DWITH_SAFEMALLOC=OFF \
             -DWITH_WSREP=OFF
+      - name: Show ccache stats (before build)
+        run: |
+          ccache --show-stats --verbose --version || :
       - name: Build MariaDB
         run: |
           cmake --build mariadb.build

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -61,6 +61,9 @@ jobs:
           path: mariadb/ccache
           key: mariadb-linux-ccache-${{ hashFiles('**/*.cpp', '**/*.h', '**/*.hpp') }}
           restore-keys:  mariadb-linux-ccache-
+      - name: Show ccache stats (before configuration)
+        run: |
+          ccache --show-stats --verbose --version || :
       - name: Configure MariaDB
         # To reduce build time, we build only the MariaDB core and Mroonga.
         # The following options disable all other storage engines, module-type
@@ -70,7 +73,6 @@ jobs:
         # To list available plugins, you can run:
         #   cmake -L $MARIADB_SOURCE_DIR | grep PLUGIN_
         run: |
-          ccache --show-stats --verbose --version || :
           cmake \
             -Smariadb \
             -Bmariadb.build \
@@ -131,4 +133,6 @@ jobs:
       - name: Build MariaDB
         run: |
           cmake --build mariadb.build
+      - name: Show ccache stats (after build)
+        run: |
           ccache --show-stats --verbose --version || :

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           path: ccache
           key: mariadb-linux-ccache-${{ hashFiles('mariadb/**/*.cpp', 'mariadb/**/*.h', 'mariadb/**/*.hpp') }}
-          restore-keys:  mariadb-linux-ccache-
+          restore-keys: mariadb-linux-ccache-
       - name: Show ccache stats (before configuration)
         run: |
           ccache --show-stats --verbose --version || :

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -59,8 +59,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: mariadb/ccache
-          key: cmake-linux-ccache-${{ hashFiles('**/*.cpp', '**/*.h', '**/*.hpp') }}
-          restore-keys:  cmake-linux-ccache-
+          key: mariadb-linux-ccache-${{ hashFiles('**/*.cpp', '**/*.h', '**/*.hpp') }}
+          restore-keys:  mariadb-linux-ccache-
       - name: Configure MariaDB
         # To reduce build time, we build only the MariaDB core and Mroonga.
         # The following options disable all other storage engines, module-type

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -54,12 +54,12 @@ jobs:
           sudo apt-get install -y ccache
       - name: Prepare ccache
         run: |
-          echo "CCACHE_DIR=${PWD}/mariadb/ccache" >> ${GITHUB_ENV}
+          echo "CCACHE_DIR=${PWD}/ccache" >> ${GITHUB_ENV}
       - name: Cache ccache
         uses: actions/cache@v4
         with:
-          path: mariadb/ccache
-          key: mariadb-linux-ccache-${{ hashFiles('**/*.cpp', '**/*.h', '**/*.hpp') }}
+          path: ccache
+          key: mariadb-linux-ccache-${{ hashFiles('mariadb/**/*.cpp', 'mariadb/**/*.h', 'mariadb/**/*.hpp') }}
           restore-keys:  mariadb-linux-ccache-
       - name: Show ccache stats (before configuration)
         run: |


### PR DESCRIPTION
GitHub: GH-900

This change enables ccache to speed up repeated builds.