### PR TITLE
mroonga_* udf correct ptr types for is_null/error

### DIFF
--- a/udf/mrn_udf_command.cpp
+++ b/udf/mrn_udf_command.cpp
@@ -268,7 +268,7 @@ static void mroonga_command_escape_value(grn_ctx *ctx,
 }
 
 MRN_API char *mroonga_command(UDF_INIT *init, UDF_ARGS *args, char *result,
-                              unsigned long *length, char *is_null, char *error)
+                              unsigned long *length, uchar *is_null, uchar *error)
 {
   CommandInfo *info = (CommandInfo *)init->ptr;
   grn_ctx *ctx = info->ctx;

--- a/udf/mrn_udf_escape.cpp
+++ b/udf/mrn_udf_escape.cpp
@@ -214,7 +214,7 @@ static void escape(EscapeInfo *info, UDF_ARGS *args)
 }
 
 MRN_API char *mroonga_escape(UDF_INIT *init, UDF_ARGS *args, char *result,
-                             unsigned long *length, char *is_null, char *error)
+                             unsigned long *length, uchar *is_null, uchar *error)
 {
   EscapeInfo *info = reinterpret_cast<EscapeInfo *>(init->ptr);
   grn_ctx *ctx = info->ctx;

--- a/udf/mrn_udf_highlight_html.cpp
+++ b/udf/mrn_udf_highlight_html.cpp
@@ -442,8 +442,8 @@ MRN_API char *mroonga_highlight_html(UDF_INIT *init,
                                      UDF_ARGS *args,
                                      char *result,
                                      unsigned long *length,
-                                     char *is_null,
-                                     char *error)
+                                     uchar *is_null,
+                                     uchar *error)
 {
   MRN_DBUG_ENTER_FUNCTION();
 

--- a/udf/mrn_udf_last_insert_grn_id.cpp
+++ b/udf/mrn_udf_last_insert_grn_id.cpp
@@ -60,8 +60,8 @@ MRN_API mrn_bool mroonga_last_insert_grn_id_init(UDF_INIT *init,
 
 MRN_API longlong mroonga_last_insert_grn_id(UDF_INIT *init,
                                             UDF_ARGS *args,
-                                            char *is_null,
-                                            char *error)
+                                            uchar *is_null,
+                                            uchar *error)
 {
   THD *thd = current_thd;
   mrn::SlotData *slot_data = mrn_get_slot_data(thd, false);
@@ -87,8 +87,8 @@ MRN_API mrn_bool last_insert_grn_id_init(UDF_INIT *init,
 
 MRN_API longlong last_insert_grn_id(UDF_INIT *init,
                                     UDF_ARGS *args,
-                                    char *is_null,
-                                    char *error)
+                                    uchar *is_null,
+                                    uchar *error)
 {
   return mroonga_last_insert_grn_id(init, args, is_null, error);
 }

--- a/udf/mrn_udf_normalize.cpp
+++ b/udf/mrn_udf_normalize.cpp
@@ -149,7 +149,7 @@ error:
 }
 
 MRN_API char *mroonga_normalize(UDF_INIT *init, UDF_ARGS *args, char *result,
-                                unsigned long *length, char *is_null, char *error)
+                                unsigned long *length, uchar *is_null, uchar *error)
 {
   st_mrn_normalize_info *info = (st_mrn_normalize_info *)init->ptr;
   grn_ctx *ctx = info->ctx;

--- a/udf/mrn_udf_query_expand.cpp
+++ b/udf/mrn_udf_query_expand.cpp
@@ -244,8 +244,8 @@ MRN_API char *mroonga_query_expand(UDF_INIT *init,
                                    UDF_ARGS *args,
                                    char *result,
                                    unsigned long *length,
-                                   char *is_null,
-                                   char *error)
+                                   uchar *is_null,
+                                   uchar *error)
 {
   MRN_DBUG_ENTER_FUNCTION();
 

--- a/udf/mrn_udf_snippet.cpp
+++ b/udf/mrn_udf_snippet.cpp
@@ -244,7 +244,7 @@ error:
 }
 
 MRN_API char *mroonga_snippet(UDF_INIT *init, UDF_ARGS *args, char *result,
-                              unsigned long *length, char *is_null, char *error)
+                              unsigned long *length, uchar *is_null, uchar *error)
 {
   st_mrn_snip_info *snip_info = (st_mrn_snip_info *) init->ptr;
   grn_ctx *ctx = snip_info->ctx;

--- a/udf/mrn_udf_snippet_html.cpp
+++ b/udf/mrn_udf_snippet_html.cpp
@@ -480,8 +480,8 @@ MRN_API char *mroonga_snippet_html(UDF_INIT *init,
                                    UDF_ARGS *args,
                                    char *result,
                                    unsigned long *length,
-                                   char *is_null,
-                                   char *error)
+                                   uchar *is_null,
+                                   uchar *error)
 {
   MRN_DBUG_ENTER_FUNCTION();
 


### PR DESCRIPTION
Shows up in mroonga UDF tests under clang with UBSAN:

UndefinedBehaviorSanitizer: function-type-mismatch