### PR TITLE
ci: windows: Add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` option to CMake

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -212,6 +212,7 @@ jobs:
             -G "Ninja" ^
             -DBUILD_CONFIG=mroonga_windows ^
             -DCMAKE_INSTALL_PREFIX=install ^
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
             -DCONNECT_WITH_LIBXML2=OFF ^
             -DMRN_GROONGA_EMBED=${{ matrix.embed || 'OFF' }} ^
             -DMRN_GROONGA_NORMALIZER_MYSQL_EMBED=${{ matrix.embed || 'OFF' }} ^


### PR DESCRIPTION
CMake in CI environment fails with 4.0.0.

```
 CMake Error at CMakeLists.txt:17 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Configuring incomplete, errors occurred!
```

We get this error with MariaDB 10.x.

MariaDB 11.x does not have this error, but fails with the same error when building Groonga.
Groonga error fixed by https://github.com/groonga/groonga/pull/2266.