### PR TITLE
mrn_field_normalizer: support utf8mb4_uca1400_as_cs collation

### DIFF
--- a/lib/mrn_field_normalizer.cpp
+++ b/lib/mrn_field_normalizer.cpp
@@ -177,6 +177,9 @@ namespace mrn {
     } else if ((strcmp(MRN_CHARSET_NAME(charset_info), "utf8mb4_uca1400_as_ci") == 0)) {
       normalizer_name = "NormalizerMySQLUnicode";
       normalizer_spec = "NormalizerMySQLUnicode('version', '14.0.0', 'accent_sensitive', true)";
+    } else if ((strcmp(MRN_CHARSET_NAME(charset_info), "utf8mb4_uca1400_as_cs") == 0)) {
+      normalizer_name = "NormalizerMySQLUnicode";
+      normalizer_spec = "NormalizerMySQLUnicode('version', '14.0.0', 'accent_sensitive', true, 'case_sensitive', true)";
     }
 
     if (normalizer_name) {

--- a/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/r/french.result
+++ b/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/r/french.result
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS diaries;
+SET NAMES utf8mb4;
+CREATE TABLE diaries (
+content varchar(256) COLLATE utf8mb4_uca1400_as_cs,
+FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ('Le fruit est mûr.');
+INSERT INTO diaries VALUES ('LE FRUIT EST MÛR.');
+INSERT INTO diaries VALUES ('Le mur est blanc.');
+INSERT INTO diaries VALUES ('LE MUR EST BLANC.');
+SELECT * FROM diaries WHERE MATCH (content) AGAINST ('+mur' IN BOOLEAN MODE);
+content
+Le mur est blanc.
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/r/japanese_accent.result
+++ b/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/r/japanese_accent.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS diaries;
+SET NAMES utf8mb4;
+CREATE TABLE diaries (
+content varchar(256) COLLATE utf8mb4_uca1400_as_cs,
+FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ('はひふへほ');
+INSERT INTO diaries VALUES ('ばびぶべぼ');
+INSERT INTO diaries VALUES ('ハヒフヘホ');
+INSERT INTO diaries VALUES ('バビブベボ');
+INSERT INTO diaries VALUES ('ﾊﾋﾌﾍﾎ');
+INSERT INTO diaries VALUES ('ﾊﾞﾋﾞﾌﾞﾍﾞﾎﾞ');
+SELECT * FROM diaries
+WHERE MATCH (content) AGAINST ('+バビブベボ' IN BOOLEAN MODE);
+content
+バビブベボ
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/r/japanese_case.result
+++ b/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/r/japanese_case.result
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS diaries;
+SET NAMES utf8mb4;
+CREATE TABLE diaries (
+content varchar(256) COLLATE utf8mb4_uca1400_as_cs,
+FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8mb4;
+INSERT INTO diaries VALUES ('やゆよ');
+INSERT INTO diaries VALUES ('ゃゅょ');
+INSERT INTO diaries VALUES ('ヤユヨ');
+INSERT INTO diaries VALUES ('ャュョ');
+INSERT INTO diaries VALUES ('ﾔﾕﾖ');
+INSERT INTO diaries VALUES ('ｬｭｮ');
+SELECT * FROM diaries
+WHERE MATCH (content) AGAINST ('+ャュョ' IN BOOLEAN MODE);
+content
+ャュョ
+DROP TABLE diaries;

--- a/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/t/french.test
+++ b/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/t/french.test
@@ -1,0 +1,41 @@
+# Copyright (C) 2018  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2025  Horimoto Yasuhiro <horimoto@clear-code.com>
+# Copyright (C) 2025  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_uca1400_collation.inc
+--source ../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+SET NAMES utf8mb4;
+CREATE TABLE diaries (
+  content varchar(256) COLLATE utf8mb4_uca1400_as_cs,
+  FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO diaries VALUES ('Le fruit est mûr.');
+INSERT INTO diaries VALUES ('LE FRUIT EST MÛR.');
+INSERT INTO diaries VALUES ('Le mur est blanc.');
+INSERT INTO diaries VALUES ('LE MUR EST BLANC.');
+
+SELECT * FROM diaries WHERE MATCH (content) AGAINST ('+mur' IN BOOLEAN MODE);
+
+DROP TABLE diaries;
+
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/t/japanese_accent.test
+++ b/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/t/japanese_accent.test
@@ -1,0 +1,44 @@
+# Copyright (C) 2018  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2025  Horimoto Yasuhiro <horimoto@clear-code.com>
+# Copyright (C) 2025  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_uca1400_collation.inc
+--source ../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+SET NAMES utf8mb4;
+CREATE TABLE diaries (
+  content varchar(256) COLLATE utf8mb4_uca1400_as_cs,
+  FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO diaries VALUES ('はひふへほ');
+INSERT INTO diaries VALUES ('ばびぶべぼ');
+INSERT INTO diaries VALUES ('ハヒフヘホ');
+INSERT INTO diaries VALUES ('バビブベボ');
+INSERT INTO diaries VALUES ('ﾊﾋﾌﾍﾎ');
+INSERT INTO diaries VALUES ('ﾊﾞﾋﾞﾌﾞﾍﾞﾎﾞ');
+
+SELECT * FROM diaries
+         WHERE MATCH (content) AGAINST ('+バビブベボ' IN BOOLEAN MODE);
+
+DROP TABLE diaries;
+
+--source ../../../../include/mroonga/have_mroonga_deinit.inc

--- a/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/t/japanese_case.test
+++ b/mysql-test/mroonga/storage/collation/utf8mb4_uca1400_as_cs/t/japanese_case.test
@@ -1,0 +1,44 @@
+# Copyright (C) 2018  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2025  Horimoto Yasuhiro <horimoto@clear-code.com>
+# Copyright (C) 2025  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--source ../../../../include/mroonga/have_uca1400_collation.inc
+--source ../../../../include/mroonga/have_mroonga.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS diaries;
+--enable_warnings
+
+SET NAMES utf8mb4;
+CREATE TABLE diaries (
+  content varchar(256) COLLATE utf8mb4_uca1400_as_cs,
+  FULLTEXT INDEX (content)
+) DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO diaries VALUES ('やゆよ');
+INSERT INTO diaries VALUES ('ゃゅょ');
+INSERT INTO diaries VALUES ('ヤユヨ');
+INSERT INTO diaries VALUES ('ャュョ');
+INSERT INTO diaries VALUES ('ﾔﾕﾖ');
+INSERT INTO diaries VALUES ('ｬｭｮ');
+
+SELECT * FROM diaries
+         WHERE MATCH (content) AGAINST ('+ャュョ' IN BOOLEAN MODE);
+
+DROP TABLE diaries;
+
+--source ../../../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
GitHub: GH-900

This changes also add support for the `utf8mb4_uca1400_as_cs` collation in Mroonga because MariaDB supports it from 11.5.

ref: https://github.com/groonga/groonga-normalizer-mysql
ref: https://mariadb.com/kb/en/supported-character-sets-and-collations/

We will support the other families about `utf8mb4_uca1400_*` in the following PRs.