### PR TITLE
ci mariadb: temporarily ignore test failures

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -140,6 +140,9 @@ jobs:
         run: |
           ccache --show-stats --verbose --version || :
       - name: Run test
+        # TODO: Temporarily ignore failures on MariaDB main. Disable this when
+        # all tests pass cleanly on main once.
+        continue-on-error: true
         run: |
           cd mariadb.build/storage/mroonga
           NO_MAKE=yes \


### PR DESCRIPTION
Tests against MariaDB main are currently failed until we finish tracking upstream changes. Which causes the CI to appear failed and could mask other real failures.

This adds `continue-on-error` option to the MariaDB CI as a temporary measure. Once all tests pass cleanly on MariaDB main, remove this.