### PR TITLE
release yum: use URI without a trailing slash to get RPM index

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -237,8 +237,9 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_rpm_version
     series = split_mysql_package[1]
+    # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS/"
+      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS?_ts=#{Time.now.to_i}"
     index_html = URI.open(srpms_url) do |response|
       response.read
     end
@@ -257,8 +258,9 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_minimal_rpm_version
     series = split_mysql_package[1]
+    # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS/"
+      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS?_ts=#{Time.now.to_i}"
     index_html = URI.open(srpms_url) do |response|
       response.read
     end
@@ -282,8 +284,9 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     if short_series == "84"
       short_series = "84-lts"
     end
+    # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.percona.com/ps-#{short_series}/yum/release/9/SRPMS"
+      "https://repo.percona.com/ps-#{short_series}/yum/release/9/SRPMS?_ts=#{Time.now.to_i}"
     index_html = URI.open(srpms_url) do |response|
       response.read
     end

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -237,7 +237,9 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_rpm_version
     series = split_mysql_package[1]
-    # CDN edge nodes may return old cached list without a cache‑buster.
+    # Use the URL without a trailing slash because the CDN caches both “…/SRPMS”
+    # and “…/SRPMS/”, but the cache for the “/SRPMS/” path hasn't been expired
+    # yet. Using the no‑slash URL ensures we get the latest listing.
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS"
     index_html = URI.open(srpms_url) do |response|
@@ -258,7 +260,9 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_minimal_rpm_version
     series = split_mysql_package[1]
-    # CDN edge nodes may return old cached list without a cache‑buster.
+    # Use the URL without a trailing slash because the CDN caches both “…/SRPMS”
+    # and “…/SRPMS/”, but the cache for the “/SRPMS/” path hasn't been expired
+    # yet. Using the no‑slash URL ensures we get the latest listing.
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"
     index_html = URI.open(srpms_url) do |response|

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -284,9 +284,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     if short_series == "84"
       short_series = "84-lts"
     end
-    # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.percona.com/ps-#{short_series}/yum/release/9/SRPMS?_ts=#{Time.now.to_i}"
+      "https://repo.percona.com/ps-#{short_series}/yum/release/9/SRPMS"
     index_html = URI.open(srpms_url) do |response|
       response.read
     end

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -237,10 +237,11 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_rpm_version
     series = split_mysql_package[1]
-    # CDN edge nodes may return old cached list without a cache‑buster.
+    # Disable CDN edge caching to ensure we always fetch the latest SRPM list.
+    headers = { "Cache-Control" => "no-cache" }
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS?_ts=#{Time.now.to_i}"
-    index_html = URI.open(srpms_url) do |response|
+      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS/"
+    index_html = URI.open(srpms_url, headers) do |response|
       response.read
     end
     latest_target_srpm =
@@ -258,10 +259,11 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_minimal_rpm_version
     series = split_mysql_package[1]
-    # CDN edge nodes may return old cached list without a cache‑buster.
+    # Disable CDN edge caching to ensure we always fetch the latest SRPM list.
+    headers = { "Cache-Control" => "no-cache" }
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS?_ts=#{Time.now.to_i}"
-    index_html = URI.open(srpms_url) do |response|
+      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS/"
+    index_html = URI.open(srpms_url, headers) do |response|
       response.read
     end
     latest_target_srpm =

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -238,7 +238,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   def detect_mysql_community_rpm_version
     series = split_mysql_package[1]
     # Use the URL without a trailing slash because the CDN caches both “…/SRPMS”
-    # and “…/SRPMS/”, but the cache for the “/SRPMS/” path hasn't been expired
+    # and "…/SRPMS/", but the cache for the "/SRPMS/" path hasn't been expired
     # yet. Using the no‑slash URL ensures we get the latest listing.
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS"
@@ -261,7 +261,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   def detect_mysql_community_minimal_rpm_version
     series = split_mysql_package[1]
     # Use the URL without a trailing slash because the CDN caches both “…/SRPMS”
-    # and “…/SRPMS/”, but the cache for the “/SRPMS/” path hasn't been expired
+    # and "…/SRPMS/", but the cache for the "/SRPMS/" path hasn't been expired
     # yet. Using the no‑slash URL ensures we get the latest listing.
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -239,7 +239,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     series = split_mysql_package[1]
     # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS?ts=#{Time.now.to_i}"
+      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS"
     index_html = URI.open(srpms_url) do |response|
       response.read
     end
@@ -260,7 +260,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     series = split_mysql_package[1]
     # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS?ts=#{Time.now.to_i}"
+      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"
     index_html = URI.open(srpms_url) do |response|
       response.read
     end

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -237,20 +237,19 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_rpm_version
     series = split_mysql_package[1]
-    # Disable CDN edge caching to ensure we always fetch the latest SRPM list.
-    headers = { "Cache-Control" => "no-cache" }
+    # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS/"
-    index_html = URI.open(srpms_url, headers) do |response|
+      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS?ts=#{Time.now.to_i}"
+    index_html = URI.open(srpms_url) do |response|
       response.read
     end
     latest_target_srpm =
       index_html.
         scan(/href="(.+?)"/i).
         flatten.
-        grep(/\Amysql-community-/).
+        grep(/\ASRPMS\/mysql-community-/).
         last
-    latest_target_srpm[/\Amysql-community-(\d+\.\d+\.\d+-\d+)/, 1]
+    latest_target_srpm[/\ASRPMS\/mysql-community-(\d+\.\d+\.\d+-\d+)/, 1]
   end
 
   def mysql_community_rpm_version
@@ -259,20 +258,19 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_minimal_rpm_version
     series = split_mysql_package[1]
-    # Disable CDN edge caching to ensure we always fetch the latest SRPM list.
-    headers = { "Cache-Control" => "no-cache" }
+    # CDN edge nodes may return old cached list without a cache‑buster.
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS/"
-    index_html = URI.open(srpms_url, headers) do |response|
+      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS?ts=#{Time.now.to_i}"
+    index_html = URI.open(srpms_url) do |response|
       response.read
     end
     latest_target_srpm =
       index_html.
         scan(/href="(.+?)"/i).
         flatten.
-        grep(/\Amysql-community-minimal-/).
+        grep(/\ASRPMS\/mysql-community-minimal-/).
         last
-    latest_target_srpm[/\Amysql-community-minimal-(\d+\.\d+\.\d+-\d+)/, 1]
+    latest_target_srpm[/\ASRPMS\/mysql-community-minimal-(\d+\.\d+\.\d+-\d+)/, 1]
   end
 
   def mysql_community_minimal_rpm_version


### PR DESCRIPTION
## Problem

CDN edge nodes can serve old cached listings and prevent detecting the latest package versions. During our last release, the
package‐detection step failed because it only saw up through 8.0.41 and could not find 8.0.42, causing a build‐dependency error:

```
mysql-community-devel = 8.0.41-1.el8 is needed by mysql-community-8.0-mroonga-15.06-1.el8.x86_64
```

## Solution

Using URI without a trailing slash ensures we always retrieve the newest RPM list.

## Reproduce using curl

URI with a trailing slash.
```console
$ curl https://repo.mysql.com/yum/mysql-8.0-community/el/9/SRPMS/
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<HTML>
 <HEAD>
  <TITLE>Index of /232905/yum/mysql-8.0-community/el/9/SRPMS</TITLE>
 </HEAD>
 <BODY>
<H1>Index of /232905/yum/mysql-8.0-community/el/9/SRPMS</H1>
<PRE>   Name                              Last modified        Size
<HR>
<IMG SRC="/icons/dir.gif" ALT="[DIR]"> <A HREF="../">Parent Directory</A>                  01-Jan-1970 00:00      -
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.30-1.el9.src.rpm">mysql-community-8.0.30-1.el9.s..&gt;</A> 19-Jul-2022 10:32   412M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.31-1.el9.src.rpm">mysql-community-8.0.31-1.el9.s..&gt;</A> 14-Sep-2022 08:28   414M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.32-1.el9.src.rpm">mysql-community-8.0.32-1.el9.s..&gt;</A> 17-Dec-2022 12:22   511M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.33-1.el9.src.rpm">mysql-community-8.0.33-1.el9.s..&gt;</A> 17-Mar-2023 09:27   512M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.34-1.el9.src.rpm">mysql-community-8.0.34-1.el9.s..&gt;</A> 25-Jun-2023 03:06   514M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.35-1.el9.src.rpm">mysql-community-8.0.35-1.el9.s..&gt;</A> 16-Oct-2023 05:28   512M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.36-1.el9.src.rpm">mysql-community-8.0.36-1.el9.s..&gt;</A> 14-Dec-2023 06:42   512M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.37-1.el9.src.rpm">mysql-community-8.0.37-1.el9.s..&gt;</A> 31-Mar-2024 14:51   519M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.39-1.el9.src.rpm">mysql-community-8.0.39-1.el9.s..&gt;</A> 13-Jul-2024 18:13   523M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.40-1.el9.src.rpm">mysql-community-8.0.40-1.el9.s..&gt;</A> 20-Sep-2024 14:46   562M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="mysql-community-8.0.41-1.el9.src.rpm">mysql-community-8.0.41-1.el9.s..&gt;</A> 17-Dec-2024 11:28   561M
<IMG SRC="/icons/dir.gif" ALT="[DIR]"> <A HREF="repodata/">repodata/</A>                         17-Jan-2025 04:48      -
</PRE><HR>
</BODY></HTML>
```

URI without a trailing slash.
```console
$ curl https://repo.mysql.com/yum/mysql-8.0-community/el/9/SRPMS
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<HTML>
 <HEAD>
  <TITLE>Index of /232905/yum/mysql-8.0-community/el/9/SRPMS</TITLE>
 </HEAD>
 <BODY>
<H1>Index of /232905/yum/mysql-8.0-community/el/9/SRPMS</H1>
<PRE>   Name                              Last modified        Size
<HR>
<IMG SRC="/icons/dir.gif" ALT="[DIR]"> <A HREF="SRPMS/../">Parent Directory</A>                  01-Jan-1970 00:00      -
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.30-1.el9.src.rpm">mysql-community-8.0.30-1.el9.s..&gt;</A> 19-Jul-2022 10:32   412M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.31-1.el9.src.rpm">mysql-community-8.0.31-1.el9.s..&gt;</A> 14-Sep-2022 08:28   414M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.32-1.el9.src.rpm">mysql-community-8.0.32-1.el9.s..&gt;</A> 17-Dec-2022 12:22   511M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.33-1.el9.src.rpm">mysql-community-8.0.33-1.el9.s..&gt;</A> 17-Mar-2023 09:27   512M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.34-1.el9.src.rpm">mysql-community-8.0.34-1.el9.s..&gt;</A> 25-Jun-2023 03:06   514M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.35-1.el9.src.rpm">mysql-community-8.0.35-1.el9.s..&gt;</A> 16-Oct-2023 05:28   512M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.36-1.el9.src.rpm">mysql-community-8.0.36-1.el9.s..&gt;</A> 14-Dec-2023 06:42   512M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.37-1.el9.src.rpm">mysql-community-8.0.37-1.el9.s..&gt;</A> 31-Mar-2024 14:51   519M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.39-1.el9.src.rpm">mysql-community-8.0.39-1.el9.s..&gt;</A> 13-Jul-2024 18:13   523M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.40-1.el9.src.rpm">mysql-community-8.0.40-1.el9.s..&gt;</A> 20-Sep-2024 14:46   562M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.41-1.el9.src.rpm">mysql-community-8.0.41-1.el9.s..&gt;</A> 17-Dec-2024 11:28   561M
<IMG SRC="/icons/generic.gif" ALT="[FILE]"> <A HREF="SRPMS/mysql-community-8.0.42-1.el9.src.rpm">mysql-community-8.0.42-1.el9.s..&gt;</A> 01-Apr-2025 16:44   564M
<IMG SRC="/icons/dir.gif" ALT="[DIR]"> <A HREF="SRPMS/repodata/">repodata/</A>                         10-Apr-2025 17:28      -
</PRE><HR>
</BODY></HTML>
```