### PR TITLE
doc: add 15.07 entry

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/news/15.po
+++ b/doc/locale/ja/LC_MESSAGES/news/15.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "News - 15 series"
 msgstr "お知らせ - 15系"
 
-msgid "Release 15.06 - 2025-04-23"
-msgstr "15.06リリース - 2025-04-23"
+msgid "Release 15.07 - 2025-04-23"
+msgstr "15.07リリース - 2025-04-23"
 
 msgid "Improvements"
 msgstr "改良"

--- a/doc/source/news/15.md
+++ b/doc/source/news/15.md
@@ -1,7 +1,7 @@
 # News - 15 series
 
-(release-15-06)=
-## Release 15.06 - 2025-04-23
+(release-15-07)=
+## Release 15.07 - 2025-04-23
 
 ### Improvements
 


### PR DESCRIPTION
We skipped 15.06 because the dependent packages were updated during the release steps.