### PR TITLE
ci: windows: Sleep before getting the patch

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -178,6 +178,10 @@ jobs:
           }
           Remove-Item extra\groonga\test -Recurse -Force
           cd extra\groonga\vendor\mruby-source
+          # Temporary workaround.
+          # If I access github immediately, an error occurs:
+          # You have exceeded a secondary rate limit.
+          Start-Sleep -Seconds 65
           Invoke-WebRequest `
             -Uri "https://github.com/mruby/mruby/pull/6279.patch" `
             -OutFile 6279.patch


### PR DESCRIPTION
This is a temporary workaround.
If we access GitHub immediately, we get the following error:

```
Whoa there!
You have exceeded a secondary rate limit.
...
```

Sleep for 65 seconds to avoid.