### PR TITLE
packages yum: update Apache Arrow package URL

### DIFF
--- a/packages/mariadb-10.11-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.11-mroonga/yum/almalinux-8/Dockerfile
@@ -14,6 +14,7 @@ RUN \
     echo "gpgcheck = 1"; \
   } | tee /etc/yum.repos.d/MariaDB.repo && \
   dnf install -y \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/packages/mariadb-10.5-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.5-mroonga/yum/almalinux-8/Dockerfile
@@ -14,6 +14,7 @@ RUN \
     echo "gpgcheck = 1"; \
   } | tee /etc/yum.repos.d/MariaDB.repo && \
   dnf install -y \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/packages/mariadb-10.6-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-10.6-mroonga/yum/almalinux-8/Dockerfile
@@ -14,6 +14,7 @@ RUN \
     echo "gpgcheck = 1"; \
   } | tee /etc/yum.repos.d/MariaDB.repo && \
   dnf install -y \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/packages/mariadb-11.4-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mariadb-11.4-mroonga/yum/almalinux-8/Dockerfile
@@ -14,6 +14,7 @@ RUN \
     echo "gpgcheck = 1"; \
   } | tee /etc/yum.repos.d/MariaDB.repo && \
   dnf install -y \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/packages/mysql-community-8.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/yum/almalinux-8/Dockerfile
@@ -12,6 +12,7 @@ RUN \
   dnf install --enablerepo=powertools -y ${quiet} \
     'dnf-command(builddep)' \
     'dnf-command(download)' \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
     https://repo.mysql.com/mysql80-community-release-el8.rpm && \
   dnf builddep --enablerepo=powertools -y ${quiet} mysql-community && \

--- a/packages/mysql-community-8.4-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/yum/almalinux-8/Dockerfile
@@ -12,6 +12,7 @@ RUN \
   dnf install --enablerepo=powertools -y ${quiet} \
     'dnf-command(builddep)' \
     'dnf-command(download)' \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
     https://repo.mysql.com/mysql84-community-release-el8.rpm && \
   dnf builddep --enablerepo=powertools -y ${quiet} mysql-community && \

--- a/packages/percona-server-8.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/percona-server-8.0-mroonga/yum/almalinux-8/Dockerfile
@@ -11,6 +11,7 @@ RUN \
   dnf update -y ${quiet} && \
   dnf install -y \
     https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
   dnf module disable -y mysql && \
   percona-release setup ps80 && \

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -13,11 +13,12 @@ case "${os_version}" in
     ;;
   *)
     DNF_INSTALL="dnf install -y"
-    sudo ${DNF_INSTALL} "https://apache.jfrog.io/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm"
     ;;
 esac
 
-sudo ${DNF_INSTALL} "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
+sudo ${DNF_INSTALL} \
+     "https://packages.apache.org/artifactory/arrow/almalinux/${os_version}/apache-arrow-release-latest.rpm" \
+     "https://packages.groonga.org/almalinux/${os_version}/groonga-release-latest.noarch.rpm"
 
 case "${package}" in
   mariadb-*)

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -15,14 +15,10 @@ major_version=$(cut -d: -f5 /etc/system-release-cpe | grep -o "^[0-9]")
 case ${major_version} in
   9)
     DNF="dnf --enablerepo=crb"
-    sudo ${DNF} install -y \
-      https://apache.jfrog.io/artifactory/arrow/almalinux/${major_version}/apache-arrow-release-latest.rpm
     ;;
   *)
     if [ ${os} = "linux" ]; then
       DNF="dnf --enablerepo=ol${major_version}_codeready_builder"
-      sudo ${DNF} install -y \
-        https://apache.jfrog.io/artifactory/arrow/almalinux/${major_version}/apache-arrow-release-latest.rpm
       os=almalinux # Because we can use packages for AlmaLinux on Oracle Linux.
     else
       DNF="dnf --enablerepo=powertools"
@@ -34,6 +30,7 @@ case ${major_version} in
 esac
 
 sudo ${DNF} install -y \
+  https://packages.apache.org/artifactory/arrow/${os}/${major_version}/apache-arrow-release-latest.rpm \
   https://packages.groonga.org/${os}/${major_version}/groonga-release-latest.noarch.rpm
 
 echo "::endgroup::"


### PR DESCRIPTION
## Problem

The following error in build step is raised because Groonga YUM repository doesn't serve arrow-devel-x.x.x package.

```
83.22 Error: 
83.22  Problem: cannot install the best candidate for the job
83.22   - nothing provides arrow-devel >= 20.0.0 needed by groonga-devel-15.0.9-1.el8.x86_64 from groonga-almalinux
83.22 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

## Solution

We added the official Apache Arrow repository.