### PR TITLE
ci: windows: Set RetryIntervalSec for patch fetching to 65 seconds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -179,6 +179,8 @@ jobs:
           Remove-Item extra\groonga\test -Recurse -Force
           cd extra\groonga\vendor\mruby-source
           Invoke-WebRequest `
+            -MaximumRetryCount 3 `
+            -RetryIntervalSec 65 `
             -Uri "https://github.com/mruby/mruby/pull/6279.patch" `
             -OutFile 6279.patch
           ridk exec patch -p1 -i 6279.patch


### PR DESCRIPTION
If we access GitHub immediately, we get the following error:

```
Whoa there!
You have exceeded a secondary rate limit.
...
```

Wait for 65 seconds to avoid.