### PR TITLE
Update name of source base directory 

### DIFF
--- a/packages/mariadb-10.6-mroonga/debian/rules
+++ b/packages/mariadb-10.6-mroonga/debian/rules
@@ -16,19 +16,11 @@ override_dh_auto_configure:
 	archive_base=mariadb-10.6_$(MARIADB_VERSION);			\
 	archive=$${archive_base}.orig.tar.gz;				\
 	debian=mariadb-10.6_$(MARIADB_VERSION_FULL).debian.tar.xz;	\
-	source_base=mariadb-$(MARIADB_VERSION);			\
+	source_base=mariadb-10.6-$(MARIADB_VERSION);			\
 	build_dir=$${source_base}/builddir;				\
-	if [ "$$(lsb_release --id --short)" = "Ubuntu" ]; then		\
-	  path=universe/m/mariadb-10.6;					\
-	  base_url=http://archive.ubuntu.com/ubuntu/pool;		\
-	  security_base_url=http://security.ubuntu.com/ubuntu/pool;	\
-	  source_base=mariadb-10.6-$(MARIADB_VERSION);		\
-	  build_dir=$${source_base}/builddir;				\
-	else								\
-	  path=main/m/mariadb-10.6;					\
-	  base_url=http://ftp.debian.org/debian/pool;			\
-	  security_base_url=http://security.debian.org/pool/updates;	\
-	fi;								\
+	path=universe/m/mariadb-10.6;					\
+	base_url=http://archive.ubuntu.com/ubuntu/pool;		\
+	security_base_url=http://security.ubuntu.com/ubuntu/pool;	\
 	wget $${security_base_url}/$${path}/$${archive} ||		\
 	  wget $${base_url}/$${path}/$${archive};			\
 	wget $${security_base_url}/$${path}/$${debian} ||		\

--- a/packages/mariadb-10.6-mroonga/debian/rules
+++ b/packages/mariadb-10.6-mroonga/debian/rules
@@ -16,7 +16,7 @@ override_dh_auto_configure:
 	archive_base=mariadb-10.6_$(MARIADB_VERSION);			\
 	archive=$${archive_base}.orig.tar.gz;				\
 	debian=mariadb-10.6_$(MARIADB_VERSION_FULL).debian.tar.xz;	\
-	source_base=mariadb-$(MARIADB_VERSION);				\
+	source_base=mariadb-10.6-$(MARIADB_VERSION);			\
 	build_dir=$${source_base}/builddir;				\
 	if [ "$$(lsb_release --id --short)" = "Ubuntu" ]; then		\
 	  path=universe/m/mariadb-10.6;					\
@@ -34,7 +34,7 @@ override_dh_auto_configure:
 	wget $${security_base_url}/$${path}/$${debian} ||		\
 	  wget $${base_url}/$${path}/$${debian};			\
 	tar xf $${archive};						\
-	(cd $${archive_base} &&						\
+	(cd $${spurce_base} &&						\
 	  tar xf ../$${debian});					\
 	dpkg-source --before-build $${source_base};			\
 	(cd $${source_base} &&						\

--- a/packages/mariadb-10.6-mroonga/debian/rules
+++ b/packages/mariadb-10.6-mroonga/debian/rules
@@ -34,7 +34,7 @@ override_dh_auto_configure:
 	wget $${security_base_url}/$${path}/$${debian} ||		\
 	  wget $${base_url}/$${path}/$${debian};			\
 	tar xf $${archive};						\
-	(cd $${source_base} &&						\
+	(cd $${archive_base} &&						\
 	  tar xf ../$${debian});					\
 	dpkg-source --before-build $${source_base};			\
 	(cd $${source_base} &&						\

--- a/packages/mariadb-10.6-mroonga/debian/rules
+++ b/packages/mariadb-10.6-mroonga/debian/rules
@@ -34,7 +34,7 @@ override_dh_auto_configure:
 	wget $${security_base_url}/$${path}/$${debian} ||		\
 	  wget $${base_url}/$${path}/$${debian};			\
 	tar xf $${archive};						\
-	(cd $${spurce_base} &&						\
+	(cd $${source_base} &&						\
 	  tar xf ../$${debian});					\
 	dpkg-source --before-build $${source_base};			\
 	(cd $${source_base} &&						\

--- a/packages/mariadb-10.6-mroonga/debian/rules
+++ b/packages/mariadb-10.6-mroonga/debian/rules
@@ -16,13 +16,13 @@ override_dh_auto_configure:
 	archive_base=mariadb-10.6_$(MARIADB_VERSION);			\
 	archive=$${archive_base}.orig.tar.gz;				\
 	debian=mariadb-10.6_$(MARIADB_VERSION_FULL).debian.tar.xz;	\
-	source_base=mariadb-10.6-$(MARIADB_VERSION);			\
+	source_base=mariadb-$(MARIADB_VERSION);			\
 	build_dir=$${source_base}/builddir;				\
 	if [ "$$(lsb_release --id --short)" = "Ubuntu" ]; then		\
 	  path=universe/m/mariadb-10.6;					\
 	  base_url=http://archive.ubuntu.com/ubuntu/pool;		\
 	  security_base_url=http://security.ubuntu.com/ubuntu/pool;	\
-	  source_base=mariadb-$(MARIADB_VERSION);		\
+	  source_base=mariadb-10.6-$(MARIADB_VERSION);		\
 	  build_dir=$${source_base}/builddir;				\
 	else								\
 	  path=main/m/mariadb-10.6;					\


### PR DESCRIPTION
Currently,  direcotry name is "mariadb-10.6-10.6.22" instead of "mariadb-10.6.22" after expand source archive as below.

---

$ tar -zxvf mariadb-10.6_10.6.22.orig.tar.gz
$ la
drwxr-xr-x 34 aaa   aaa   4.0K  5月  7 13:27  mariadb-10.6-10.6.22/
-rw-r--r--  1 aaa   aaa    97M  5月 20 20:36  mariadb-10.6_10.6.22.orig.tar.gz

