### PR TITLE
test wrapper distinct: specify charset explicitly

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -7,7 +7,6 @@ on:
       - "**/*.hpp"
       - "**/CMakeLists.txt"
       - ".github/workflows/mariadb.yml"
-      - "mysql-test/**"
       - "version_*"
   pull_request:
     paths:
@@ -16,7 +15,6 @@ on:
       - "**/*.hpp"
       - "**/CMakeLists.txt"
       - ".github/workflows/mariadb.yml"
-      - "mysql-test/**"
       - "version_*"
   schedule:
     - cron: |

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -7,6 +7,7 @@ on:
       - "**/*.hpp"
       - "**/CMakeLists.txt"
       - ".github/workflows/mariadb.yml"
+      - "mysql-test/**"
       - "version_*"
   pull_request:
     paths:
@@ -15,6 +16,7 @@ on:
       - "**/*.hpp"
       - "**/CMakeLists.txt"
       - ".github/workflows/mariadb.yml"
+      - "mysql-test/**"
       - "version_*"
   schedule:
     - cron: |

--- a/mysql-test/mroonga/wrapper/r/distinct.result
+++ b/mysql-test/mroonga/wrapper/r/distinct.result
@@ -3,7 +3,7 @@ CREATE TABLE items (
 id int PRIMARY KEY,
 color VARCHAR(16) NOT NULL,
 INDEX (color)
-) COMMENT='ENGINE "InnoDB"';
+) COMMENT='ENGINE "InnoDB"' DEFAULT CHARSET=utf8mb4;
 INSERT INTO items VALUES (1, 'red');
 INSERT INTO items VALUES (2, 'blue');
 INSERT INTO items VALUES (3, 'green');

--- a/mysql-test/mroonga/wrapper/r/distinct.result
+++ b/mysql-test/mroonga/wrapper/r/distinct.result
@@ -9,5 +9,5 @@ INSERT INTO items VALUES (2, 'blue');
 INSERT INTO items VALUES (3, 'green');
 EXPLAIN SELECT DISTINCT color FROM items;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	items	range	NULL	color	18	NULL	3	Using index for group-by
+1	SIMPLE	items	range	NULL	color	66	NULL	3	Using index for group-by
 DROP TABLE items;

--- a/mysql-test/mroonga/wrapper/t/distinct.test
+++ b/mysql-test/mroonga/wrapper/t/distinct.test
@@ -32,6 +32,8 @@ INSERT INTO items VALUES (1, 'red');
 INSERT INTO items VALUES (2, 'blue');
 INSERT INTO items VALUES (3, 'green');
 
+# For MariaDB < 11
+-- replace_result 4 3
 EXPLAIN SELECT DISTINCT color FROM items;
 
 DROP TABLE items;

--- a/mysql-test/mroonga/wrapper/t/distinct.test
+++ b/mysql-test/mroonga/wrapper/t/distinct.test
@@ -26,7 +26,7 @@ CREATE TABLE items (
   id int PRIMARY KEY,
   color VARCHAR(16) NOT NULL,
   INDEX (color)
-) COMMENT='ENGINE "InnoDB"';
+) COMMENT='ENGINE "InnoDB"' DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO items VALUES (1, 'red');
 INSERT INTO items VALUES (2, 'blue');
@@ -35,8 +35,6 @@ INSERT INTO items VALUES (3, 'green');
 # For MariaDB < 11
 -- replace_result 4 3
 
-# For MariaDB < master
--- replace_result 18 66
 EXPLAIN SELECT DISTINCT color FROM items;
 
 DROP TABLE items;

--- a/mysql-test/mroonga/wrapper/t/distinct.test
+++ b/mysql-test/mroonga/wrapper/t/distinct.test
@@ -34,6 +34,9 @@ INSERT INTO items VALUES (3, 'green');
 
 # For MariaDB < 11
 -- replace_result 4 3
+
+# For MariaDB < master
+-- replace_result 18 66
 EXPLAIN SELECT DISTINCT color FROM items;
 
 DROP TABLE items;

--- a/mysql-test/mroonga/wrapper/t/distinct.test
+++ b/mysql-test/mroonga/wrapper/t/distinct.test
@@ -34,7 +34,6 @@ INSERT INTO items VALUES (3, 'green');
 
 # For MariaDB < 11
 -- replace_result 4 3
-
 EXPLAIN SELECT DISTINCT color FROM items;
 
 DROP TABLE items;

--- a/mysql-test/mroonga/wrapper/t/distinct.test
+++ b/mysql-test/mroonga/wrapper/t/distinct.test
@@ -32,8 +32,6 @@ INSERT INTO items VALUES (1, 'red');
 INSERT INTO items VALUES (2, 'blue');
 INSERT INTO items VALUES (3, 'green');
 
-# For MariaDB < 11
--- replace_result 4 3
 EXPLAIN SELECT DISTINCT color FROM items;
 
 DROP TABLE items;


### PR DESCRIPTION
Related GH-900.

This PR resolve the following error.

```
CURRENT_TEST: mroonga/wrapper.distinct
--- /home/runner/work/mroonga/mroonga/mariadb/mysql-test/suite/mroonga/wrapper/r/distinct.result	2025-05-27 01:57:13.191770063 +0000
+++ /home/runner/work/mroonga/mroonga/mariadb/mysql-test/suite/mroonga/wrapper/r/distinct.reject	2025-05-27 01:59:55.334834725 +0000
@@ -9,5 +9,5 @@
 INSERT INTO items VALUES (3, 'green');
 EXPLAIN SELECT DISTINCT color FROM items;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	items	range	NULL	color	18	NULL	3	Using index for group-by
+1	SIMPLE	items	range	NULL	color	66	NULL	3	Using index for group-by
 DROP TABLE items;
```
https://github.com/mroonga/mroonga/actions/runs/15264998418/job/42929027513#step:15:57

`mroonga/wrapper.distinct` test is pass after this PR apply as below. 

```
mroonga/wrapper.distinct                 w4 [ pass ]     31
```
https://github.com/mroonga/mroonga/actions/runs/15249339012/job/42882196010#step:15:53


Default "character_set_server" is utf8mb4 in MariaDB main as below.

```
SHOW VARIABLES LIKE "char%";
Variable_name  Value
character_set_client   latin1
character_set_collations       utf8mb3=utf8mb3_uca1400_ai_ci,ucs2=ucs2_uca1400_ai_ci,utf8mb4=utf8mb4_uca1400_ai_ci,utf16=utf16_uca1400_ai_ci,utf32=utf32_uca1400_ai_ci
character_set_connection       latin1
character_set_database utf8mb4
character_set_filesystem       binary
character_set_results  latin1
character_set_server   utf8mb4
character_set_system   utf8mb3
character_sets_dir     /mariadb-server/sql/share/charsets/
```

So, we specifying charset explicitly in this PR.