### PR TITLE
doc news: fix wrong description

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/news/15.po
+++ b/doc/locale/ja/LC_MESSAGES/news/15.po
@@ -29,8 +29,8 @@ msgstr "UbuntuのMySQL 8.0.42をサポート"
 msgid "This is the latest MySQL release."
 msgstr "これは最新のMySQLのリリースです。"
 
-msgid "Added support for MariaDB 10.5.29, 10.6.22, 10.11.12, and 11.4.6"
-msgstr "MariaDB 10.5.29, 10.6.22, 10.11.12, 11.4.6をサポート"
+msgid "Added support for MariaDB 10.5.29 and 10.6.22"
+msgstr "MariaDB 10.5.29と10.6.22をサポート"
 
 msgid "These are the latest MariaDB release."
 msgstr "これらは最新のMariaDBのリリースです。"

--- a/doc/source/news/15.md
+++ b/doc/source/news/15.md
@@ -9,7 +9,7 @@
 
 This is the latest MySQL release.
 
-#### Added support for MariaDB 10.5.29, 10.6.22, 10.11.12, and 11.4.6
+#### Added support for MariaDB 10.5.29 and 10.6.22
 
 These are the latest MariaDB release.
 


### PR DESCRIPTION
We don't support MariaDB 10.11.12 and 11.4.6 yet.
Currently, we supported for MariaDB 10.11.11 and 11.4.5.