### PR TITLE
cmake: return early if mroonga is disabled

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -149,7 +149,6 @@ jobs:
           key: mariadb-linux-ccache-${{ hashFiles('mariadb/**/*.cpp', 'mariadb/**/*.h', 'mariadb/**/*.hpp') }}
           restore-keys: mariadb-linux-ccache-
       - name: Configure MariaDB
-        continue-on-error: ${{ matrix.id != 'amd64-compile-only-core' }}
         run: |
           cmake \
             -Smariadb \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,9 @@ if(MRN_BUNDLED)
     ${MRN_ALL_SOURCES}
     STORAGE_ENGINE MODULE_ONLY
     LINK_LIBRARIES ${MRN_LIBRARIES})
+  if(NOT TARGET mroonga)
+    return()
+  endif()
 else()
   add_library(mroonga MODULE ${MRN_ALL_SOURCES})
 


### PR DESCRIPTION
Related commit:
GitHub https://github.com/MariaDB/server/commit/d98514690fc647682ac06e7b09502b4274fa3e20