### PR TITLE
release yum: use URI that returns newer SRPM version

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -238,6 +238,10 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   def latest_target_version(series, trailing_slash, minimal_or_not = nil)
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS"
+    if minimal_or_not == :minimal
+      srpms_url =
+        "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"
+    end
     pattern = "SRPMS\/mysql-community-"
     if trailing_slash == :with_trailing_slash
       srpms_url << "/"

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -281,19 +281,6 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
       latest_target_version(series, :with_trailing_slash, :minimal),
       latest_target_version(series, :without_trailing_slash, :minimal)
     ].max
-
-    srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"
-    index_html = URI.open(srpms_url) do |response|
-      response.read
-    end
-    latest_target_srpm =
-      index_html.
-        scan(/href="(.+?)"/i).
-        flatten.
-        grep(/\ASRPMS\/mysql-community-minimal-/).
-        last
-    latest_target_srpm[/\ASRPMS\/mysql-community-minimal-(\d+\.\d+\.\d+-\d+)/, 1]
   end
 
   def mysql_community_minimal_rpm_version

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -235,7 +235,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     [names.join("-"), series]
   end
 
-  def latest_target_version(series, trailing_slash: false, minimal: false)
+  def target_version(series, trailing_slash: false, minimal: false)
     path = minimal ? "docker/el/9/SRPMS" : "el/9/SRPMS"
     path += "/" if trailing_slash
     srpms_url =
@@ -255,14 +255,21 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     latest_target_srpm[/\A#{pattern}(\d+\.\d+\.\d+-\d+)/, 1]
   end
 
+  def latest_target_version(target_versions)
+    Gem::Version.new(target_versions[0]) >= Gem::Version.new(target_versions[1])
+      ? Gem::Version.new(target_versions[0]) : Gem::Version.new(target_versions[1])
+  end
+
   def detect_mysql_community_rpm_version
     series = split_mysql_package[1]
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
-    [
-      latest_target_version(series, trailing_slash: true),
-      latest_target_version(series, trailing_slash: false)
-    ].max
+    latest_target_version(
+      [
+        target_version(series, trailing_slash: true),
+        target_version(series, trailing_slash: false)
+      ]
+    )
   end
 
   def mysql_community_rpm_version
@@ -273,10 +280,12 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     series = split_mysql_package[1]
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
-    [
-      latest_target_version(series, trailing_slash: true, minimal: true),
-      latest_target_version(series, trailing_slash: false, minimal: true)
-    ].max
+    latest_target_version (
+      [
+        target_version(series, trailing_slash: true, minimal: true),
+        target_version(series, trailing_slash: false, minimal: true)
+      ]
+    )
   end
 
   def mysql_community_minimal_rpm_version

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -240,7 +240,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     path += "/" if trailing_slash
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/#{path}"
-    pattern =  trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
+    pattern = trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
     pattern += "minimal-" if minimal
 
     index_html = URI.open(srpms_url) do |response|

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -255,15 +255,15 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     latest_target_srpm[/\A#{pattern}(\d+\.\d+\.\d+-\d+)/, 1]
   end
 
-  def latest_target_version(version1, version2)
-    unless version1.is_a?(String) && version2.is_a?(String)
+  def latest_target_version(version1_raw, version2_raw)
+    unless version1_raw.is_a?(String) && version2_raw.is_a?(String)
       raise ArgumentError,
             "latest_target_version expects two version strings as arguments
-             : <#{version1}>, <#{version2}>"
+             : <#{version1_raw}>, <#{version2_raw}>"
     end
-    version1 = Gem::Version.new(version1)
-    version2 = Gem::Version.new(version2)
-    version1 >= version2 ? version1 : version2
+    version1 = Gem::Version.new(version1_raw)
+    version2 = Gem::Version.new(version2_raw)
+    version1 >= version2 ? version1_raw : version2_raw
   end
 
   def detect_mysql_community_rpm_version

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -256,6 +256,11 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def latest_target_version(version1, version2)
+    unless version1.is_a?(String) && version2.is_a?(String)
+      raise ArgumentError,
+            "latest_target_version expects two version strings as arguments
+             : <#{version1}>, <#{version2}>"
+    end
     version1 = Gem::Version.new(version1)
     version2 = Gem::Version.new(version2)
     version1 >= version2 ? version1 : version2

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -239,7 +239,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     path = minimal ? "docker/el/9/SRPMS" : "el/9/SRPMS"
     path += "/" if trailing_slash
     srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/${path}"
+      "https://repo.mysql.com/yum/mysql-#{series}-community/#{path}"
     pattern =  trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
     pattern += "minimal-" if minimal
 

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -236,12 +236,12 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def latest_target_version(series, trailing_slash: false, minimal: false)
-path = minimal ? "docker/el/9/SRPMS" : "el/9/SRPMS"
-path += "/" if trailing_slash
-srpms_url =
-"https://repo.mysql.com/yum/mysql-#{series}-community/${path}"
-pattern =  trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
-pattern += "minimal-"
+    path = minimal ? "docker/el/9/SRPMS" : "el/9/SRPMS"
+    path += "/" if trailing_slash
+    srpms_url =
+      "https://repo.mysql.com/yum/mysql-#{series}-community/${path}"
+    pattern =  trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
+    pattern += "minimal-"
 
     index_html = URI.open(srpms_url) do |response|
       response.read

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -240,7 +240,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     path += "/" if trailing_slash
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/#{path}"
-    pattern =  trailing_slash ? "mysql-community-" : "SRPMS\/mysql-community-"
+    pattern = trailing_slash ? "mysql-community-" : "SRPMS\/mysql-community-"
     pattern += "minimal-" if minimal
 
     index_html = URI.open(srpms_url) do |response|

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -241,7 +241,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/${path}"
     pattern =  trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
-    pattern += "minimal-"
+    pattern += "minimal-" if minimal
 
     index_html = URI.open(srpms_url) do |response|
       response.read

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -235,19 +235,19 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     [names.join("-"), series]
   end
 
-  def latest_target_version(series, trailing_slash, minimal_or_not = nil)
+  def latest_target_version(series, trailing_slash: false, minimal: false)
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS"
-    if minimal_or_not == :minimal
+    if minimal
       srpms_url =
         "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"
     end
     pattern = "SRPMS\/mysql-community-"
-    if trailing_slash == :with_trailing_slash
+    if trailing_slash
       srpms_url << "/"
       pattern = "mysql-community-"
     end
-    if minimal_or_not == :minimal
+    if minimal
       pattern << "minimal-"
     end
 
@@ -268,8 +268,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
     [
-      latest_target_version(series, :with_trailing_slash),
-      latest_target_version(series, :without_trailing_slash)
+      latest_target_version(series, trailing_slash: true),
+      latest_target_version(series, trailing_slash: false)
     ].max
   end
 
@@ -282,8 +282,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
     [
-      latest_target_version(series, :with_trailing_slash, :minimal),
-      latest_target_version(series, :without_trailing_slash, :minimal)
+      latest_target_version(series, trailing_slash: true, minimal: true),
+      latest_target_version(series, trailing_slash: false, minimal: true)
     ].max
   end
 

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -236,20 +236,12 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def latest_target_version(series, trailing_slash: false, minimal: false)
-    srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS"
-    if minimal
-      srpms_url =
-        "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"
-    end
-    pattern = "SRPMS\/mysql-community-"
-    if trailing_slash
-      srpms_url << "/"
-      pattern = "mysql-community-"
-    end
-    if minimal
-      pattern << "minimal-"
-    end
+path = minimal ? "docker/el/9/SRPMS" : "el/9/SRPMS"
+path += "/" if trailing_slash
+srpms_url =
+"https://repo.mysql.com/yum/mysql-#{series}-community/${path}"
+pattern =  trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
+pattern += "minimal-"
 
     index_html = URI.open(srpms_url) do |response|
       response.read

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -280,7 +280,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     series = split_mysql_package[1]
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
-    latest_target_version (
+    latest_target_version(
       [
         target_version(series, trailing_slash: true, minimal: true),
         target_version(series, trailing_slash: false, minimal: true)

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -240,7 +240,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     path += "/" if trailing_slash
     srpms_url =
       "https://repo.mysql.com/yum/mysql-#{series}-community/#{path}"
-    pattern = trailing_slash ? "SRPMS\/mysql-community-" : "mysql-community-"
+    pattern =  trailing_slash ? "mysql-community-" : "SRPMS\/mysql-community-"
     pattern += "minimal-" if minimal
 
     index_html = URI.open(srpms_url) do |response|

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -256,8 +256,9 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def latest_target_version(target_versions)
-    Gem::Version.new(target_versions[0]) >= Gem::Version.new(target_versions[1])
-      ? Gem::Version.new(target_versions[0]) : Gem::Version.new(target_versions[1])
+    v1 = Gem::Version.new(target_versions[0])
+    v2 = Gem::Version.new(target_versions[1])
+    v1 >= v2 ? v1 : v2
   end
 
   def detect_mysql_community_rpm_version

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -264,8 +264,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
     [
-      latest_target_version(series, :with_trailing_slash, :minimal),
-      latest_target_version(series, :without_trailing_slash, :minimal)
+      latest_target_version(series, :with_trailing_slash),
+      latest_target_version(series, :without_trailing_slash)
     ].max
   end
 
@@ -278,8 +278,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
     [
-      latest_target_version(series, :with_trailing_slash),
-      latest_target_version(series, :without_trailing_slash)
+      latest_target_version(series, :with_trailing_slash, :minimal),
+      latest_target_version(series, :without_trailing_slash, :minimal)
     ].max
 
     srpms_url =

--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -255,10 +255,10 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     latest_target_srpm[/\A#{pattern}(\d+\.\d+\.\d+-\d+)/, 1]
   end
 
-  def latest_target_version(target_versions)
-    v1 = Gem::Version.new(target_versions[0])
-    v2 = Gem::Version.new(target_versions[1])
-    v1 >= v2 ? v1 : v2
+  def latest_target_version(version1, version2)
+    version1 = Gem::Version.new(version1)
+    version2 = Gem::Version.new(version2)
+    version1 >= version2 ? version1 : version2
   end
 
   def detect_mysql_community_rpm_version
@@ -266,10 +266,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
     latest_target_version(
-      [
-        target_version(series, trailing_slash: true),
-        target_version(series, trailing_slash: false)
-      ]
+      target_version(series, trailing_slash: true),
+      target_version(series, trailing_slash: false)
     )
   end
 
@@ -282,10 +280,8 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     # Use the URL returns newer version because the CDN caches both “…/SRPMS”
     # and "…/SRPMS/", but one of caches may return old version.
     latest_target_version(
-      [
-        target_version(series, trailing_slash: true, minimal: true),
-        target_version(series, trailing_slash: false, minimal: true)
-      ]
+      target_version(series, trailing_slash: true, minimal: true),
+      target_version(series, trailing_slash: false, minimal: true)
     )
   end
 


### PR DESCRIPTION
The CDN caches both “…/SRPMS” and "…/SRPMS/".
Also, both of caches may return old version.

We will try that we get the latest version from `dnf` command.

---

I have already tried the following approaches, but these are not working out.

* Get the latest version from tags on GitHub(mysql/mysql-server).
* Get the latest version from MySQL's release note.

These approaches can not get MySQL release number.
(MySQL release number is 1 of mysql-community-8.0.43-1.el9.src.rpm.)
Probably, this number can only get from MySQL yum repository.
(We don't get this number from release note and Github tags...)