### PR TITLE
release yum: set the latest MySQL Community version from MySQL's release note

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -237,21 +237,19 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def detect_mysql_community_rpm_version
     series = split_mysql_package[1]
-    # Use the URL without a trailing slash because the CDN caches both “…/SRPMS”
-    # and "…/SRPMS/", but the cache for the "/SRPMS/" path hasn't been expired
-    # yet. Using the no‑slash URL ensures we get the latest listing.
-    srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/el/9/SRPMS"
-    index_html = URI.open(srpms_url) do |response|
+    if series == "8.4"
+      release_type = "LTS Release"
+    else
+      release_type = "General Availability"
+    end
+    release_note_url = "https://dev.mysql.com/doc/relnotes/mysql/#{series}/en/"
+    index_html = URI.open(release_note_url) do |response|
       response.read
     end
-    latest_target_srpm =
-      index_html.
-        scan(/href="(.+?)"/i).
-        flatten.
-        grep(/\ASRPMS\/mysql-community-/).
-        last
-    latest_target_srpm[/\ASRPMS\/mysql-community-(\d+\.\d+\.\d+-\d+)/, 1]
+    index_html.
+      scan(/Changes in MySQL ([0-9]+\.[0-9]+\.[0-9]+) \([0-9]{4}-[0-9]{2}-[0-9]{2}, #{release_type}\)/).
+      flatten.
+      first
   end
 
   def mysql_community_rpm_version
@@ -259,22 +257,7 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def detect_mysql_community_minimal_rpm_version
-    series = split_mysql_package[1]
-    # Use the URL without a trailing slash because the CDN caches both “…/SRPMS”
-    # and "…/SRPMS/", but the cache for the "/SRPMS/" path hasn't been expired
-    # yet. Using the no‑slash URL ensures we get the latest listing.
-    srpms_url =
-      "https://repo.mysql.com/yum/mysql-#{series}-community/docker/el/9/SRPMS"
-    index_html = URI.open(srpms_url) do |response|
-      response.read
-    end
-    latest_target_srpm =
-      index_html.
-        scan(/href="(.+?)"/i).
-        flatten.
-        grep(/\ASRPMS\/mysql-community-minimal-/).
-        last
-    latest_target_srpm[/\ASRPMS\/mysql-community-minimal-(\d+\.\d+\.\d+-\d+)/, 1]
+    detect_mysql_community_rpm_version
   end
 
   def mysql_community_minimal_rpm_version


### PR DESCRIPTION
TODO: Test on CI.

The CDN caches both “…/SRPMS” and "…/SRPMS/".
also, both of caches may return old version.

Therefore, we use version of MySQL's release note instead of URI of SRPMS.

---

We can also get the latest version from tags for mysql/mysql-server repository on GitHub.
However, I think this approach is not good. because of tags of mysql/mysql-server is many and we can get tags only every 100 tags via GItHub API.
And mysql/mysql-server doesn't have release page on GitHub. So, We can only use tags information to get the latest version.

The cause of tags of mysql/mysql-server is many is they also include mysql-cluster and  EOLed version (e.g. mysql-5.7.xx and mysql-5.6.xx)