### PR TITLE
package: Use the package information in the repository

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -259,6 +259,19 @@ jobs:
             if [ ${exit_status} -eq 0 ]; then
               break
             fi
+            if [ "${PACKAGE_TYPE}" = "yum" ] && [[ "${{ matrix.package }}" == "mysql-community-"*  ]]; then
+              export mysql_community_src_rpm_version=$(
+                docker container run --rm \
+                "ghcr.io/mroonga/package-ghcr.io/mroonga/mroonga-package:${{ matrix.package }}-mroonga-${{ matrix.os }}" \
+                dnf info mysql-community-devel | grep -oP '^Source\s*:\s*\K.*'
+              )
+            elif [ "${PACKAGE_TYPE}" = "yum" ] && [[ "${{ matrix.package }}" == "mariadb-"*  ]]; then
+              export mariadb_src_rpm_version=$(
+                docker container run --rm \
+                "ghcr.io/mroonga/package-ghcr.io/mroonga/mroonga-package:${{ matrix.package }}-mroonga-${{ matrix.os }}" \
+                dnf info MariaDB-devel | grep -oP '^Source\s*:\s*\K.*'
+              )
+            fi
           done
           rake docker:push || :
           exit ${exit_status}


### PR DESCRIPTION
The latest versions of MySQL and MariaDB are fetched from the web page.
But, the latest version cannot be fetched due to caching.

In such cases, fetch the latest version from the package in the repository.