### PR TITLE
Clean up code related to MariaDB 10.5

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -276,7 +276,7 @@ static mysql_mutex_t* mrn_LOCK_open;
     while (false)
 #endif
 
-#if MYSQL_VERSION_ID >= 100504 && defined(MRN_MARIADB_P)
+#ifdef MRN_MARIADB_P
 #  define MRN_COLUMN(name, type_length, type_id, type_object)                  \
     Show::Column((name), (type_object), NOT_NULL)
 #  define MRN_COLUMN_END() Show::CEnd()
@@ -288,8 +288,7 @@ static mysql_mutex_t* mrn_LOCK_open;
 #  define MRN_COLUMN_END() MRN_COLUMN(NULL, 0, MYSQL_TYPE_LONG, )
 #endif
 
-#if !defined(MRN_MARIADB_P) ||                                                 \
-  MYSQL_VERSION_ID < 100500 && defined(MRN_MARIADB_P)
+#ifndef MRN_MARIADB_P
 #  define MRN_HANDLERTON_HAVE_STATE
 #endif
 
@@ -1515,7 +1514,7 @@ static void mrn_hton_drop_database(handlerton* hton, char* path)
   DBUG_VOID_RETURN;
 }
 
-#if !(defined(MRN_MARIADB_P) && MYSQL_VERSION_ID >= 100504)
+#ifndef MRN_MARIADB_P
 #  define MRN_HANDLERTON_CLOSE_CONNECTION_NEED_THREAD_DATA_RESET
 #endif
 

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -380,8 +380,7 @@ typedef uchar* mrn_write_row_buf_t;
 #endif
 
 #if defined(MRN_MARIADB_P) &&                                                  \
-  ((MYSQL_VERSION_ID >= 100525 && MYSQL_VERSION_ID < 100600) ||                \
-   (MYSQL_VERSION_ID >= 100618 && MYSQL_VERSION_ID < 100700) ||                \
+  ((MYSQL_VERSION_ID >= 100618 && MYSQL_VERSION_ID < 100700) ||                \
    (MYSQL_VERSION_ID >= 101108 && MYSQL_VERSION_ID < 101200) ||                \
    (MYSQL_VERSION_ID >= 110402))
 #  define MRN_HANDLER_ENABLE_INDEXES_PARAMETERS       key_map map, bool persist
@@ -438,8 +437,7 @@ using mrn_io_and_cpu_cost = double;
 #endif
 
 #if defined(MRN_MARIADB_P) &&                                                  \
-  ((MYSQL_VERSION_ID >= 100527 && MYSQL_VERSION_ID < 100600) ||                \
-   (MYSQL_VERSION_ID >= 100620 && MYSQL_VERSION_ID < 100700) ||                \
+  ((MYSQL_VERSION_ID >= 100620 && MYSQL_VERSION_ID < 100700) ||                \
    (MYSQL_VERSION_ID >= 101110 && MYSQL_VERSION_ID < 101200) ||                \
    (MYSQL_VERSION_ID >= 110400))
 using mrn_handler_referenced_by_foreign_key_bool = bool;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -158,12 +158,9 @@ typedef MYSQL_CONST_LEX_STRING mrn_thd_lex_string;
 typedef MYSQL_LEX_STRING mrn_thd_lex_string;
 #endif
 
-#if defined(MRN_MARIADB_P) && MYSQL_VERSION_ID >= 100504
+#ifdef MRN_MARIADB_P
 #  define mrn_init_alloc_root(root, name, block_size, pre_alloc_size, flags)   \
     init_alloc_root(mrn_memory_key, root, block_size, pre_alloc_size, flags)
-#elif defined(MRN_MARIADB_P)
-#  define mrn_init_alloc_root(root, name, block_size, pre_alloc_size, flags)   \
-    init_alloc_root(root, name, block_size, pre_alloc_size, flags)
 #elif MYSQL_VERSION_ID >= 80027
 #  define mrn_init_alloc_root(root, name, block_size, pre_alloc_size, flags)   \
     ::new ((void*)root) MEM_ROOT(mrn_memory_key, block_size)
@@ -291,7 +288,7 @@ typedef HASH mrn_table_def_cache_type;
 #  define MRN_HAVE_SQL_DERROR_H
 #endif
 
-#if (defined(MRN_MARIADB_P) && MYSQL_VERSION_ID >= 100504)
+#ifdef MRN_MARIADB_P
 #  define MRN_HAVE_SQL_TYPE_GEOM_H
 #endif
 
@@ -400,21 +397,13 @@ typedef uint mrn_srid;
 #endif
 
 #ifdef MRN_MARIADB_P
-#  if MYSQL_VERSION_ID >= 100504
-#    define mrn_init_sql_alloc(thd, name, mem_root)                            \
-      init_sql_alloc(mrn_memory_key,                                           \
-                     mem_root,                                                 \
-                     TABLE_ALLOC_BLOCK_SIZE,                                   \
-                     0,                                                        \
-                     MYF(thd->slave_thread ? 0 : MY_THREAD_SPECIFIC))
-#  else
-#    define mrn_init_sql_alloc(thd, name, mem_root)                            \
-      init_sql_alloc(mem_root,                                                 \
-                     name,                                                     \
-                     TABLE_ALLOC_BLOCK_SIZE,                                   \
-                     0,                                                        \
-                     MYF(thd->slave_thread ? 0 : MY_THREAD_SPECIFIC))
-#  endif
+#  define mrn_init_sql_alloc(thd, name, mem_root)                              \
+    init_sql_alloc(mrn_memory_key,                                             \
+                   mem_root,                                                   \
+                   TABLE_ALLOC_BLOCK_SIZE,                                     \
+                   0,                                                          \
+                   MYF(thd->slave_thread ? 0 : MY_THREAD_SPECIFIC))
+
 #else
 #  define mrn_init_sql_alloc(thd, name, mem_root)                              \
     init_sql_alloc(mrn_memory_key, mem_root, TABLE_ALLOC_BLOCK_SIZE, 0)
@@ -885,8 +874,7 @@ using TABLE_LIST = Table_ref;
 #endif
 
 #if defined(MRN_MARIADB_P) &&                                                  \
-  ((MYSQL_VERSION_ID >= 100526 && MYSQL_VERSION_ID < 100600) ||                \
-   (MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) ||                \
+  ((MYSQL_VERSION_ID >= 100619 && MYSQL_VERSION_ID < 100700) ||                \
    (MYSQL_VERSION_ID >= 101109 && MYSQL_VERSION_ID < 101200) ||                \
    (MYSQL_VERSION_ID >= 110403))
 #  define MRN_GET_TABLE_NAME(query_tables) (query_tables->get_table_name().str)


### PR DESCRIPTION
GitHub fixes GH-964

MariaDB 10.5 drops support with EOL, so clean up related codes.