### PR TITLE
ci windows: use "INSTALL_RUNTIME_DEPENDENCIES" instead of deprecated flag

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -217,7 +217,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=install ^
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
             -DCONNECT_WITH_LIBXML2=OFF ^
-            -DINSTALL_RUNTIME_DEPENDENCIES_DEFAULT=OFF ^
+            -DINSTALL_RUNTIME_DEPENDENCIES=OFF ^
             -DMRN_GROONGA_EMBED=${{ matrix.embed || 'OFF' }} ^
             -DMRN_GROONGA_NORMALIZER_MYSQL_EMBED=${{ matrix.embed || 'OFF' }} ^
             -DGRN_WITH_MRUBY=ON ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -208,7 +208,8 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VC_ARCHITECTURE% || exit /B
-          # -DINSTALL_RUNTIME_DEPENDENCIES_DEFAULT=OFF is workaround for: https://jira.mariadb.org/browse/MDEV-36904
+          # -DINSTALL_RUNTIME_DEPENDENCIES=OFF is workaround for: https://github.com/mroonga/mroonga/issues/967
+          # We can remove this workaround after supporting vcpkg in Groonga.
           cmake ^
             -S mariadb ^
             -B build ^


### PR DESCRIPTION
GitHub: GH-967

This fixes the build error caused by MariaDB 11.4.8+ changes.

MariaDB commit: https://github.com/MariaDB/server/commit/9bf0492 removed the use of `INSTALL_RUNTIME_DEPENDENCIES_DEFAULT` variable and made `INSTALL_RUNTIME_DEPENDENCIES` always default to `ON`.

This commit updates our CI to use the correct flag name:
- Before: `-DINSTALL_RUNTIME_DEPENDENCIES_DEFAULT=OFF`
- After:  `-DINSTALL_RUNTIME_DEPENDENCIES=OFF`

This resolves the following error that started appearing with MariaDB 11.4.8+:

```
CMake Error at cmake_install.cmake:1653 (file):
  file Could not resolve runtime dependencies:

    groonga-llama.dll

FAILED: [code=1] CMakeFiles/install.util
C:\Windows\system32\cmd.exe /C "cd /D D:\a\mroonga\mroonga\build && "C:\Program Files\CMake\bin\cmake.exe" -P cmake_install.cmake"
ninja: build stopped: subcommand failed.
```

ref: https://github.com/mroonga/mroonga/actions/runs/16980398831

The error occurs because:
1. MariaDB now tries to resolve runtime dependencies by default
2. Our previous flag (`INSTALL_RUNTIME_DEPENDENCIES_DEFAULT`) is ignored
3. The build process fails when trying to resolve groonga-llama.dll dependencies

ref: https://github.com/mroonga/mroonga/pull/934