### PR TITLE
test: Specify the character encoding because mroonga_normalize() test cause garbled text

### DIFF
--- a/mysql-test/mroonga/storage/function/normalize/r/record.result
+++ b/mysql-test/mroonga/storage/function/normalize/r/record.result
@@ -1,6 +1,7 @@
+SET NAMES utf8mb4;
 CREATE TABLE memos (
 content text
-);
+) DEFAULT CHARSET=utf8mb4;
 INSERT INTO memos VALUES ('aBcＡｂＣ㍑');
 SELECT mroonga_normalize(content) FROM memos;
 mroonga_normalize(content)

--- a/mysql-test/mroonga/storage/function/normalize/t/record.test
+++ b/mysql-test/mroonga/storage/function/normalize/t/record.test
@@ -24,9 +24,11 @@ DROP TABLE IF EXISTS memos;
 --enable_query_log
 --enable_warnings
 
+SET NAMES utf8mb4;
+
 CREATE TABLE memos (
   content text
-);
+) DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO memos VALUES ('aBcＡｂＣ㍑');
 


### PR DESCRIPTION
The default character encoding has changed in MariaDB 11.8, so we explicitly specify it.
This change fixes the test error caused by garbled text.

```
select version();
version()
11.4.8-MariaDB-debug-log

SHOW VARIABLES LIKE 'character_set_%';
Variable_name	Value
character_set_client	latin1
character_set_collations
character_set_connection	latin1
character_set_database	latin1
character_set_filesystem	binary
character_set_results	latin1
character_set_server	latin1
character_set_system	utf8mb3
character_sets_dir	/mariadb/mariadb-11.4.8/sql/share/charsets/
```

```
select version();
version()
11.8.3-MariaDB-debug-log

SHOW VARIABLES LIKE 'character_set_%';
Variable_name	Value
character_set_client	latin1
character_set_collations	utf8mb3=utf8mb3_uca1400_ai_ci,ucs2=ucs2_uca1400_ai_ci,utf8mb4=utf8mb4_uca1400_ai_ci,utf16=utf16_uca1400_ai_ci,utf32=utf32_uca1400_ai_ci
character_set_connection	latin1
character_set_database	utf8mb4
character_set_filesystem	binary
character_set_results	latin1
character_set_server	utf8mb4
character_set_system	utf8mb3
character_sets_dir	/mariadb/mariadb-11.8.3/sql/share/charsets/
```