### PR TITLE
cmake: suppress the frame-larger-than warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,8 +274,6 @@ set(MRN_ALL_SOURCES
 
 mrn_build_flag("-Wno-frame-larger-than")
 if(MRN_BUNDLED)
-  set_source_files_properties(${MRN_ALL_SOURCES} PROPERTIES
-    COMPILE_FLAGS "${MRN_CXX_COMPILE_FLAGS}")
   mysql_add_plugin(mroonga
     ${MRN_ALL_SOURCES}
     STORAGE_ENGINE MODULE_ONLY
@@ -283,6 +281,8 @@ if(MRN_BUNDLED)
   if(NOT TARGET mroonga)
     return()
   endif()
+  separate_arguments(MRN_CXX_COMPILE_FLAGS_LIST NATIVE_COMMAND "${MRN_CXX_COMPILE_FLAGS}")
+  target_compile_options(mroonga PRIVATE ${MRN_CXX_COMPILE_FLAGS_LIST})
 else()
   add_library(mroonga MODULE ${MRN_ALL_SOURCES})
 


### PR DESCRIPTION
## Issue

We got the following error when we built Mroonga with MariaDB.

```
/home/buildbot/storage/mroonga/lib/mrn_database_manager.cpp:159:3: error: the frame size of 22816 bytes is larger than 16384 bytes [-Werror=frame-larger-than=]
...
```

## How to reporduce

```
rm -rf mroonga.mariadb-11.8.3 && \
cmake \
    -Smroonga \
    -Bmroonga.mariadb-11.8.3 \
    --preset=debug \
    -DCMAKE_INSTALL_PREFIX=/tmp/local \
    -DMYSQL_BUILD_DIR=$HOME/work/cpp/mariadb-11.8.3.build \
    -DMYSQL_CONFIG=$HOME/work/cpp/mariadb-11.8.3.build/scripts/mysql_config \
    -DMYSQL_SOURCE_DIR=$HOME/work/cpp/mariadb-11.8.3 \
    -DCMAKE_CXX_FLAGS="-Werror=frame-larger-than=16384"
```

## Cause

In MariaDB’s build environment, compiler warnings are promoted to errors. As a result, any -Werror=frame-larger-than= diagnostics fail the build.

## Solution

We will suppress this warning now because there are no effects to Mroonga.