### PR TITLE
mariadb-11.8: spatial is always enabled

### DIFF
--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -297,7 +297,7 @@ typedef HASH mrn_table_def_cache_type;
 #  define MRN_HAVE_SRID
 #  include <sql/gis/srid.h>
 using mrn_srid = gis::srid_t;
-#  define MRN_FIELD_GEOM_GET_SRID(field)                                     \
+#  define MRN_FIELD_GEOM_GET_SRID(field)                                       \
     (field->get_srid().has_value() ? field->get_srid().value() : 0)
 #  define MRN_HAVE_SRS
 #elif (MYSQL_VERSION_ID >= 110800 || defined(HAVE_SPATIAL))


### PR DESCRIPTION
Fix: GH-982.

`HAVE_SPATIAL` is removed at https://github.com/MariaDB/server/commit/32e6f8ff2eb54f029e9fced9b17b780e7b7bd6d9.
So, `MRN_HAVE_SPATIAL` is always enabled in MariaDB 11.8 with Mroonga.