### PR TITLE
packages apt: use the latest repository setup package

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -121,9 +121,9 @@ case ${package} in
     mysql_test_dir=/usr/share/mysql/mysql-test
     ;;
   mysql-community-*)
-    # This is This is workaround.
+    # This is a workaround.
     # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-    # About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
+    # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
     # See: https://bugs.mysql.com/bug.php?id=119212
     wget -O mysql-apt-config.deb \
          https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb

--- a/packages/mysql-community-8.0-mroonga/apt/debian-bookworm/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/debian-bookworm/Dockerfile
@@ -22,9 +22,9 @@ RUN \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is This is workaround.
+  # This is a workaround.
   # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
+  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
   # See: https://bugs.mysql.com/bug.php?id=119212
   wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \

--- a/packages/mysql-community-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
@@ -22,9 +22,9 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is This is workaround.
+  # This is a workaround.
   # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
+  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
   # See: https://bugs.mysql.com/bug.php?id=119212
   wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \

--- a/packages/mysql-community-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -21,10 +21,10 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is This is workaround.
+  # This is a workaround.
   # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212  
+  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
+  # See: https://bugs.mysql.com/bug.php?id=119212
   wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \

--- a/packages/mysql-community-8.4-mroonga/apt/debian-bookworm/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/apt/debian-bookworm/Dockerfile
@@ -22,10 +22,10 @@ RUN \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is This is workaround.
+  # This is a workaround.
   # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212  
+  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
+  # See: https://bugs.mysql.com/bug.php?id=119212
   wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \

--- a/packages/mysql-community-8.4-mroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/apt/ubuntu-jammy/Dockerfile
@@ -22,9 +22,9 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is This is workaround.
+  # This is a workaround.
   # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
+  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
   # See: https://bugs.mysql.com/bug.php?id=119212
   wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \

--- a/packages/mysql-community-8.4-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/apt/ubuntu-noble/Dockerfile
@@ -21,9 +21,9 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is This is workaround.
+  # This is a workaround.
   # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
+  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
   # See: https://bugs.mysql.com/bug.php?id=119212
   wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
   apt install -y -V --no-install-recommends ${quiet} \


### PR DESCRIPTION
This is workaround.

We use repository setup package directly below https://repo.mysql.com/.
However, "apt update" is failure as below because of the GPG key include https://repo.mysql.com/mysql-apt-config.deb is old.

```
10.62 W: GPG error: http://repo.mysql.com/apt/debian bookworm InRelease: The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
10.62 E: The repository 'http://repo.mysql.com/apt/debian bookworm InRelease' is not signed.
```

So, we use https://repo.mysql.com/apt/debian/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb.
Because mysql-apt-config_0.8.36-1_all.deb is the latest version.

About https://repo.mysql.com/mysql-apt-config.deb updating has already reported to upstream.
See: https://bugs.mysql.com/bug.php?id=119212

We can remove this modification when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.