### PR TITLE
packages mysql-community-8.4: add the missing dependency package

### DIFF
--- a/packages/mysql-community-8.4-mroonga/yum/almalinux-10/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/yum/almalinux-10/Dockerfile
@@ -22,6 +22,7 @@ RUN \
     intltool \
     libcurl-devel \
     libtool \
+    libquadmath-devel \
     make \
     pkgconfig \
     rpm-build \


### PR DESCRIPTION
Fix: https://github.com/mroonga/mroonga/actions/runs/19654876473/job/56289478031

```
error: Failed build dependencies:

RPM build warnings:
	libquadmath-devel is needed by mysql-community-8.4.7-1.el10.x86_64
```

I confirmed that the RPM of MySQL community server 8.4 build successful in CI as below.
https://github.com/komainu8/mroonga/actions/runs/19662098848/job/56310540653