### PR TITLE
test wrapper: use "tokenizer" instead of "parser"

### DIFF
--- a/mysql-test/mroonga/wrapper/create/table/index/parser/r/comment.result
+++ b/mysql-test/mroonga/wrapper/create/table/index/parser/r/comment.result
@@ -3,10 +3,8 @@ create table diaries (
 id int primary key auto_increment,
 body text,
 fulltext index body_index (body)
-comment 'parser "TokenBigramSplitSymbolAlphaDigit"'
+comment 'tokenizer "TokenBigramSplitSymbolAlphaDigit"'
 ) comment = 'engine "innodb"' default charset utf8mb4;
-Warnings:
-Warning	1287	'parser' is deprecated and will be removed in a future release. Please use tokenizer instead
 insert into diaries (body) values ("will start Groonga!");
 insert into diaries (body) values ("starting Groonga...");
 insert into diaries (body) values ("started Groonga.");

--- a/mysql-test/mroonga/wrapper/create/table/index/parser/t/comment.test
+++ b/mysql-test/mroonga/wrapper/create/table/index/parser/t/comment.test
@@ -27,7 +27,7 @@ create table diaries (
   id int primary key auto_increment,
   body text,
   fulltext index body_index (body)
-    comment 'parser "TokenBigramSplitSymbolAlphaDigit"'
+    comment 'tokenizer "TokenBigramSplitSymbolAlphaDigit"'
 ) comment = 'engine "innodb"' default charset utf8mb4;
 insert into diaries (body) values ("will start Groonga!");
 insert into diaries (body) values ("starting Groonga...");


### PR DESCRIPTION
Because 'parser' is deprecated and will be removed in a future release.