### PR TITLE
test wrapper: add the missing single quotation mark in warning message

### DIFF
--- a/mysql-test/mroonga/wrapper/create/table/index/parser/r/comment.result
+++ b/mysql-test/mroonga/wrapper/create/table/index/parser/r/comment.result
@@ -6,7 +6,7 @@ fulltext index body_index (body)
 comment 'parser "TokenBigramSplitSymbolAlphaDigit"'
 ) comment = 'engine "innodb"' default charset utf8mb4;
 Warnings:
-Warning	1287	'parser' is deprecated and will be removed in a future release. Please use tokenizer instead
+Warning	1287	'parser' is deprecated and will be removed in a future release. Please use 'tokenizer' instead
 insert into diaries (body) values ("will start Groonga!");
 insert into diaries (body) values ("starting Groonga...");
 insert into diaries (body) values ("started Groonga.");

--- a/mysql-test/mroonga/wrapper/create/table/index/parser/t/comment.test
+++ b/mysql-test/mroonga/wrapper/create/table/index/parser/t/comment.test
@@ -23,6 +23,7 @@
 drop table if exists diaries;
 --enable_warnings
 
+--replace_result "Please use tokenizer instead" "Please use 'tokenizer' instead"
 create table diaries (
   id int primary key auto_increment,
   body text,


### PR DESCRIPTION
MariaDB 11.8 or later use `'tokenizer'` instead of `tokenizer`.