### PR TITLE
mysql-test: fix MariaDB 11.5 or later detection

### DIFF
--- a/mysql-test/mroonga/include/mroonga/check_version.inc
+++ b/mysql-test/mroonga/include/mroonga/check_version.inc
@@ -38,5 +38,5 @@ let $version_8_0           = `SELECT $version_major_minor = 8.00`;
 
 let $version_8_0_or_later   = `SELECT $version_major_minor >= 8.00`;
 let $version_10_11_or_later  = `SELECT $version_major_minor >= 10.11`;
-let $version_11_5_or_later  = `SELECT $version_major_minor >= 11.5`;
+let $version_11_5_or_later  = `SELECT $version_major_minor >= 11.05`;
 --enable_query_log


### PR DESCRIPTION
GitHub: Fix GH-983

We need to use `11.05` not `11.5`.

If `$version_11_5_or_later` isn't detected correctly, `FLUSH GLOBAL STATUS` isn't executed with MariaDB 11.5 or later.
