### PR TITLE
release: add release:version:validate task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,33 +38,33 @@ def new_version
   env_var("NEW_VERSION", version.succ)
 end
 
-def version_components(version)
+def version_segments(version)
   major, minor_micro = version.split(".")
   [major, minor_micro[0], minor_micro[1]]
 end
 
 def new_version_major
-  version_components(new_version)[0]
+  version_segments(new_version)[0]
 end
 
 def new_version_minor
-  version_components(new_version)[1]
+  version_segments(new_version)[1]
 end
 
 def new_version_micro
-  version_components(new_version)[2]
+  version_segments(new_version)[2]
 end
 
 def version_major
-  version_components(version)[0]
+  version_segments(version)[0]
 end
 
 def version_minor
-  version_components(version)[1]
+  version_segments(version)[1]
 end
 
 def version_micro
-  version_components(version)[2]
+  version_segments(version)[2]
 end
 
 def latest_groonga_version


### PR DESCRIPTION
This task validates the following before release:

1. VERSION environment variable must match VERSION_FULL
- Prevents us from releasing the wrong version
- Suggests the correct dev:version:bump command on failure

e.g. When Mroonga version is 15.21 and we specifythe VERSION=15.22

```console
$ VERSION=15.22 rake release:version:validate
rake aborted!
You must NOT specify VERSION=15.22 for 'rake release'. You must run 'rake dev:version:bump NEW_VERSION=15.22' before 'rake release'.
```

2. Mroonga version must be >= latest Groonga version
- Fetches latest Groonga version from GitHub API
- Suggests the correct dev:version:bump command on failure

e.g. When Mroonga version is 15.20 and Groonga version is 15.2.1

```console
$ echo "15.20" > version_full && rake release:version:validate
rake aborted!
Mroonga version (15.20) must be greater than or equal to the latest Groonga version (15.2.1). You must run 'rake dev:version:bump NEW_VERSION=15.21'.
```