### PR TITLE
packages: remove needless `docker_image` override

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -360,10 +360,6 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     true
   end
 
-  def docker_image(os, architecture)
-    "ghcr.io/mroonga/package-#{super}"
-  end
-
   def built_package_url(target_namespace, target)
     url = "https://github.com/mroonga/mroonga/releases/download/v#{@version}/"
     if target_namespace == :source


### PR DESCRIPTION
We can use `docker_image` defined in Groonga as-is: https://github.com/groonga/groonga/blob/v15.2.1/packages/packages-groonga-org-package-task.rb#L181-L183

If we override like this, the generated Docker image name is `ghcr.io/mroonga-package-ghcr.io/mroonga-package:mysql-8.0-mroonga-ubuntu-noble`. It's redundant.