### PR TITLE
ci mariadb main: remove "continue-on-error"

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -167,9 +167,6 @@ jobs:
           ccache --show-stats --verbose --version || :
       - name: Run test
         if: matrix.id == 'core'
-        # TODO: Temporarily ignore failures on MariaDB main. Disable this when
-        # all tests pass cleanly on main once.
-        continue-on-error: true
         run: |
           cd mariadb.build/storage/mroonga
           NO_MAKE=yes \


### PR DESCRIPTION
Because all tests of MariaDB main passed on CI as below.

https://github.com/mroonga/mroonga/actions/runs/19922782771/job/57115042562#step:15:952

```
Completed: All 815 tests were successful.
```