### PR TITLE
ci percona-server-8.0: add missing dependency repository

### DIFF
--- a/packages/percona-server-8.0-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/percona-server-8.0-mroonga/yum/almalinux-8/Dockerfile
@@ -14,7 +14,8 @@ RUN \
     https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
   dnf module disable -y mysql && \
-  percona-release setup ps80 && \
+  echo "REPOSITORIES=\"tools\"" | tee /etc/default/percona-release && \
+  percona-release setup ps-80 && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     'dnf-command(builddep)' \

--- a/packages/percona-server-8.0-mroonga/yum/almalinux-9/Dockerfile
+++ b/packages/percona-server-8.0-mroonga/yum/almalinux-9/Dockerfile
@@ -13,7 +13,8 @@ RUN \
     https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
     https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm \
     https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
-  percona-release setup -y ps80 && \
+  echo "REPOSITORIES=\"tools\"" | tee /etc/default/percona-release && \
+  percona-release setup -y ps-80 && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=crb -y ${quiet} \
     'dnf-command(builddep)' \

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -84,7 +84,8 @@ REPO
          https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     percona_package_version=$(echo ${mysql_version} | sed -e 's/\.//g')
     if [ "${percona_package_version}" = "80" ]; then
-      sudo percona-release setup ps${percona_package_version}
+      echo "REPOSITORIES=\"tools\"" | sudo tee /etc/default/percona-release
+      sudo percona-release setup ps-${percona_package_version}
     else
       sudo percona-release enable-only ps-${percona_package_version}-lts release
     fi


### PR DESCRIPTION
If REPOSITORIES="tools" is not set, "percona-release setup ps-80" fails.