### PR TITLE
wrapper: Drop support for engine "XXX" in CONNECTION

### DIFF
--- a/mrn_table.cpp
+++ b/mrn_table.cpp
@@ -348,9 +348,9 @@ int mrn_parse_table_param(MRN_SHARE *share, TABLE *table)
     &part_elem, &sub_elem);
 #endif
 #ifdef WITH_PARTITION_STORAGE_ENGINE
-  for (i = 4; i > 0; i--)
+  for (i = 3; i > 0; i--)
 #else
-  for (i = 2; i > 0; i--)
+  for (i = 1; i > 0; i--)
 #endif
   {
     const char *params_string_value = NULL;
@@ -358,7 +358,7 @@ int mrn_parse_table_param(MRN_SHARE *share, TABLE *table)
     switch (i)
     {
 #ifdef WITH_PARTITION_STORAGE_ENGINE
-      case 4:
+      case 3:
         if (!sub_elem || !sub_elem->part_comment)
           continue;
         DBUG_PRINT("info", ("mroonga create sub comment string"));
@@ -367,7 +367,7 @@ int mrn_parse_table_param(MRN_SHARE *share, TABLE *table)
         DBUG_PRINT("info",
                    ("mroonga sub comment string=%s", params_string_value));
         break;
-      case 3:
+      case 2:
         if (!part_elem || !part_elem->part_comment)
           continue;
         DBUG_PRINT("info", ("mroonga create part comment string"));
@@ -377,7 +377,7 @@ int mrn_parse_table_param(MRN_SHARE *share, TABLE *table)
                    ("mroonga part comment string=%s", params_string_value));
         break;
 #endif
-      case 2:
+      default:
         if (LEX_STRING_IS_EMPTY(table->s->comment))
           continue;
         DBUG_PRINT("info", ("mroonga create comment string"));
@@ -385,16 +385,6 @@ int mrn_parse_table_param(MRN_SHARE *share, TABLE *table)
         params_string_length = table->s->comment.length;
         DBUG_PRINT("info",
                    ("mroonga comment string=%.*s",
-                    params_string_length, params_string_value));
-        break;
-      default:
-        if (LEX_STRING_IS_EMPTY(table->s->connect_string))
-          continue;
-        DBUG_PRINT("info", ("mroonga create connect_string string"));
-        params_string_value = table->s->connect_string.str;
-        params_string_length = table->s->connect_string.length;
-        DBUG_PRINT("info",
-                   ("mroonga connect_string=%.*s",
                     params_string_length, params_string_value));
         break;
     }
@@ -1115,7 +1105,6 @@ mrn::SlotData *mrn_get_slot_data(THD *thd, bool can_create)
 #endif
     slot_data->alter_create_info = NULL;
     slot_data->disable_keys_create_info = NULL;
-    slot_data->alter_connect_string = NULL;
     slot_data->alter_comment = NULL;
     {
       mrn::Lock lock(&mrn_allocated_thds_mutex);

--- a/mrn_table.hpp
+++ b/mrn_table.hpp
@@ -103,7 +103,6 @@ namespace mrn {
 #endif
         alter_create_info(NULL),
         disable_keys_create_info(NULL),
-        alter_connect_string(NULL),
         alter_comment(NULL),
         associated_grn_ctxs() {
     }
@@ -127,10 +126,6 @@ namespace mrn {
 #endif
       alter_create_info = NULL;
       disable_keys_create_info = NULL;
-      if (alter_connect_string) {
-        my_free(alter_connect_string);
-        alter_connect_string = NULL;
-      }
       if (alter_comment) {
         my_free(alter_comment);
         alter_comment = NULL;
@@ -151,7 +146,6 @@ namespace mrn {
 #endif
     HA_CREATE_INFO *alter_create_info;
     HA_CREATE_INFO *disable_keys_create_info;
-    char *alter_connect_string;
     char *alter_comment;
     std::list<grn_ctx *> associated_grn_ctxs;
   };


### PR DESCRIPTION
FIx: GH-1033

Mroonga accepts engine "XXX" for wrapper mode in not only COMMENT but also CONNECTION: https://jira.mariadb.org/browse/MDEV-38530

It's not documented and tested.
Therefore, we drop support for the feature.