### PR TITLE
Use more suitable macro name

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -3773,7 +3773,7 @@ int ha_mroonga::wrapper_create(const char* name,
     DBUG_RETURN(HA_ERR_OUT_OF_MEM);
   }
 #  ifdef MRN_SUPPORT_CUSTOM_OPTIONS
-  info->option_struct = MRN_GET_TABLE_SHARE_OPTION_STRUCT(table->s);
+  info->option_struct = MRN_GET_TABLE_SHARE_OPTION_STRUCT_TABLE(table->s);
 #  endif
 #  ifdef MRN_HANDLER_CREATE_HAVE_TABLE_DEFINITION
   error = hnd->ha_create(name, table, info, table_def);
@@ -15120,8 +15120,8 @@ int ha_mroonga::wrapper_truncate(
   if (parse_engine_table_options(ha_thd(), tmp_share->hton, table->s)) {
     error = MRN_GET_ERROR_NUMBER;
   } else {
-    MRN_SET_OPTION_STRUCT_TO_TABLE_OPTION_STRUCT(table->s);
-    MRN_SET_OPTION_STRUCT_TO_HANDLER(table->s);
+    MRN_SET_OPTION_STRUCT_TABLE_TO_TABLE_OPTION_STRUCT(table->s);
+    MRN_SET_OPTION_STRUCT_TABLE_TO_HANDLER(table->s);
   }
 #  endif
 #  ifdef MRN_HANDLER_TRUNCATE_HAVE_TABLE_DEFINITION
@@ -16735,7 +16735,7 @@ int ha_mroonga::wrapper_recreate_indexes(THD* thd)
   }
   HA_CREATE_INFO info;
 #  ifdef MRN_SUPPORT_CUSTOM_OPTIONS
-  info.option_struct = MRN_GET_TABLE_SHARE_OPTION_STRUCT(table_share);
+  info.option_struct = MRN_GET_TABLE_SHARE_OPTION_STRUCT_TABLE(table_share);
 #  endif
   error =
     wrapper_create_index(table_share->normalized_path.str, table, &info, share);

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -936,16 +936,16 @@ using TABLE_LIST = Table_ref;
 #endif
 
 #if defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 120300)
-#  define MRN_GET_TABLE_SHARE_OPTION_STRUCT(table_share)                       \
+#  define MRN_GET_TABLE_SHARE_OPTION_STRUCT_TABLE(table_share)                 \
     ((table_share)->option_struct_table)
-#  define MRN_SET_OPTION_STRUCT_TO_TABLE_OPTION_STRUCT(table_share)            \
+#  define MRN_SET_OPTION_STRUCT_TABLE_TO_TABLE_OPTION_STRUCT(table_share)      \
     (option_struct = (table_share)->option_struct_table)
-#  define MRN_SET_OPTION_STRUCT_TO_HANDLER(table_share)                        \
+#  define MRN_SET_OPTION_STRUCT_TABLE_TO_HANDLER(table_share)                  \
     (wrap_handler->option_struct = (table_share)->option_struct_table)
 #else
-#  define MRN_GET_TABLE_SHARE_OPTION_STRUCT(table_share)                       \
+#  define MRN_GET_TABLE_SHARE_OPTION_STRUCT_TABLE(table_share)                 \
     ((table_share)->option_struct)
-#  define MRN_SET_OPTION_STRUCT_TO_TABLE_OPTION_STRUCT(table_share)            \
-    ;                                                     /* No operation */
-#  define MRN_SET_OPTION_STRUCT_TO_HANDLER(table_share) ; /* No operation */
+/* The following macros do nothing */
+#  define MRN_SET_OPTION_STRUCT_TABLE_TO_TABLE_OPTION_STRUCT(table_share)
+#  define MRN_SET_OPTION_STRUCT_TABLE_TO_HANDLER(table_share)
 #endif


### PR DESCRIPTION
We should use newer name not older name for API compatibility macro name because we will remove API compatibility macro eventually. (We'll drop support for old MySQL/MariaDB/... eventually.) If we use newer name for API, we don't need to care about older name from now.

This also removes redundant `;` content from "does nothing" macros.