### PR TITLE
handler: Remove generic_reset()

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -14105,50 +14105,13 @@ int ha_mroonga::storage_encode_multiple_column_key_range(KEY* key_info,
   DBUG_RETURN(error);
 }
 
-int ha_mroonga::generic_reset()
-{
-  MRN_DBUG_ENTER_METHOD();
-  int error = 0;
-
-  ctx->rc = GRN_SUCCESS;
-  ctx->errbuf[0] = '\0';
-
-  if (thd_sql_command(ha_thd()) != SQLCOM_SELECT) {
-    DBUG_RETURN(error);
-  }
-
-  TABLE_LIST* table_list = table->pos_in_table_list;
-  if (!table_list) {
-    DBUG_RETURN(error);
-  }
-
-  mrn_query_block* query_block = MRN_TABLE_LIST_QUERY_BLOCK(table_list);
-  if (!query_block) {
-    DBUG_RETURN(error);
-  }
-
-  if (!query_block->ftfunc_list) {
-    DBUG_RETURN(error);
-  }
-  if (!query_block->ftfunc_list->elements) {
-    DBUG_RETURN(error);
-  }
-  List_iterator<Item_func_match> iterator(*(query_block->ftfunc_list));
-  Item_func_match* item;
-  while ((item = iterator++)) {
-    if (item->ft_handler) {
-      mrn_generic_ft_clear(reinterpret_cast<st_mrn_ft_info*>(item->ft_handler));
-    }
-  }
-
-  DBUG_RETURN(error);
-}
-
 #ifdef MRN_ENABLE_WRAPPER_MODE
 int ha_mroonga::wrapper_reset()
 {
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
+  ctx->rc = GRN_SUCCESS;
+  ctx->errbuf[0] = '\0';
   MRN_SET_WRAP_SHARE_KEY(share, table->s);
   MRN_SET_WRAP_TABLE_KEY(this, table);
   error = wrap_handler->ha_reset();
@@ -14159,10 +14122,6 @@ int ha_mroonga::wrapper_reset()
     alter_key_info_buffer = NULL;
   }
   wrap_ft_init_count = 0;
-  int generic_error = generic_reset();
-  if (error == 0) {
-    error = generic_error;
-  }
   DBUG_RETURN(error);
 }
 #endif
@@ -14170,9 +14129,9 @@ int ha_mroonga::wrapper_reset()
 int ha_mroonga::storage_reset()
 {
   MRN_DBUG_ENTER_METHOD();
-  int error;
-  error = generic_reset();
-  DBUG_RETURN(error);
+  ctx->rc = GRN_SUCCESS;
+  ctx->errbuf[0] = '\0';
+  DBUG_RETURN(0);
 }
 
 int ha_mroonga::reset()

--- a/ha_mroonga.hpp
+++ b/ha_mroonga.hpp
@@ -1279,7 +1279,6 @@ private:
   int wrapper_extra_opt(enum ha_extra_function operation, ulong cache_size);
 #endif
   int storage_extra_opt(enum ha_extra_function operation, ulong cache_size);
-  int generic_reset();
 #ifdef MRN_ENABLE_WRAPPER_MODE
   int wrapper_reset();
 #endif


### PR DESCRIPTION
GitHub fixes GH-1063

`generic_reset()` clear the following two resources.

A. Reset Groonga ctx
```
ctx->rc = GRN_SUCCESS;
ctx->errbuf[0] = '\0';
```

B. Free Groonga objects for each ft_handler
```
while ((item = iterator++)) {
  if (item->ft_handler) {
    mrn_generic_ft_clear(...);
  }
}
```

A is still needed, so it has been moved to wrapper_reset() and  storage_reset().

B has been removed as it is safe to do so.
This fixes a crash caused by accessing an invalid resource after it has been freed (GH-1063).

The reason B can be removed is that it is never executed in the current MariaDB implementation.

In `mysql_execute_command()`, the following two functions are called: `lex->unit.cleanup()` https://github.com/MariaDB/server/blob/mariadb-12.3.1/sql/sql_parse.cc#L5932 `close_thread_tables_for_query(thd)` https://github.com/MariaDB/server/blob/mariadb-12.3.1/sql/sql_parse.cc#L5993

`lex->unit.cleanup()` calls several functions internally, which free Groonga resources and clear `ft_handler` to 0. `close_thread_tables_for_query(thd)` is then called, and `generic_reset()` is executed within it.

Since `ft_handler` has already been cleared by the time `generic_reset()`, the following check is always false and `mrn_generic_ft_clear(...)` is never called:
```
if (item->ft_handler) {
  mrn_generic_ft_clear(...);
}
```

We were unable to trace the details of why this function was added in https://github.com/mroonga/mroonga/commit/ffbe22346b5c23e4aa39042b61b335eac819908e, but since it is not always executed, removing `generic_reset()` should not cause the previous bug to reappear.

MySQL (and Percona Server, which is based on it) also executes in the same order.
https://github.com/mysql/mysql-server/blob/mysql-8.4.8/sql/sql_parse.cc#L4971-L4975