### PR TITLE
mariadb-main: follow max_statement_time value in error message change

### DIFF
--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -879,7 +879,7 @@ using TABLE_LIST = Table_ref;
         }                                                                      \
       } while (false)
 #  else
-#    define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code)                          \
+#    define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code, current_thd)             \
       do {                                                                     \
         if ((ctx)->rc == GRN_CANCEL) {                                         \
           my_error(MRN_ERROR_CANCEL, MYF(0));                                  \

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -850,26 +850,44 @@ using TABLE_LIST = Table_ref;
 
 #ifdef MRN_MARIADB_P
 #  define MRN_ERROR_CANCEL ER_STATEMENT_TIMEOUT
-#  define MRN_TIMEOUT_VALUE(current_thd)                                       \
-    (current_thd->variables.max_statement_time_double)
 #else
 #  define MRN_ERROR_CANCEL ER_QUERY_TIMEOUT
-#  define MRN_TIMEOUT_VALUE(current_thd)                                       \
-    (current_thd->variables.max_execution_time)
 #endif
 
 #ifdef MRN_ERROR_CANCEL
-#  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code, current_thd)               \
-    do {                                                                       \
-      if ((ctx)->rc == GRN_CANCEL) {                                           \
-        my_error(                                                              \
-          MRN_ERROR_CANCEL,                                                    \
-          MYF(0),                                                              \
-          std::to_string((current_thd)->variables.max_statement_time_double)); \
-      } else {                                                                 \
-        my_message((error_code), (ctx)->errbuf, MYF(0));                       \
-      }                                                                        \
-    } while (false)
+#  if defined(MRN_MARIADB_P) && (MYSQL_VERSION_ID >= 130000)
+#    define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code, current_thd)             \
+      do {                                                                     \
+        if ((ctx)->rc == GRN_CANCEL) {                                         \
+          double timeout_sec = current_thd->query_timer.timeout / 1000000.0;   \
+          char timeout_str[32];                                                \
+          size_t timeout_str_length =                                          \
+            my_snprintf(timeout_str, sizeof(timeout_str), "%g", timeout_sec);  \
+                                                                               \
+          if (!strchr(timeout_str, '.') && !strchr(timeout_str, 'e')) {        \
+            timeout_str_length +=                                              \
+              my_snprintf(timeout_str + timeout_str_length,                    \
+                          sizeof(timeout_str) - timeout_str_length,            \
+                          ".0");                                               \
+          }                                                                    \
+          my_snprintf(timeout_str + timeout_str_length,                        \
+                      sizeof(timeout_str) - timeout_str_length,                \
+                      " sec");                                                 \
+          my_error(MRN_ERROR_CANCEL, MYF(0), timeout_str);                     \
+        } else {                                                               \
+          my_message((error_code), (ctx)->errbuf, MYF(0));                     \
+        }                                                                      \
+      } while (false)
+#  else
+#    define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code)                          \
+      do {                                                                     \
+        if ((ctx)->rc == GRN_CANCEL) {                                         \
+          my_error(MRN_ERROR_CANCEL, MYF(0));                                  \
+        } else {                                                               \
+          my_message((error_code), (ctx)->errbuf, MYF(0));                     \
+        }                                                                      \
+      } while (false)
+#  endif
 #else
 #  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code, current_thd)               \
     my_message(error_code, ctx->errbuf, MYF(0))

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -850,21 +850,27 @@ using TABLE_LIST = Table_ref;
 
 #ifdef MRN_MARIADB_P
 #  define MRN_ERROR_CANCEL ER_STATEMENT_TIMEOUT
+#  define MRN_TIMEOUT_VALUE(current_thd)                \
+    (current_thd->variables.max_statement_time_double)
 #else
 #  define MRN_ERROR_CANCEL ER_QUERY_TIMEOUT
+#  define MRN_TIMEOUT_VALUE(current_thd)                \
+    (current_thd->variables.max_execution_time)
 #endif
 
 #ifdef MRN_ERROR_CANCEL
-#  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code)                            \
+#  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code, current_thd)               \
     do {                                                                       \
       if ((ctx)->rc == GRN_CANCEL) {                                           \
-        my_error(MRN_ERROR_CANCEL, MYF(0));                                    \
+        my_error(MRN_ERROR_CANCEL,                                             \
+                 MYF(0),                                                       \
+                 std::to_string((current_thd)->variables.max_statement_time_double)); \
       } else {                                                                 \
         my_message((error_code), (ctx)->errbuf, MYF(0));                       \
       }                                                                        \
     } while (false)
 #else
-#  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code)                            \
+#  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code, current_thd)               \
     my_message(error_code, ctx->errbuf, MYF(0))
 #endif
 

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -850,11 +850,11 @@ using TABLE_LIST = Table_ref;
 
 #ifdef MRN_MARIADB_P
 #  define MRN_ERROR_CANCEL ER_STATEMENT_TIMEOUT
-#  define MRN_TIMEOUT_VALUE(current_thd)                \
+#  define MRN_TIMEOUT_VALUE(current_thd)                                       \
     (current_thd->variables.max_statement_time_double)
 #else
 #  define MRN_ERROR_CANCEL ER_QUERY_TIMEOUT
-#  define MRN_TIMEOUT_VALUE(current_thd)                \
+#  define MRN_TIMEOUT_VALUE(current_thd)                                       \
     (current_thd->variables.max_execution_time)
 #endif
 
@@ -862,9 +862,10 @@ using TABLE_LIST = Table_ref;
 #  define MRN_SET_MESSAGE_FROM_CTX(ctx, error_code, current_thd)               \
     do {                                                                       \
       if ((ctx)->rc == GRN_CANCEL) {                                           \
-        my_error(MRN_ERROR_CANCEL,                                             \
-                 MYF(0),                                                       \
-                 std::to_string((current_thd)->variables.max_statement_time_double)); \
+        my_error(                                                              \
+          MRN_ERROR_CANCEL,                                                    \
+          MYF(0),                                                              \
+          std::to_string((current_thd)->variables.max_statement_time_double)); \
       } else {                                                                 \
         my_message((error_code), (ctx)->errbuf, MYF(0));                       \
       }                                                                        \

--- a/udf/mrn_udf_command.cpp
+++ b/udf/mrn_udf_command.cpp
@@ -306,7 +306,7 @@ MRN_API char *mroonga_command(UDF_INIT *init, UDF_ARGS *args, char *result,
                0);
   if (ctx->rc != GRN_SUCCESS) {
     if ((ctx)->rc == GRN_CANCEL) {
-      double timeout_sec = current_thd->query_timer.period / 1000000.0;
+      double timeout_sec = current_thd->query_timer.timeout / 1000000.0;
       char timeout_str[32];
       size_t timeout_str_length =
         my_snprintf(timeout_str, sizeof(timeout_str), "%g", timeout_sec);

--- a/udf/mrn_udf_command.cpp
+++ b/udf/mrn_udf_command.cpp
@@ -306,18 +306,24 @@ MRN_API char *mroonga_command(UDF_INIT *init, UDF_ARGS *args, char *result,
                0);
   if (ctx->rc != GRN_SUCCESS) {
     if ((ctx)->rc == GRN_CANCEL) {
-      char max_statement_time_str[32];
-      size_t length =
-        my_snprintf(max_statement_time_str,
-                    sizeof(max_statement_time_str),
-                    "%g",
-                    current_thd->variables.max_statement_time_double);
-      my_snprintf(max_statement_time_str + length,
-                  sizeof(max_statement_time_str) - length,
+      double timeout_sec = current_thd->query_timer.period / 1000000.0;
+      char timeout_str[32];
+      size_t timeout_str_length =
+        my_snprintf(timeout_str, sizeof(timeout_str), "%g", timeout_sec);
+
+
+      if (!strchr(timeout_str, '.') && !strchr(timeout_str, 'e')) {
+        timeout_str_length +=
+          my_snprintf(timeout_str + timeout_str_length,
+                      sizeof(timeout_str) - timeout_str_length,
+                      ".0");
+      }
+      my_snprintf(timeout_str + timeout_str_length,
+                  sizeof(timeout_str) - timeout_str_length,
                   " sec");
       my_error(MRN_ERROR_CANCEL,
                MYF(0),
-               max_statement_time_str);
+               timeout_str);
     } else {
       MRN_SET_MESSAGE_FROM_CTX(ctx, ER_ERROR_ON_WRITE, current_thd);
     }

--- a/udf/mrn_udf_command.cpp
+++ b/udf/mrn_udf_command.cpp
@@ -305,7 +305,22 @@ MRN_API char *mroonga_command(UDF_INIT *init, UDF_ARGS *args, char *result,
                GRN_TEXT_LEN(&(info->command)),
                0);
   if (ctx->rc != GRN_SUCCESS) {
-    MRN_SET_MESSAGE_FROM_CTX(ctx, ER_ERROR_ON_WRITE);
+    if ((ctx)->rc == GRN_CANCEL) {
+      char max_statement_time_str[32];
+      size_t length =
+        my_snprintf(max_statement_time_str,
+                    sizeof(max_statement_time_str),
+                    "%g",
+                    current_thd->variables.max_statement_time_double);
+      my_snprintf(max_statement_time_str + length,
+                  sizeof(max_statement_time_str) - length,
+                  " sec");
+      my_error(MRN_ERROR_CANCEL,
+               MYF(0),
+               max_statement_time_str);
+    } else {
+      MRN_SET_MESSAGE_FROM_CTX(ctx, ER_ERROR_ON_WRITE, current_thd);
+    }
     goto error;
   }
 
@@ -315,7 +330,7 @@ MRN_API char *mroonga_command(UDF_INIT *init, UDF_ARGS *args, char *result,
     unsigned int buffer_length;
     grn_ctx_recv(ctx, &buffer, &buffer_length, &flags);
     if (ctx->rc != GRN_SUCCESS) {
-      MRN_SET_MESSAGE_FROM_CTX(ctx, ER_ERROR_ON_READ);
+      MRN_SET_MESSAGE_FROM_CTX(ctx, ER_ERROR_ON_READ, current_thd);
       goto error;
     }
     if (buffer_length > 0) {

--- a/udf/mrn_udf_command.cpp
+++ b/udf/mrn_udf_command.cpp
@@ -305,28 +305,7 @@ MRN_API char *mroonga_command(UDF_INIT *init, UDF_ARGS *args, char *result,
                GRN_TEXT_LEN(&(info->command)),
                0);
   if (ctx->rc != GRN_SUCCESS) {
-    if ((ctx)->rc == GRN_CANCEL) {
-      double timeout_sec = current_thd->query_timer.timeout / 1000000.0;
-      char timeout_str[32];
-      size_t timeout_str_length =
-        my_snprintf(timeout_str, sizeof(timeout_str), "%g", timeout_sec);
-
-
-      if (!strchr(timeout_str, '.') && !strchr(timeout_str, 'e')) {
-        timeout_str_length +=
-          my_snprintf(timeout_str + timeout_str_length,
-                      sizeof(timeout_str) - timeout_str_length,
-                      ".0");
-      }
-      my_snprintf(timeout_str + timeout_str_length,
-                  sizeof(timeout_str) - timeout_str_length,
-                  " sec");
-      my_error(MRN_ERROR_CANCEL,
-               MYF(0),
-               timeout_str);
-    } else {
-      MRN_SET_MESSAGE_FROM_CTX(ctx, ER_ERROR_ON_WRITE, current_thd);
-    }
+    MRN_SET_MESSAGE_FROM_CTX(ctx, ER_ERROR_ON_WRITE, current_thd);
     goto error;
   }
 


### PR DESCRIPTION
Don't use max_statement_time value directory.

Ref: 
https://github.com/MariaDB/server/commit/850d901b988d31e03f7c91d05bb0005494551d0
https://github.com/MariaDB/server/commit/6ca70dd64ce56da40fad3bcd0641493210dd0a4c

Fix the following errors by this modification.

```
CURRENT_TEST: mroonga/storage/function/command.max_statement_time
--- /home/runner/work/mroonga/mroonga/mariadb/mysql-test/suite/mroonga/storage/function/command/r/max_statement_time.result	2026-04-20 03:33:34.497540625 +0000
+++ /home/runner/work/mroonga/mroonga/mariadb/mysql-test/suite/mroonga/storage/function/command/r/max_statement_time.reject	2026-04-20 03:50:42.658528619 +0000
@@ -1,6 +1,6 @@
 SET STATEMENT max_statement_time = 0.001 FOR
 SELECT mroonga_command('sleep', 'second', '1');
-ERROR 70100: Query was interrupted: execution time limit 0.001 sec exceeded
+ERROR 70100: Query was interrupted: execution time limit  exceeded
 SELECT mroonga_command('sleep', 'second', '1');
 mroonga_command('sleep', 'second', '1')
 true
```