### PR TITLE
test: fix syntax error by setting "set old_mode=2_DIGIT_YEAR" in 13.00 or later (replace deprecated YEAR(2))

### DIFF
--- a/mysql-test/mroonga/include/mroonga/have_old_mode_2_digit_year.inc
+++ b/mysql-test/mroonga/include/mroonga/have_old_mode_2_digit_year.inc
@@ -20,7 +20,7 @@
 --source ../../include/mroonga/check_mariadb.inc
 
 --disable_query_log
-if ($version_13_0_or_later) {
+if ($mariadb && $version_13_0_or_later) {
 --disable_warnings
   set old_mode=2_DIGIT_YEAR;
 --enable_warnings

--- a/mysql-test/mroonga/include/mroonga/have_old_mode_2_digit_year.inc
+++ b/mysql-test/mroonga/include/mroonga/have_old_mode_2_digit_year.inc
@@ -1,6 +1,6 @@
 # -*- mode: sql; sql-product: mysql -*-
 #
-# Copyright (C) 2012-2024  Sutou Kouhei <kou@clear-code.com>
+# Copyright(C) 2026  Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,28 +16,13 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+--source ../../include/mroonga/check_version.inc
+--source ../../include/mroonga/check_mariadb.inc
+
 --disable_query_log
-let $version_major_minor =
-  `SELECT CAST(
-    CONCAT(
-      SUBSTRING_INDEX(@@global.version, '.', 1),
-      '.',
-      LPAD(
-        SUBSTRING_INDEX(
-          SUBSTRING_INDEX(@@global.version, '.', 2),
-          '.',
-          -1),
-        2,
-        '0'
-      )
-    )
-    AS DECIMAL(4, 2)
-  )`;
-
-let $version_8_0           = `SELECT $version_major_minor = 8.00`;
-
-let $version_8_0_or_later   = `SELECT $version_major_minor >= 8.00`;
-let $version_10_11_or_later  = `SELECT $version_major_minor >= 10.11`;
-let $version_11_5_or_later  = `SELECT $version_major_minor >= 11.05`;
-let $version_13_0_or_later  = `SELECT $version_major_minor >= 13.00`;
+if ($version_13_0_or_later) {
+--disable_warnings
+  set old_mode=2_DIGIT_YEAR;
+--enable_warnings
+}
 --enable_query_log

--- a/mysql-test/mroonga/storage/column/year/t/two_digit.test
+++ b/mysql-test/mroonga/storage/column/year/t/two_digit.test
@@ -19,6 +19,7 @@
 --source ../../../../include/mroonga/skip_windows.inc
 --source ../../../../include/mroonga/have_mariadb.inc
 --source ../../../../include/mroonga/have_mroonga.inc
+--source ../../../../include/mroonga/have_old_mode_2_digit_year.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS two_digits;


### PR DESCRIPTION
YEAR(2) is deprecated, and a syntax error will occur unless "set old_mode=2_DIGIT_YEAR" is set in 13.00 or later.”
Ref: https://github.com/MariaDB/server/commit/3e971059757839981444ada3dc249a55d38e0cf3