### PR TITLE
mysql-server-9.7: follow hton_drop_database() argument type change

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1547,10 +1547,11 @@ static handler* mrn_hton_handler_create(handlerton* hton,
   DBUG_RETURN(new_handler);
 }
 
-static void mrn_hton_drop_database(handlerton* hton, char* path)
+static void mrn_hton_drop_database(handlerton* hton,
+                                   MRN_SCHEMA_NAME_DECLARATION)
 {
   MRN_DBUG_ENTER_FUNCTION();
-  mrn_db_manager->drop(path);
+  mrn_db_manager->drop(MRN_SCHEMA_NAME);
   DBUG_VOID_RETURN;
 }
 

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1547,13 +1547,21 @@ static handler* mrn_hton_handler_create(handlerton* hton,
   DBUG_RETURN(new_handler);
 }
 
-static void mrn_hton_drop_database(handlerton* hton,
-                                   MRN_SCHEMA_NAME_DECLARATION)
+#if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
+static void mrn_hton_drop_database(handlerton* hton, const char* schema_name)
 {
   MRN_DBUG_ENTER_FUNCTION();
-  mrn_db_manager->drop(MRN_SCHEMA_NAME);
+  mrn_db_manager->drop(schema_name);
   DBUG_VOID_RETURN;
 }
+#else
+static void mrn_hton_drop_database(handlerton* hton, char* path)
+{
+  MRN_DBUG_ENTER_FUNCTION();
+  mrn_db_manager->drop(path);
+  DBUG_VOID_RETURN;
+}
+#endif
 
 #ifndef MRN_MARIADB_P
 #  define MRN_HANDLERTON_CLOSE_CONNECTION_NEED_THREAD_DATA_RESET

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -1547,6 +1547,60 @@ static handler* mrn_hton_handler_create(handlerton* hton,
   DBUG_RETURN(new_handler);
 }
 
+/*
+ * MySQL passes "path" in one of the following forms:
+ *
+ * - "./${db}/${table}"
+ * - "./${db}/"
+ *
+ * This "path" is generated base on "mysql_data_home" by
+ * "build_table_filename()" in MySQL.
+ * "mysql_data_home" is defined as:
+ *
+ *   "char *mysql_data_home = const_cast<char*>(".");"
+ *
+ * Therefore, "mysql_data_home" is always ".", and "path" always has one of
+ * the above forms.
+ *
+ * Mroonga handles these forms in the "PathMapper" class.
+ * "PathMapper::db_name()" and "PathMapper::db_path()" translate "path" into
+ * Mroonga's db name and db path as follows:
+ *
+ * "PathMapper::db_name()":
+ *
+ * - "./${db}/${table}" => "${db}"
+ * - "./${db}/"         => "${db}"
+ *
+ * "PathMapper::db_path()":
+ *
+ * - "./${db}/${table}" => "${db}.mrn"
+ * - "./${db}/"         => "${db}.mrn"
+ *
+ * Therefore, the expected behavior of "PathMapper::db_name()" is to return
+ * "${db}", and the expected behavior of "PathMapper::db_path()" is to return
+ * "${db}.mrn".
+ *
+ * In Mysql 9.7, "schema_name"(e.g."${db}") is passed to
+ * "mrn_hton_drop_database()" instead of "path"(e.g."./${db}/").
+ *
+ * If PathMapper is given "schema_name" instead of "path", the behavior is:
+ *
+ * "PathMapper::db_name()":
+ *
+ * - "${db}" => "${db}"
+ *
+ * "PathMapper::db_path()":
+ *
+ * "${db}" => "${db}.mrn"
+ *
+ * "mysql_data_home_path" only set in the MariaDB.
+ *
+ * Therefore, "PathMapper" behaves correctly whether MySQL passes "path" or
+ * "schema_name".
+ *
+ * For these reasons, this change only updates the argument type and name of
+ * this function.
+ */
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 static void mrn_hton_drop_database(handlerton* hton, const char* schema_name)
 {

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -1044,11 +1044,11 @@ static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
 #endif
 
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
-#  define MRN_MULTI_EQ_FUNC MULTI_EQ_FUNC
+#  define MRN_MULTI_EQ_FUNC           MULTI_EQ_FUNC
 #  define MRN_SCHEMA_NAME_DECLARATION const char* schema_name
-#  define MRN_SCHEMA_NAME (schema_name)
+#  define MRN_SCHEMA_NAME             (schema_name)
 #else
-#  define MRN_MULTI_EQ_FUNC MULT_EQUAL_FUNC
+#  define MRN_MULTI_EQ_FUNC           MULT_EQUAL_FUNC
 #  define MRN_SCHEMA_NAME_DECLARATION char* path
 #  define MRN_SCHEMA_NAME             (path)
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -1045,6 +1045,10 @@ static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
 
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 #  define MRN_MULTI_EQ_FUNC MULTI_EQ_FUNC
+#  define MRN_SCHEMA_NAME_DECLARATION const char* schema_name
+#  define MRN_SCHEMA_NAME (schema_name)
 #else
 #  define MRN_MULTI_EQ_FUNC MULT_EQUAL_FUNC
+#  define MRN_SCHEMA_NAME_DECLARATION char* path
+#  define MRN_SCHEMA_NAME             (path)
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -1044,11 +1044,7 @@ static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
 #endif
 
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
-#  define MRN_MULTI_EQ_FUNC           MULTI_EQ_FUNC
-#  define MRN_SCHEMA_NAME_DECLARATION const char* schema_name
-#  define MRN_SCHEMA_NAME             (schema_name)
+#  define MRN_MULTI_EQ_FUNC MULTI_EQ_FUNC
 #else
-#  define MRN_MULTI_EQ_FUNC           MULT_EQUAL_FUNC
-#  define MRN_SCHEMA_NAME_DECLARATION char* path
-#  define MRN_SCHEMA_NAME             (path)
+#  define MRN_MULTI_EQ_FUNC MULT_EQUAL_FUNC
 #endif


### PR DESCRIPTION
Ref: https://github.com/mysql/mysql-server/commit/33ebb9b09940a0db391e4e32b43e3c54c5bd922e

The following error is resolved by this modification.

```
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:2229:25: error: invalid conversion from ‘void (*)(handlerton*, char*)’ to ‘drop_database_t’ {aka ‘void (*)(handlerton*, const char*)’} [-fpermissive]
 2229 |   hton->drop_database = mrn_hton_drop_database;
      |                         ^~~~~~~~~~~~~~~~~~~~~~
      |                         |
      |                         void (*)(handlerton*, char*)
```

---

MySQL passes `path` in one of the following forms:

- "./${db}/${table}"
- "./${db}/"

This `path` is generated base on `mysql_data_home` by `build_table_filename()` in MySQL.
`mysql_data_home` is defined as:

  - `char *mysql_data_home = const_cast<char*>(".");`

Therefore, `mysql_data_home` is always ".", and `path` always has one of the above forms.

Mroonga handles these forms in the `PathMapper` class.
`PathMapper::db_name()` and `PathMapper::db_path()` translate `path` into Mroonga's db name and db path as follows:

`PathMapper::db_name()`:

- "./${db}/${table}" => "${db}"
- "./${db}/"         => "${db}"

`PathMapper::db_path()`:

- "./${db}/${table}" => "${db}.mrn"
- "./${db}/"         => "${db}.mrn"

Therefore, the expected behavior of `PathMapper::db_name()` is to return "${db}", and the expected behavior of `PathMapper::db_path()` is to return "${db}.mrn".

In Mysql 9.7, `schema_name`(e.g."${db}") is passed to `mrn_hton_drop_database()` instead of `path`(e.g."./${db}/").

If `PathMapper` is given `schema_name` instead of `path`, the behavior is:

`PathMapper::db_name()`:

- "${db}" => "${db}"

`PathMapper::db_path()`:

- "${db}" => "${db}.mrn"

`mysql_data_home_path` only set in the MariaDB.

Therefore, `PathMapper` behaves correctly whether MySQL passes `path` or `schema_name`.

For these reasons, this change only updates the argument type and name of this function.