### PR TITLE
mysql-server-9.7: follow rename of Field_datetimef class

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12443,7 +12443,7 @@ int ha_mroonga::generic_store_bulk_datetime2(Field* field, grn_obj* buf)
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
   bool truncated = false;
-  Field_datetimef* datetimef_field = (Field_datetimef*)field;
+  MRN_FIELD_DATETIME* datetimef_field = (MRN_FIELD_DATETIME*)field;
   MYSQL_TIME mysql_time;
   MRN_FIELD_GET_TIME(datetimef_field, &mysql_time, current_thd);
   long long int time = 0;
@@ -13750,7 +13750,7 @@ int ha_mroonga::storage_encode_key_datetime2(Field* field,
   int error = 0;
   bool truncated = false;
 
-  Field_datetimef* datetime2_field = (Field_datetimef*)field;
+  MRN_FIELD_DATETIME* datetime2_field = (MRN_FIELD_DATETIME*)field;
   longlong packed_time =
     my_datetime_packed_from_binary(key, datetime2_field->decimals());
   MYSQL_TIME mysql_time;

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -4,7 +4,7 @@
   Copyright (C) 2010-2013 Kentoku SHIBA
   Copyright (C) 2011-2025 Sutou Kouhei <kou@clear-code.com>
   Copyright (C) 2013 Kenji Maruyama <mmmaru777@gmail.com>
-  Copyright (C) 2020-2021 Horimoto Yasuhiro <horimoto@clear-code.com>
+  Copyright (C) 2020 Horimoto Yasuhiro <horimoto@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -12443,9 +12443,9 @@ int ha_mroonga::generic_store_bulk_datetime2(Field* field, grn_obj* buf)
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
   bool truncated = false;
-  MRN_FIELD_DATETIME* datetimef_field = (MRN_FIELD_DATETIME*)field;
+  MRN_FIELD_DATETIME* datetime_field = (MRN_FIELD_DATETIME*)field;
   MYSQL_TIME mysql_time;
-  MRN_FIELD_GET_TIME(datetimef_field, &mysql_time, current_thd);
+  MRN_FIELD_GET_TIME(datetime_field, &mysql_time, current_thd);
   long long int time = 0;
   mrn::TimeConverter time_converter;
   if (!field->is_null()) {

--- a/lib/mrn_multiple_column_key_codec.cpp
+++ b/lib/mrn_multiple_column_key_codec.cpp
@@ -186,8 +186,8 @@ namespace mrn {
         if (is_null) {
           grn_time = 0;
         } else {
-          Field_datetimef* datetimef_field =
-            static_cast<Field_datetimef*>(field);
+          MRN_FIELD_DATETIME* datetimef_field =
+            static_cast<MRN_FIELD_DATETIME*>(field);
           long long int mysql_datetime_packed =
             my_datetime_packed_from_binary(current_mysql_key,
                                            datetimef_field->decimals());
@@ -306,7 +306,8 @@ namespace mrn {
         }
       } break;
       case TYPE_DATETIME2: {
-        Field_datetimef* datetimef_field = static_cast<Field_datetimef*>(field);
+        MRN_FIELD_DATETIME* datetimef_field =
+          static_cast<MRN_FIELD_DATETIME*>(field);
         long long int grn_time;
         grn_key_data_size = 8;
         decode_long_long_int(key_part, current_grn_key, &grn_time);

--- a/lib/mrn_multiple_column_key_codec.cpp
+++ b/lib/mrn_multiple_column_key_codec.cpp
@@ -186,11 +186,11 @@ namespace mrn {
         if (is_null) {
           grn_time = 0;
         } else {
-          MRN_FIELD_DATETIME* datetimef_field =
+          MRN_FIELD_DATETIME* datetime_field =
             static_cast<MRN_FIELD_DATETIME*>(field);
           long long int mysql_datetime_packed =
             my_datetime_packed_from_binary(current_mysql_key,
-                                           datetimef_field->decimals());
+                                           datetime_field->decimals());
           MYSQL_TIME mysql_time;
           TIME_from_longlong_datetime_packed(&mysql_time,
                                              mysql_datetime_packed);
@@ -306,7 +306,7 @@ namespace mrn {
         }
       } break;
       case TYPE_DATETIME2: {
-        MRN_FIELD_DATETIME* datetimef_field =
+        MRN_FIELD_DATETIME* datetime_field =
           static_cast<MRN_FIELD_DATETIME*>(field);
         long long int grn_time;
         grn_key_data_size = 8;
@@ -320,7 +320,7 @@ namespace mrn {
           mrn_TIME_to_longlong_datetime_packed(mysql_time);
         my_datetime_packed_to_binary(mysql_datetime_packed,
                                      current_mysql_key,
-                                     datetimef_field->decimals());
+                                     datetime_field->decimals());
       } break;
       case TYPE_BYTE_SEQUENCE:
         decode_sequence(key_part,

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -965,8 +965,9 @@ using TABLE_LIST = Table_ref;
 #  define MRN_HA_EXTRA_ABORT_COPY      HA_EXTRA_ABORT_ALTER_COPY
 #endif
 
+#include<sql/field.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
-#  define MRN_FIELD_DATETIME Field_datetime
+using MRN_FIELD_DATETIME = Field_datetime;
 #else
-#  define MRN_FIELD_DATETIME Field_datetimef
+using MRN_FIELD_DATETIME = Field_datetimef;
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -964,3 +964,14 @@ using TABLE_LIST = Table_ref;
 #  define MRN_HA_EXTRA_ABORT_COPY_NAME "HA_EXTRA_ABORT_ALTER_COPY"
 #  define MRN_HA_EXTRA_ABORT_COPY      HA_EXTRA_ABORT_ALTER_COPY
 #endif
+
+#if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
+#  define MRN_SCHEMA_NAME_DECLARATION const char* schema_name
+#  define MRN_SCHEMA_NAME             (schema_name)
+#  define MRN_FIELD_DATETIME          Field_datetime
+#else
+#  define MRN_SCHEMA_NAME_DECLARATION char* path
+#  define MRN_SCHEMA_NAME             (path)
+#  define MRN_FIELD_DATETIME          Field_datetimef
+#endif
+>>>>>>> d115f15b8 (mysql-server-9.7: follow rename of Field_datetimef class)

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -974,4 +974,3 @@ using TABLE_LIST = Table_ref;
 #  define MRN_SCHEMA_NAME             (path)
 #  define MRN_FIELD_DATETIME          Field_datetimef
 #endif
->>>>>>> d115f15b8 (mysql-server-9.7: follow rename of Field_datetimef class)

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -966,11 +966,7 @@ using TABLE_LIST = Table_ref;
 #endif
 
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
-#  define MRN_SCHEMA_NAME_DECLARATION const char* schema_name
-#  define MRN_SCHEMA_NAME             (schema_name)
 #  define MRN_FIELD_DATETIME          Field_datetime
 #else
-#  define MRN_SCHEMA_NAME_DECLARATION char* path
-#  define MRN_SCHEMA_NAME             (path)
 #  define MRN_FIELD_DATETIME          Field_datetimef
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -965,7 +965,7 @@ using TABLE_LIST = Table_ref;
 #  define MRN_HA_EXTRA_ABORT_COPY      HA_EXTRA_ABORT_ALTER_COPY
 #endif
 
-#include<sql/field.h>
+#include <sql/field.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using MRN_FIELD_DATETIME = Field_datetime;
 #else

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -966,7 +966,7 @@ using TABLE_LIST = Table_ref;
 #endif
 
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
-#  define MRN_FIELD_DATETIME          Field_datetime
+#  define MRN_FIELD_DATETIME Field_datetime
 #else
-#  define MRN_FIELD_DATETIME          Field_datetimef
+#  define MRN_FIELD_DATETIME Field_datetimef
 #endif


### PR DESCRIPTION
Ref: https://github.com/mysql/mysql-server/commit/9e75348dd1da20328867f7c27d917cf83d9fbe63

The following error is resolved by this modification.

```
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12446:3: error: ‘Field_datetimef’ was not declared in this scope; did you mean ‘Field_datetime’?
12446 |   Field_datetimef* datetimef_field = (Field_datetimef*)field;
      |   ^~~~~~~~~~~~~~~
      |   Field_datetime
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12446:20: error: ‘datetimef_field’ was not declared in this scope; did you mean ‘Datetime_val’?
12446 |   Field_datetimef* datetimef_field = (Field_datetimef*)field;
      |                    ^~~~~~~~~~~~~~~
      |                    Datetime_val
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12446:55: error: expected primary-expression before ‘)’ token
12446 |   Field_datetimef* datetimef_field = (Field_datetimef*)field;
      |                                                       ^
```