### PR TITLE
mysql-server-9.7: follow rename of Field_timestampf class

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12428,9 +12428,9 @@ int ha_mroonga::generic_store_bulk_timestamp2(Field* field, grn_obj* buf)
   int error = 0;
   int64_t grn_time = 0;
   if (!field->is_null()) {
-    MRN_FIELD_TIMESTAMP* timestamp_field =
-      static_cast<MRN_FIELD_TIMESTAMP*>(field);
-    mrn::TimestampFieldValueConverter<MRN_FIELD_TIMESTAMP> converter(
+    mrn_field_timestamp* timestamp_field =
+      static_cast<mrn_field_timestamp*>(field);
+    mrn::TimestampFieldValueConverter<mrn_field_timestamp> converter(
       timestamp_field);
     grn_time = converter.convert();
   }
@@ -13713,7 +13713,7 @@ int ha_mroonga::storage_encode_key_timestamp2(Field* field,
   int error = 0;
   bool truncated = false;
 
-  MRN_FIELD_TIMESTAMP* timestamp2_field = (MRN_FIELD_TIMESTAMP*)field;
+  mrn_field_timestamp* timestamp2_field = (mrn_field_timestamp*)field;
   MYSQL_TIME mysql_time;
 #ifdef MRN_TIMESTAMP_USE_MY_TIMEVAL
   struct my_timeval my_tm;

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12428,8 +12428,9 @@ int ha_mroonga::generic_store_bulk_timestamp2(Field* field, grn_obj* buf)
   int error = 0;
   int64_t grn_time = 0;
   if (!field->is_null()) {
-    Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
-    mrn::TimestampFieldValueConverter<Field_timestampf> converter(
+    MRN_FIELD_TIMESTAMP* timestamp_field =
+      static_cast<MRN_FIELD_TIMESTAMP*>(field);
+    mrn::TimestampFieldValueConverter<MRN_FIELD_TIMESTAMP> converter(
       timestamp_field);
     grn_time = converter.convert();
   }
@@ -13712,7 +13713,7 @@ int ha_mroonga::storage_encode_key_timestamp2(Field* field,
   int error = 0;
   bool truncated = false;
 
-  Field_timestampf* timestamp2_field = (Field_timestampf*)field;
+  MRN_FIELD_TIMESTAMP* timestamp2_field = (MRN_FIELD_TIMESTAMP*)field;
   MYSQL_TIME mysql_time;
 #ifdef MRN_TIMESTAMP_USE_MY_TIMEVAL
   struct my_timeval my_tm;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -968,8 +968,8 @@ using TABLE_LIST = Table_ref;
 #include <sql/field.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using MRN_FIELD_DATETIME = Field_datetime;
-using MRN_FIELD_TIMESTAMP = Field_timestamp;
+using mrn_field_timestamp = Field_timestamp;
 #else
 using MRN_FIELD_DATETIME = Field_datetimef;
-using MRN_FIELD_TIMESTAMP = Field_timestampf;
+using mrn_field_timestamp = Field_timestampf;
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -971,5 +971,5 @@ using MRN_FIELD_DATETIME = Field_datetime;
 using MRN_FIELD_TIMESTAMP = Field_timestamp;
 #else
 using MRN_FIELD_DATETIME = Field_datetimef;
-using MRN_FIELD_TIMESTAMP = Field_timestampf:
+using MRN_FIELD_TIMESTAMP = Field_timestampf;
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -968,6 +968,8 @@ using TABLE_LIST = Table_ref;
 #include <sql/field.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using MRN_FIELD_DATETIME = Field_datetime;
+using MRN_FIELD_TIMESTAMP = Field_timestamp;
 #else
 using MRN_FIELD_DATETIME = Field_datetimef;
+using MRN_FIELD_TIMESTAMP = Field_timestampf:
 #endif


### PR DESCRIPTION
Ref: https://github.com/mysql/mysql-server/commit/9e75348dd1da20328867f7c27d917cf83d9fbe63

The following error is resolved by this modification.

```
/home/horimoto/Work/free-software/mroonga.fork/ha_mroonga.cpp:12431:5: error: ‘Field_timestampf’ was not declared in this scope; did you mean ‘Field_timestamp’?
12431 |     Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
      |     ^~~~~~~~~~~~~~~~
      |     Field_timestamp
/mroonga.fork/ha_mroonga.cpp:12431:23: error: ‘timestamp_field’ was not declared in this scope
12431 |     Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
      |                       ^~~~~~~~~~~~~~~
/mroonga.fork/ha_mroonga.cpp:12431:53: error: ‘Field_timestampf’ does not name a type; did you mean ‘Field_timestamp’?
12431 |     Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
      |                                                     ^~~~~~~~~~~~~~~~
      |                                                     Field_timestamp
/mroonga.fork/ha_mroonga.cpp:12431:69: error: expected ‘>’ before ‘*’ token
12431 |     Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
      |                                                                     ^
/mroonga.fork/ha_mroonga.cpp:12431:69: error: expected ‘(’ before ‘*’ token
12431 |     Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
      |                                                                     ^
      |                                                                     (
/mroonga.fork/ha_mroonga.cpp:12431:70: error: expected primary-expression before ‘>’ token
12431 |     Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
      |                                                                      ^
/mroonga.fork/ha_mroonga.cpp:12431:78: error: expected ‘)’ before ‘;’ token
12431 |     Field_timestampf* timestamp_field = static_cast<Field_timestampf*>(field);
      |                                                                              ^
      |                                                                              )
/mroonga.fork/ha_mroonga.cpp:13715:3: error: ‘Field_timestampf’ was not declared in this scope; did you mean ‘Field_timestamp’?
13715 |   Field_timestampf* timestamp2_field = (Field_timestampf*)field;
      |   ^~~~~~~~~~~~~~~~
      |   Field_timestamp
/mroonga.fork/ha_mroonga.cpp:13715:21: error: ‘timestamp2_field’ was not declared in this scope
13715 |   Field_timestampf* timestamp2_field = (Field_timestampf*)field;
      |                     ^~~~~~~~~~~~~~~~
/mroonga.fork/ha_mroonga.cpp:13715:58: error: expected primary-expression before ‘)’ token
13715 |   Field_timestampf* timestamp2_field = (Field_timestampf*)field;
      |                                                          ^
```