### PR TITLE
refactor: use lowercase for types to prevent macro confusion

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12444,7 +12444,7 @@ int ha_mroonga::generic_store_bulk_datetime2(Field* field, grn_obj* buf)
   MRN_DBUG_ENTER_METHOD();
   int error = 0;
   bool truncated = false;
-  MRN_FIELD_DATETIME* datetime_field = (MRN_FIELD_DATETIME*)field;
+  mrn_field_datetime* datetime_field = (mrn_field_datetime*)field;
   MYSQL_TIME mysql_time;
   MRN_FIELD_GET_TIME(datetime_field, &mysql_time, current_thd);
   long long int time = 0;
@@ -13751,7 +13751,7 @@ int ha_mroonga::storage_encode_key_datetime2(Field* field,
   int error = 0;
   bool truncated = false;
 
-  MRN_FIELD_DATETIME* datetime2_field = (MRN_FIELD_DATETIME*)field;
+  mrn_field_datetime* datetime2_field = (mrn_field_datetime*)field;
   longlong packed_time =
     my_datetime_packed_from_binary(key, datetime2_field->decimals());
   MYSQL_TIME mysql_time;

--- a/lib/mrn_multiple_column_key_codec.cpp
+++ b/lib/mrn_multiple_column_key_codec.cpp
@@ -186,8 +186,8 @@ namespace mrn {
         if (is_null) {
           grn_time = 0;
         } else {
-          MRN_FIELD_DATETIME* datetime_field =
-            static_cast<MRN_FIELD_DATETIME*>(field);
+          mrn_field_datetime* datetime_field =
+            static_cast<mrn_field_datetime*>(field);
           long long int mysql_datetime_packed =
             my_datetime_packed_from_binary(current_mysql_key,
                                            datetime_field->decimals());
@@ -306,8 +306,8 @@ namespace mrn {
         }
       } break;
       case TYPE_DATETIME2: {
-        MRN_FIELD_DATETIME* datetime_field =
-          static_cast<MRN_FIELD_DATETIME*>(field);
+        mrn_field_datetime* datetime_field =
+          static_cast<mrn_field_datetime*>(field);
         long long int grn_time;
         grn_key_data_size = 8;
         decode_long_long_int(key_part, current_grn_key, &grn_time);

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -967,9 +967,9 @@ using TABLE_LIST = Table_ref;
 
 #include <sql/field.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
-using MRN_FIELD_DATETIME = Field_datetime;
+using mrn_field_datetime = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
 #else
-using MRN_FIELD_DATETIME = Field_datetimef;
+using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
 #endif


### PR DESCRIPTION
Renamed types to lowercase.
Uppercase names are reserved for #define macros to avoid ambiguity.