### PR TITLE
mysql-server-9.7: follow rename of Field_timef class

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -13782,7 +13782,7 @@ int ha_mroonga::storage_encode_key_time2(Field* field,
   int error = 0;
   bool truncated = false;
 
-  Field_timef* time2_field = (Field_timef*)field;
+  mrn_field_time* time2_field = (mrn_field_time*)field;
   longlong packed_time =
     my_time_packed_from_binary(key, time2_field->decimals());
   MYSQL_TIME mysql_time;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -969,7 +969,9 @@ using TABLE_LIST = Table_ref;
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using MRN_FIELD_DATETIME = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
+using mrn_field_time = Field_time;
 #else
 using MRN_FIELD_DATETIME = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
+using mrn_field_time = Field_timef;
 #endif


### PR DESCRIPTION
Ref: mysql/mysql-server@9e75348

The following error is resolved by this modification.

```
mroonga.fork/ha_mroonga.cpp:13785:3: error: ‘Field_timef’ was not declared in this scope; did you mean ‘Field_time’?
13785 |   Field_timef* time2_field = (Field_timef*)field;
      |   ^~~~~~~~~~~
      |   Field_time
mroonga.fork/ha_mroonga.cpp:13785:16: error: ‘time2_field’ was not declared in this scope
13785 |   Field_timef* time2_field = (Field_timef*)field;
      |                ^~~~~~~~~~~
mroonga.fork/ha_mroonga.cpp:13785:43: error: expected primary-expression before ‘)’ token
13785 |   Field_timef* time2_field = (Field_timef*)field;
      |                                           ^
```