### PR TITLE
mysql-compat: fix a wrong include path

### DIFF
--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -965,7 +965,11 @@ using TABLE_LIST = Table_ref;
 #  define MRN_HA_EXTRA_ABORT_COPY      HA_EXTRA_ABORT_ALTER_COPY
 #endif
 
-#include <sql/field.h>
+#if defined(MRN_MARIADB_P)
+#  include <field.h>
+#else
+#  include <sql/field.h>
+#endif
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using MRN_FIELD_DATETIME = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -965,11 +965,7 @@ using TABLE_LIST = Table_ref;
 #  define MRN_HA_EXTRA_ABORT_COPY      HA_EXTRA_ABORT_ALTER_COPY
 #endif
 
-#if defined(MRN_MARIADB_P)
-#  include <field.h>
-#else
-#  include <sql/field.h>
-#endif
+#include <field.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using MRN_FIELD_DATETIME = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;


### PR DESCRIPTION
This fix the following error:

```
In file included from /root/rpmbuild/BUILD/mroonga-16.02/udf/mrn_udf_snippet.cpp:24:
/root/rpmbuild/BUILD/mroonga-16.02/mrn_mysql_compat.h:968:10: fatal error: sql/field.h: No such file or directory
 #include <sql/field.h>
          ^~~~~~~~~~~~~
```