### PR TITLE
mysql-test: don't use "&&" in condition; likely unsupported

### DIFF
--- a/mysql-test/mroonga/include/mroonga/have_old_mode_2_digit_year.inc
+++ b/mysql-test/mroonga/include/mroonga/have_old_mode_2_digit_year.inc
@@ -20,9 +20,11 @@
 --source ../../include/mroonga/check_mariadb.inc
 
 --disable_query_log
-if ($mariadb && $version_13_0_or_later) {
+if ($mariadb) {
+  if ($version_13_0_or_later) {
 --disable_warnings
-  set old_mode=2_DIGIT_YEAR;
+    set old_mode=2_DIGIT_YEAR;
 --enable_warnings
+  }
 }
 --enable_query_log


### PR DESCRIPTION
This fix the following error:

```
  CURRENT_TEST: plugin/mroonga/storage/column/year.two_digit
  mysqltest: In included file "./plugin/mroonga/storage/column/year/t/../../../../include/mroonga/have_old_mode_2_digit_year.inc": 
  included from ./plugin/mroonga/storage/column/year/t/two_digit.test at line 23:
  At line 23: Found junk '&& $version_13_0_or_later' after $variable in condition
```