### PR TITLE
mysql-server-9.7: follow Field_newdate class rename

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12497,7 +12497,7 @@ int ha_mroonga::generic_store_bulk_new_date(Field* field, grn_obj* buf)
   bool truncated = false;
   long long int time = 0;
   if (!field->is_null()) {
-    auto newdate_field = static_cast<Field_newdate*>(field);
+    auto newdate_field = static_cast<mrn_field_date*>(field);
     MYSQL_TIME mysql_date;
     MRN_FIELD_GET_TIME(newdate_field, &mysql_date, current_thd);
     mrn::TimeConverter time_converter;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -970,8 +970,10 @@ using TABLE_LIST = Table_ref;
 using mrn_field_datetime = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
+using mrn_field_date = Field_date;
 #else
 using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
+using mrn_field_date = Field_newdate;
 #endif


### PR DESCRIPTION
Ref: https://github.com/mysql/mysql-server/commit/421d9793d7373051a499963d19d886051d9fe5ef

The following error is resolved by this modification.

```
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12500:38: error: ‘Field_newdate’ does not name a type; did you mean ‘Field_date’?
12500 |     auto newdate_field = static_cast<Field_newdate*>(field);
      |                                      ^~~~~~~~~~~~~
      |                                      Field_date
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12500:51: error: expected ‘>’ before ‘*’ token
12500 |     auto newdate_field = static_cast<Field_newdate*>(field);
      |                                                   ^
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12500:51: error: expected ‘(’ before ‘*’ token
12500 |     auto newdate_field = static_cast<Field_newdate*>(field);
      |                                                   ^
      |                                                   (
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12500:52: error: expected primary-expression before ‘>’ token
12500 |     auto newdate_field = static_cast<Field_newdate*>(field);
      |                                                    ^
/root/rpmbuild/BUILD/mroonga-16.02/ha_mroonga.cpp:12500:60: error: expected ‘)’ before ‘;’ token
12500 |     auto newdate_field = static_cast<Field_newdate*>(field);
      |                                                            ^
      |                                                            )
```