### PR TITLE
mysql-server-9.7: follow refactor TIME handling

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -13784,7 +13784,7 @@ int ha_mroonga::storage_encode_key_time2(Field* field,
 
   mrn_field_time* time2_field = (mrn_field_time*)field;
   MYSQL_TIME mysql_time;
-  MRN_LOAD_TIME(key, time2_field, mysql_time);
+  mysql_time = mrn_field_time_load_from_key(key, time2_field);
   mrn::TimeConverter time_converter;
   long long int grn_time =
     time_converter.mysql_time_to_grn_time(&mysql_time, &truncated);

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -13783,8 +13783,7 @@ int ha_mroonga::storage_encode_key_time2(Field* field,
   bool truncated = false;
 
   mrn_field_time* time2_field = (mrn_field_time*)field;
-  MYSQL_TIME mysql_time;
-  mysql_time = mrn_field_time_load_from_key(key, time2_field);
+  MYSQL_TIME mysql_time = mrn_field_time_load_from_key(key, time2_field);
   mrn::TimeConverter time_converter;
   long long int grn_time =
     time_converter.mysql_time_to_grn_time(&mysql_time, &truncated);

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -13783,10 +13783,8 @@ int ha_mroonga::storage_encode_key_time2(Field* field,
   bool truncated = false;
 
   mrn_field_time* time2_field = (mrn_field_time*)field;
-  longlong packed_time =
-    my_time_packed_from_binary(key, time2_field->decimals());
   MYSQL_TIME mysql_time;
-  TIME_from_longlong_time_packed(&mysql_time, packed_time);
+  MRN_LOAD_TIME(key, time2_field, mysql_time);
   mrn::TimeConverter time_converter;
   long long int grn_time =
     time_converter.mysql_time_to_grn_time(&mysql_time, &truncated);

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -971,9 +971,23 @@ using mrn_field_datetime = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
+
+#  define MRN_LOAD_TIME(key, field_time, mysq_time)                            \
+    do {                                                                       \
+      Time_val time;                                                           \
+      Time_val::load_time(key, field_time->decimals(), &time);                 \
+      mysql_time = MYSQL_TIME(time);                                           \
+    } while (false)
 #else
 using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
 using mrn_field_date = Field_newdate;
+
+#  define MRN_LOAD_TIME(key, field_time, mysq_time)                            \
+    do {                                                                       \
+      longlong packed_time =                                                   \
+        my_time_packed_from_binary(key, field_time->decimals());               \
+      TIME_from_longlong_time_packed(&mysql_time, packed_time);                \
+    } while (false)
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -972,7 +972,7 @@ using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
 
-#  define MRN_LOAD_TIME(key, field_time, mysq_time)                            \
+#  define MRN_LOAD_TIME(key, field_time, mysql_time)                            \
     do {                                                                       \
       Time_val time;                                                           \
       Time_val::load_time(key, field_time->decimals(), &time);                 \

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -972,22 +972,25 @@ using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
 
-#  define MRN_LOAD_TIME(key, field_time, mysql_time)                            \
-    do {                                                                       \
-      Time_val time;                                                           \
-      Time_val::load_time(key, field_time->decimals(), &time);                 \
-      mysql_time = MYSQL_TIME(time);                                           \
-    } while (false)
+static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
+                                                      mrn_field_time* field)
+{
+  Time_val time;
+  Time_val::load_time(key, field->decimals(), &time);
+  return MYSQL_TIME(time);
+}
 #else
 using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
 using mrn_field_date = Field_newdate;
 
-#  define MRN_LOAD_TIME(key, field_time, mysq_time)                            \
-    do {                                                                       \
-      longlong packed_time =                                                   \
-        my_time_packed_from_binary(key, field_time->decimals());               \
-      TIME_from_longlong_time_packed(&mysql_time, packed_time);                \
-    } while (false)
+static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
+                                                      mrn_field_time* field)
+{
+  MYSQL_TIME mysql_time;
+  longlong packed_time = my_time_packed_from_binary(key, field->decimals());
+  TIME_from_longlong_time_packed(&mysql_time, packed_time);
+  return mysql_time;
+}
 #endif


### PR DESCRIPTION
Ref: https://github.com/mysql/mysql-server/commit/6b5b6f5c407c49e727bc73bdc41dd71a78657232

TIME_from_longlong_time_packed() and my_time_packed_from_binary() have been removed in MySQL 9.7.

The following error is resolved by this modification.

```
/mroonga/ha_mroonga.cpp:13787:5: error: ‘my_time_packed_from_binary’ was not declared in this scope; did you mean ‘my_datetime_packed_from_binary’?
13787 |     my_time_packed_from_binary(key, time2_field->decimals());
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |     my_datetime_packed_from_binary
/mroonga/ha_mroonga.cpp:13789:3: error: ‘TIME_from_longlong_time_packed’ was not declared in this scope; did you mean ‘TIME_from_longlong_datetime_packed’?
13789 |   TIME_from_longlong_time_packed(&mysql_time, packed_time);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   TIME_from_longlong_datetime_packed
```