### PR TITLE
mysql-server-9.7: follow rename Functype value

### DIFF
--- a/lib/mrn_count_skip_checker.cpp
+++ b/lib/mrn_count_skip_checker.cpp
@@ -226,7 +226,7 @@ namespace mrn {
         DBUG_RETURN(skippable);
       }
       break;
-    case Item_func::MULT_EQUAL_FUNC:
+    case Item_func::MRN_MULTI_EQ_FUNC:
 #ifdef MRN_HAVE_ITEM_EQUAL_FIELDS_ITERATOR
       {
         Item_equal *equal_item = static_cast<Item_equal *>(func_item);

--- a/lib/mrn_count_skip_checker.cpp
+++ b/lib/mrn_count_skip_checker.cpp
@@ -226,7 +226,7 @@ namespace mrn {
         DBUG_RETURN(skippable);
       }
       break;
-    case Item_func::MRN_MULTI_EQ_FUNC:
+    case MRN_MULTI_EQ_FUNC:
 #ifdef MRN_HAVE_ITEM_EQUAL_FIELDS_ITERATOR
       {
         Item_equal *equal_item = static_cast<Item_equal *>(func_item);

--- a/lib/mrn_count_skip_checker.cpp
+++ b/lib/mrn_count_skip_checker.cpp
@@ -226,7 +226,7 @@ namespace mrn {
         DBUG_RETURN(skippable);
       }
       break;
-    case MRN_MULTI_EQ_FUNC:
+    case Item_func::MRN_MULTI_EQ_FUNC:
 #ifdef MRN_HAVE_ITEM_EQUAL_FIELDS_ITERATOR
       {
         Item_equal *equal_item = static_cast<Item_equal *>(func_item);

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -966,14 +966,13 @@ using TABLE_LIST = Table_ref;
 #endif
 
 #include <field.h>
-#include <item_func.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using mrn_field_datetime = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
 
-constexpr Item_func::Functype MRN_MULTI_EQ_FUNC = Item_func::MULTI_EQ_FUNC;
+#define MRN_MULTI_EQ_FUNC MULTI_EQ_FUNC
 
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)
@@ -988,7 +987,7 @@ using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
 using mrn_field_date = Field_newdate;
 
-constexpr Item_func::Functype MRN_MULTI_EQ_FUNC = Item_func::MULT_EQUAL_FUNC;
+#define MRN_MULTI_EQ_FUNC MULT_EQUAL_FUNC
 
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -972,6 +972,8 @@ using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
 
+constexpr Functype MRN_MULTI_EQ_FUNC = MULTI_EQ_FUNC;
+
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)
 {
@@ -979,11 +981,14 @@ static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
   Time_val::load_time(key, field->decimals(), &time);
   return MYSQL_TIME(time);
 }
+
 #else
 using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
 using mrn_field_date = Field_newdate;
+
+constexpr Functype MRN_MULTI_EQ_FUNC = MULT_EQUAL_FUNC;
 
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -971,6 +971,7 @@ using mrn_field_datetime = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
+
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)
 {
@@ -983,6 +984,7 @@ using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
 using mrn_field_date = Field_newdate;
+
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)
 {

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -971,9 +971,6 @@ using mrn_field_datetime = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
-
-#define MRN_MULTI_EQ_FUNC MULTI_EQ_FUNC
-
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)
 {
@@ -986,9 +983,6 @@ using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
 using mrn_field_date = Field_newdate;
-
-#define MRN_MULTI_EQ_FUNC MULT_EQUAL_FUNC
-
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)
 {
@@ -997,4 +991,10 @@ static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
   TIME_from_longlong_time_packed(&mysql_time, packed_time);
   return mysql_time;
 }
+#endif
+
+#if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
+#  define MRN_MULTI_EQ_FUNC MULTI_EQ_FUNC
+#else
+#  define MRN_MULTI_EQ_FUNC MULT_EQUAL_FUNC
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -966,13 +966,14 @@ using TABLE_LIST = Table_ref;
 #endif
 
 #include <field.h>
+#include <item_func.h>
 #if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
 using mrn_field_datetime = Field_datetime;
 using mrn_field_timestamp = Field_timestamp;
 using mrn_field_time = Field_time;
 using mrn_field_date = Field_date;
 
-constexpr Functype MRN_MULTI_EQ_FUNC = MULTI_EQ_FUNC;
+constexpr Item_func::Functype MRN_MULTI_EQ_FUNC = Item_func::MULTI_EQ_FUNC;
 
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)
@@ -988,7 +989,7 @@ using mrn_field_timestamp = Field_timestampf;
 using mrn_field_time = Field_timef;
 using mrn_field_date = Field_newdate;
 
-constexpr Functype MRN_MULTI_EQ_FUNC = MULT_EQUAL_FUNC;
+constexpr Item_func::Functype MRN_MULTI_EQ_FUNC = Item_func::MULT_EQUAL_FUNC;
 
 static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
                                                       mrn_field_time* field)

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -982,7 +982,6 @@ static inline MYSQL_TIME mrn_field_time_load_from_key(const uchar* key,
   Time_val::load_time(key, field->decimals(), &time);
   return MYSQL_TIME(time);
 }
-
 #else
 using mrn_field_datetime = Field_datetimef;
 using mrn_field_timestamp = Field_timestampf;


### PR DESCRIPTION
Ref: https://github.com/mysql/mysql-server/commit/2fe245e177909cb87694f84baf1fa8a486d00c7c

MULT_EQUAL_FUNC is renamed to MULTI_EQ_FUNC in MySQL 9.7.

The following error is resolved by this modification.

```
/mroonga/lib/mrn_count_skip_checker.cpp: In member function ‘bool mrn::CountSkipChecker::is_skippable(Item_func*)’:
/mroonga/lib/mrn_count_skip_checker.cpp:229:21: error: ‘MULT_EQUAL_FUNC’ is not a member of ‘Item_func’
  229 |     case Item_func::MULT_EQUAL_FUNC:
      |                     ^~~~~~~~~~~~~~~
```