### PR TITLE
mysql-server-9.7: follow refactor TIME handring

### DIFF
--- a/lib/mrn_condition_converter.cpp
+++ b/lib/mrn_condition_converter.cpp
@@ -577,7 +577,7 @@ namespace mrn {
     Item* real_value_item = value_item->real_item();
     switch (field_item->field->type()) {
     case MYSQL_TYPE_TIME:
-      error = MRN_ITEM_GET_TIME(real_value_item, mysql_time, thread_);
+      error = mrn_item_get_time(real_value_item, mysql_time, thread_);
       break;
     case MYSQL_TYPE_YEAR:
       mysql_time->year = static_cast<int>(value_item->val_int());

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -750,13 +750,29 @@ using TABLE_LIST = Table_ref;
 #  define MRN_ITEM_IS_INT_TYPE(item)    ((item)->type() == Item::INT_ITEM)
 #endif
 
+#include <item.h>
 #ifdef MRN_MARIADB_P
-#  define MRN_ITEM_GET_TIME(item, time, thd)                                   \
-    ((item)->get_date((thd), (time), Time::Options((thd))))
+static inline bool mrn_item_get_time(Item* item, MYSQL_TIME* my_time, THD* thd)
+{
+  return item->get_date(thd, my_time, Time::Options(thd));
+}
+
 #  define MRN_ITEM_GET_DATE_FUZZY(item, time, thd)                             \
     ((item)->get_date((thd), (time), Time::Options(TIME_FUZZY_DATES, (thd))))
 #else
-#  define MRN_ITEM_GET_TIME(item, time, thd) ((item)->get_time((time)))
+static inline bool mrn_item_get_time(Item* item, MYSQL_TIME* my_time, THD* thd)
+{
+#  if MYSQL_VERSION_ID >= 90700
+  Time_val time;
+  bool result;
+  result = item->val_time(&time);
+  *my_time = MYSQL_TIME(time);
+  return result;
+#  else
+  return item->get_time(my_time);
+#  endif
+}
+
 #  define MRN_ITEM_GET_DATE_FUZZY(item, time, thd)                             \
     ((item)->get_date((time), TIME_FUZZY_DATE))
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -764,8 +764,7 @@ static inline bool mrn_item_get_time(Item* item, MYSQL_TIME* my_time, THD* thd)
 {
 #  if MYSQL_VERSION_ID >= 90700
   Time_val time;
-  bool result;
-  result = item->val_time(&time);
+  bool result = item->val_time(&time);
   *my_time = MYSQL_TIME(time);
   return result;
 #  else


### PR DESCRIPTION
Ref: mysql/mysql-server@6b5b6f5

Use Item::val_time() instead of Item::get_time() since MySQL 9.7. Item::get_time() is removed in MySQL 9.7.

The following error is resolved by this modification.

```
/mroonga/lib/mrn_condition_converter.cpp: In member function ‘bool mrn::ConditionConverter::get_time_value(const Item_field*, Item*, MYSQL_TIME*)’:
/mroonga/mrn_mysql_compat.h:759:55: error: ‘class Item’ has no member named ‘get_time’
  759 | #  define MRN_ITEM_GET_TIME(item, time, thd) ((item)->get_time((time)))
      |                                                       ^~~~~~~~
/mroonga/lib/mrn_condition_converter.cpp:580:15: note: in expansion of macro ‘MRN_ITEM_GET_TIME’
  580 |       error = MRN_ITEM_GET_TIME(real_value_item, mysql_time, thread_);
      |               ^~~~~~~~~~~~~~~~~
```