### PR TITLE
package almalinux-8: use gcc-toolset-12 to fix build errors

### DIFF
--- a/packages/mysql-community-8.4-mroonga/yum/almalinux-8/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/yum/almalinux-8/Dockerfile
@@ -4,7 +4,7 @@ FROM ${FROM}
 ARG DEBUG
 
 ENV \
-  SCL=gcc-toolset-11
+  SCL=gcc-toolset-12
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \


### PR DESCRIPTION
This pull request resolves the following error.

```
lto1: fatal error: bytecode stream in file '/usr/lib64/mysql/libmysqlservices.a' generated with LTO version 12.0 instead of the expected 11.2
```

This error occurs because `libmysqlservices.a` and `ha_mroonga.so` were built using different compiler versions.
Specifically, `libmysqlservices.a` was built via rpmbuild using gcc-toolset-12 with LTO enables.
`ha_mroonga.so` was built with gcc-toolset-11.

To fix this, this pull request uses gcc-toolset-12 to build `ha_mroonga.so`.