### PR TITLE
packages almalinux 9: add a missing dependency package

### DIFF
--- a/packages/mariadb-11.4-mroonga/yum/almalinux-9/Dockerfile
+++ b/packages/mariadb-11.4-mroonga/yum/almalinux-9/Dockerfile
@@ -32,6 +32,7 @@ RUN \
     libtool \
     make \
     pkgconfig \
+    selinux-policy-devel \
     sudo \
     wget \
     which && \

--- a/packages/mariadb-11.8-mroonga/yum/almalinux-9/Dockerfile
+++ b/packages/mariadb-11.8-mroonga/yum/almalinux-9/Dockerfile
@@ -32,6 +32,7 @@ RUN \
     libtool \
     make \
     pkgconfig \
+    selinux-policy-devel \
     sudo \
     wget \
     which && \


### PR DESCRIPTION
This is because the following change requires the "selinux-policy-devel" package to build [mariadb-columnstore-engine](https://github.com/mariadb-corporation/mariadb-columnstore-engine).

- https://github.com/mariadb-corporation/mariadb-columnstore-engine/commit/9a9d9e36567f936840b78c0f158815f8948bb60f

This modification resolves the following error.

```
CMake Error at storage/columnstore/columnstore/cmake/selinux_policy.cmake:40 (message):
  SELinux policy build requires '/usr/share/selinux/devel/Makefile'.  Please
  install 'selinux-policy-devel' (RHEL/Rocky >= 9) and re-run CMake.
Call Stack (most recent call first):
  storage/columnstore/columnstore/CMakeLists.txt:51 (include)


-- Configuring incomplete, errors occurred!
error: Bad exit status from /var/tmp/rpm-tmp.DNDA6y (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.DNDA6y (%build)
error: Bad exit status from /var/tmp/rpm-tmp.Vl8YoJ (%build)

    Bad exit status from /var/tmp/rpm-tmp.Vl8YoJ (%build)

RPM build errors:
```