### PR TITLE
packages almalinux 10: fix MySQL Server RPM install fails

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -161,7 +161,7 @@ function mroonga_can_be_registered_for_mysql_community_minimal() {
 
 # This is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
 # Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
-# Therefore, we exclude MariaDB 11.8 package from this precess.
+# Therefore, we exclude MariaDB 11.8 package from this process.
 if [ "${major_version}" -ge 10 ] ; then
   echo "exclude=mariadb11.8*" | sudo tee -a /etc/dnf/dnf.conf
 fi

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -159,6 +159,13 @@ function mroonga_can_be_registered_for_mysql_community_minimal() {
   mysqladmin -u root -p${auto_generated_password} shutdown
 }
 
+# This is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
+# Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
+# Therefore, we exclude MariaDB 11.8 package from this precess.
+if [ "${major_version}" -ge 10 ] ; then
+  echo "exclude=mariadb11.8*" | sudo tee -a /etc/dnf/dnf.conf
+fi
+
 repositories_dir=/host/packages/${package}/yum/repositories
 sudo ${DNF} install -y \
   ${repositories_dir}/${os}/${major_version}/*/Packages/*.rpm


### PR DESCRIPTION
This is a workaround.
Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10 as below:

```
Error: Transaction test error:
  file /usr/bin/mysqldumpslow conflicts between attempted installs of mysql-community-server-8.4.9-1.el10.x86_64 and mariadb11.8-client-utils-3:11.8.6-2.el10_2.alma.1.noarch
  file /usr/share/man/man1/mysqldumpslow.1.gz conflicts between attempted installs of mysql-community-server-8.4.9-1.el10.x86_64 and mariadb11.8-client-utils-3:11.8.6-2.el10_2.alma.1.noarch
  file /usr/bin/innochecksum conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/myisam_ftdump conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/myisamchk conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/myisamlog conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/myisampack conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/mysql_secure_installation conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/perror conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/lib/systemd/system/mysqld.service conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/sbin/mysqld conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/innochecksum.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/myisam_ftdump.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/myisamchk.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/myisamlog.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/myisampack.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysql_secure_installation.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/perror.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man8/mysqld.8.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /var/lib/mysql conflicts between attempted installs of mariadb11.8-server-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/my_print_defaults conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/mysql conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/bin/mysql_tzinfo_to_sql conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/bin/mysqladmin conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/bin/mysqlbinlog conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/bin/mysqlcheck conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/bin/mysqldump conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/bin/mysqlimport conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/bin/mysqlshow conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/bin/mysqlslap conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/my_print_defaults.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysql.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysql_tzinfo_to_sql.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysqladmin.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysqlbinlog.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysqlcheck.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysqldump.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysqlimport.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysqlshow.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
  file /usr/share/man/man1/mysqlslap.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.6-2.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
```

Therefore, we exclude MariaDB 11.8 package.