### PR TITLE
packages almalinux 10: disable default mysql8.4 packages to install mysql-community-server

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -159,11 +159,16 @@ function mroonga_can_be_registered_for_mysql_community_minimal() {
   mysqladmin -u root -p${auto_generated_password} shutdown
 }
 
-# This is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
-# Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
-# Therefore, we exclude MariaDB 11.8 package from this process.
 if [ "${major_version}" -ge 10 ] ; then
+  # This is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
+  # Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
+  # Therefore, we exclude MariaDB 11.8 package from this process.
   echo "exclude=mariadb11.8*" | sudo tee -a /etc/dnf/dnf.conf
+  # In AlmaLinux 10, DNF Modularity has been removed.
+  # As a result, we can not longer disable the mysql8.4 packages which is provided AppStream via "dnf module disable".
+  # Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf.
+  # Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation.
+  sudo sed -i '$ s/$/ mysql8.4*/' /etc/dnf/dnf.conf
 fi
 
 repositories_dir=/host/packages/${package}/yum/repositories

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -160,15 +160,15 @@ function mroonga_can_be_registered_for_mysql_community_minimal() {
 }
 
 if [ "${major_version}" -ge 10 ] ; then
-  # This is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
+  # "exclude=mariadb11.8*" is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
   # Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
   # Therefore, we exclude MariaDB 11.8 package from this process.
-  echo "exclude=mariadb11.8*" | sudo tee -a /etc/dnf/dnf.conf
-  # In AlmaLinux 10, DNF Modularity has been removed.
+  #
+  # "exclude=mysql8.4*" is not a workaround. In AlmaLinux 10, DNF Modularity has been removed.
   # As a result, we can not longer disable the mysql8.4 packages which is provided AppStream via "dnf module disable".
   # Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf.
   # Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation.
-  sudo sed -i '$ s/$/ mysql8.4*/' /etc/dnf/dnf.conf
+  echo "exclude=mariadb11.8* mysql8.4*" | sudo tee -a /etc/dnf/dnf.conf
 fi
 
 repositories_dir=/host/packages/${package}/yum/repositories

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -165,7 +165,7 @@ if [ "${major_version}" -ge 10 ] ; then
   # Therefore, we exclude MariaDB 11.8 package from this process.
   #
   # "exclude=mysql8.4*" is not a workaround. In AlmaLinux 10, DNF Modularity has been removed.
-  # As a result, we can not longer disable the mysql8.4 packages which is provided AppStream via "dnf module disable".
+  # As a result, we can no longer disable the mysql8.4 packages that are provided by AppStream via "dnf module disable".
   # Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf.
   # Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation.
   echo "exclude=mariadb11.8* mysql8.4*" | sudo tee -a /etc/dnf/dnf.conf


### PR DESCRIPTION
In AlmaLinux 10, DNF Modularity has been removed.
As a result, we can not longer disable the mysql8.4 packages which is provided AppStream via "dnf module disable". Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf. Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation as below.

```
  Error: Transaction test error:
    file /usr/bin/mysql conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysql_config_editor conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysqladmin conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysqlbinlog conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysqlcheck conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysqldump conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysqlimport conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysqlshow conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysqlslap conflicts between attempted installs of mysql8.4-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/ibd2sdi conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/innochecksum conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/my_print_defaults conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/myisam_ftdump conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/myisamchk conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/myisamlog conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/myisampack conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/mysql_migrate_keyring conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-client-8.4.9-1.el10.x86_64
    file /usr/bin/mysql_secure_installation conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/mysql_tzinfo_to_sql conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/mysqld_pre_systemd conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/bin/perror conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib/systemd/system/mysqld.service conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib/systemd/system/mysqld@.service conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/adt_null.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/auth_socket.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_audit_api_message_emit.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_keyring_file.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_log_filter_dragnet.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_log_sink_json.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_log_sink_syseventlog.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_mysqlbackup.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_query_attributes.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_reference_cache.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/component_validate_password.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/connection_control.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/ddl_rewriter.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/group_replication.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/ha_example.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/ha_mock.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/keyring_udf.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/libpluginmecab.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/locking_service.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/mypluglib.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/mysql_clone.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/mysql_no_login.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/rewrite_example.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/rewriter.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/semisync_master.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/semisync_replica.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/semisync_slave.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/semisync_source.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/validate_password.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/lib64/mysql/plugin/version_token.so conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /usr/sbin/mysqld conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /var/lib/mysql conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
    file /var/lib/mysql-keyring conflicts between attempted installs of mysql8.4-server-8.4.9-1.el10_2.alma.1.x86_64 and mysql-community-server-8.4.9-1.el10.x86_64
```