### PR TITLE
packages apt: remove workaround for mysql-apt-config.deb

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -126,12 +126,7 @@ case ${package} in
     mysql_test_dir=/usr/share/mariadb/mariadb-test
     ;;
   mysql-community-*)
-    # This is a workaround.
-    # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-    # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-    # See: https://bugs.mysql.com/bug.php?id=119212
-    wget -O mysql-apt-config.deb \
-         https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb
+    wget https://repo.mysql.com/mysql-apt-config.deb
     mysql_community_install_mysql_apt_config
     mysql_package_prefix=mysql
     client_dev_package=libmysqlclient-dev

--- a/packages/mysql-community-8.0-mroonga/apt/debian-bookworm/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/debian-bookworm/Dockerfile
@@ -22,11 +22,7 @@ RUN \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is a workaround.
-  # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212
-  wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/ubuntu-jammy/Dockerfile
@@ -22,11 +22,7 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is a workaround.
-  # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212
-  wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.0-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-community-8.0-mroonga/apt/ubuntu-noble/Dockerfile
@@ -21,11 +21,7 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is a workaround.
-  # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212
-  wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.4-mroonga/apt/debian-bookworm/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/apt/debian-bookworm/Dockerfile
@@ -22,11 +22,7 @@ RUN \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is a workaround.
-  # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212
-  wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.4-mroonga/apt/debian-trixie/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/apt/debian-trixie/Dockerfile
@@ -23,11 +23,7 @@ RUN \
   wget https://packages.apache.org/artifactory/arrow/${distribution}/apache-arrow-apt-source-latest-${code_name}.deb && \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-${code_name}.deb && \
   wget https://packages.groonga.org/${distribution}/groonga-apt-source-latest-${code_name}.deb && \
-  # This is a workaround.
-  # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212
-  wget https://repo.mysql.com/apt/${distribution}/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.4-mroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/apt/ubuntu-jammy/Dockerfile
@@ -22,11 +22,7 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is a workaround.
-  # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212
-  wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \

--- a/packages/mysql-community-8.4-mroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/mysql-community-8.4-mroonga/apt/ubuntu-noble/Dockerfile
@@ -21,11 +21,7 @@ RUN \
     wget && \
   add-apt-repository -y ppa:groonga/ppa && \
   wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
-  # This is a workaround.
-  # We can use mysql-apt-config.deb when https://repo.mysql.com/mysql-apt-config.deb is updated to the latest version.
-  # The https://repo.mysql.com/mysql-apt-config.deb updating has already been reported to upstream.
-  # See: https://bugs.mysql.com/bug.php?id=119212
-  wget https://repo.mysql.com/apt/$(lsb_release --id --short | tr 'A-Z' 'a-z')/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb && \
+  wget https://repo.mysql.com/mysql-apt-config.deb && \
   apt install -y -V --no-install-recommends ${quiet} \
     ./*.deb && \
   rm *.deb && \


### PR DESCRIPTION
We can use the latest mysql-apt-config via https://repo.mysql.com/mysql-apt-config.deb.