### PR TITLE
package: fix the logic for getting the latest version of Percona Server

### DIFF
--- a/packages/mroonga-package-task.rb
+++ b/packages/mroonga-package-task.rb
@@ -288,13 +288,11 @@ class MroongaPackageTask < PackagesGroongaOrgPackageTask
     index_html = URI.open(srpms_url) do |response|
       response.read
     end
-    latest_target_srpm =
-      index_html.
-        scan(/href="(.+?)"/i).
-        flatten.
-        grep(/\Apercona-server-/).
-        last
-    latest_target_srpm[/\Apercona-server-(\d+\.\d+\.\d+-\d+\.\d+)/, 1]
+    index_html.
+      scan(/href="(.+?)"/i).
+      flatten.
+      filter_map {|href| href[/\Apercona-server-(\d+\.\d+\.\d+-\d+\.\d+)/, 1]}.
+      max_by {|version| Gem::Version.new(version)}
   end
 
   def percona_server_rpm_version


### PR DESCRIPTION
In the current logic, when both `8.4.8-8.1` and `8.4.10-10.1` exist, `8.4.8-8.1` is selected as the latest.