### PR TITLE
ci linux: skip Percona Server 8.4 build temporarily

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -181,12 +181,14 @@ jobs:
             test-image: "images:almalinux/9"
 
           # Percona Server 8.4
-          - os: almalinux-9
-            package: percona-server-8.4
-            test-image: "images:almalinux/9"
-          - os: almalinux-10
-            package: percona-server-8.4
-            test-image: "images:almalinux/10"
+          # This is a temporary workaround.
+          # The build fails due to what appears to be an upstream issue, so we skip it for now.
+          # - os: almalinux-9
+          #   package: percona-server-8.4
+          #   test-image: "images:almalinux/9"
+          # - os: almalinux-10
+          #   package: percona-server-8.4
+          #   test-image: "images:almalinux/10"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
       GROONGA_REPOSITORY: ${{ github.workspace }}/groonga


### PR DESCRIPTION
It fails with the following error.

```
...
-- Generating done (2.2s)
-- Build files have been written to: /root/rpmbuild/BUILD/percona-server-8.4.10-10/release
+ pushd release
~/rpmbuild/BUILD/percona-server-8.4.10-10/release ~/rpmbuild/BUILD/percona-server-8.4.10-10
++ readlink mysql-test/var
+ rm -r
rm: missing operand
Try 'rm --help' for more information.
error: Bad exit status from /var/tmp/rpm-tmp.WPWXDQ (%build)
    Macro expanded in comment on line 28: %{_libdir}/mysql/private/ and

    Macro expanded in comment on line 29: %{_libdir}/mysqlrouter/private/. rpm's default build-id link mode rejects
...
```