### PR TITLE
package percona-server-8.4: Don't enable PGO

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -181,14 +181,12 @@ jobs:
             test-image: "images:almalinux/9"
 
           # Percona Server 8.4
-          # This is a temporary workaround.
-          # The build fails due to what appears to be an upstream issue, so we skip it for now.
-          # - os: almalinux-9
-          #   package: percona-server-8.4
-          #   test-image: "images:almalinux/9"
-          # - os: almalinux-10
-          #   package: percona-server-8.4
-          #   test-image: "images:almalinux/10"
+          - os: almalinux-9
+            package: percona-server-8.4
+            test-image: "images:almalinux/9"
+          - os: almalinux-10
+            package: percona-server-8.4
+            test-image: "images:almalinux/10"
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
       GROONGA_REPOSITORY: ${{ github.workspace }}/groonga

--- a/packages/percona-server-8.4-mroonga/yum/percona-server-8.4-mroonga.spec.in
+++ b/packages/percona-server-8.4-mroonga/yum/percona-server-8.4-mroonga.spec.in
@@ -58,7 +58,7 @@ sed -i'' -e 's/^  make /  # make /' ~/rpmbuild/SPECS/%{_mysql_spec_file}
 sed -i'' -e 's/^  cmake3 /  cmake /' ~/rpmbuild/SPECS/%{_mysql_spec_file}
 
 %build
-rpmbuild -bc ~/rpmbuild/SPECS/%{_mysql_spec_file}
+rpmbuild -bc --define "without_pgo 1" ~/rpmbuild/SPECS/%{_mysql_spec_file}
 mysql_source=$HOME/rpmbuild/BUILD/percona-server-%{_mysql_version}-%{_percona_server_version}/percona-server-%{_mysql_version}-%{_percona_server_version}
 mysql_build=$HOME/rpmbuild/BUILD/percona-server-%{_mysql_version}-%{_percona_server_version}/release
 make %_smp_mflags -C ${mysql_build}/utilities GenError


### PR DESCRIPTION
If we enable PGO (Profile-Guided Optimization), Percona Server will be built twice. It causes a build error because we don't provide `mysql-test/var` directory that needs PGO enabled build.

https://github.com/percona/percona-server/blob/aa9cdab9f209d9e60886a1320b2d7111bb796a56/build-ps/percona-server.spec#L690-L761

Mroonga doesn't need full Percona Server build. So our build system builds only needed parts to reduce build time. PGO enabled build is also not needed for us.