### PR TITLE
ci install test: disable default mysql8.4 packages to install percona-server-8.4-mroonga

### DIFF
--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -75,6 +75,20 @@ REPO
     ;;
 esac
 
+# "exclude=mariadb11.8*" is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
+# Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
+# Therefore, we exclude MariaDB 11.8 package from this process.
+#
+# "exclude=mysql8.4*" is not a workaround. In AlmaLinux 10, DNF Modularity has been removed.
+# As a result, we can no longer disable the mysql8.4 packages that are provided by AppStream via "dnf module disable".
+# Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf.
+# Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation.
+case "${package}" in
+  *-8.4-*)
+    echo "exclude=mariadb11.8* mysql8.4*" | sudo tee -a /etc/dnf/dnf.conf
+    ;;
+esac
+
 sudo ${DNF_INSTALL} "${package}"
 
 case "${package}" in

--- a/packages/yum/install_test.sh
+++ b/packages/yum/install_test.sh
@@ -7,6 +7,22 @@ package="$1"
 os_version=$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)
 
 case "${os_version}" in
+  10)
+    DNF_INSTALL="dnf install -y"
+    # "exclude=mariadb11.8*" is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
+    # Now, MySQL/Percona Server 8.4 RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
+    # Therefore, we exclude MariaDB 11.8 package from this process.
+    #
+    # "exclude=mysql8.4*" is not a workaround. In AlmaLinux 10, DNF Modularity has been removed.
+    # As a result, we can no longer disable the mysql8.4 packages that are provided by AppStream via "dnf module disable".
+    # Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf.
+    # Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation.
+    case "${package}" in
+      *-8.4-*)
+        echo "exclude=mariadb11.8* mysql8.4*" | sudo tee -a /etc/dnf/dnf.conf
+        ;;
+    esac
+    ;;
   8)
     DNF_INSTALL="dnf install -y --enablerepo=powertools"
     sudo dnf module -y disable mysql
@@ -72,20 +88,6 @@ REPO
       sudo percona-release enable-only ps-${percona_package_version}-lts release
     fi
     sudo ${DNF_INSTALL} percona-icu-data-files
-    ;;
-esac
-
-# "exclude=mariadb11.8*" is a workaround. We can remove this when https://bugs.mysql.com/bug.php?id=120594 is resolved.
-# Now, MySQL Server RPM installation fails due to MariaDB 11.8 package conflicts in AlmaLinux 10.
-# Therefore, we exclude MariaDB 11.8 package from this process.
-#
-# "exclude=mysql8.4*" is not a workaround. In AlmaLinux 10, DNF Modularity has been removed.
-# As a result, we can no longer disable the mysql8.4 packages that are provided by AppStream via "dnf module disable".
-# Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf.
-# Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation.
-case "${package}" in
-  *-8.4-*)
-    echo "exclude=mariadb11.8* mysql8.4*" | sudo tee -a /etc/dnf/dnf.conf
     ;;
 esac
 


### PR DESCRIPTION
This is the same issue as #1098.

In AlmaLinux 10, DNF Modularity has been removed.
As a result, we can not longer disable the mysql8.4 packages which is provided AppStream via "dnf module disable". Since we only need mysql-community-server, we exclude the default mysql8.4 packages in /etc/dnf/dnf.conf. Otherwise, a conflict will occur between mysql8.4 and mysql-community-server, preventing the installation as below.

```
Error: Transaction test error:
  file /usr/bin/mysqldumpslow conflicts between attempted installs of percona-server-server-8.4.8-8.1.el10.x86_64 and mariadb11.8-client-utils-3:11.8.8-1.el10_2.noarch
  file /usr/share/man/man1/mysqldumpslow.1.gz conflicts between attempted installs of percona-server-server-8.4.8-8.1.el10.x86_64 and mariadb11.8-client-utils-3:11.8.8-1.el10_2.noarch
  file /usr/bin/innochecksum conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/myisam_ftdump conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/myisamchk conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/myisamlog conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/myisampack conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysql_secure_installation conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqld_safe conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/perror conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/lib/systemd/system/mysqld.service conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/sbin/mysqld conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/innochecksum.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/myisam_ftdump.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/myisamchk.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/myisamlog.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/myisampack.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysql_secure_installation.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/perror.1.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man8/mysqld.8.gz conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /var/lib/mysql conflicts between attempted installs of mariadb11.8-server-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/my_print_defaults conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysql conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysql_tzinfo_to_sql conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqladmin conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqlbinlog conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqlcheck conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqldump conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqlimport conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqlshow conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/bin/mysqlslap conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/my_print_defaults.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysql.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysql_tzinfo_to_sql.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-server-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysqladmin.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysqlbinlog.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysqlcheck.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysqldump.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysqlimport.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysqlshow.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
  file /usr/share/man/man1/mysqlslap.1.gz conflicts between attempted installs of mariadb11.8-3:11.8.8-1.el10_2.x86_64 and percona-server-client-8.4.8-8.1.el10.x86_64
```