### PR TITLE
mysql-server-9.7: follow refactor DATE type

### DIFF
--- a/lib/mrn_condition_converter.cpp
+++ b/lib/mrn_condition_converter.cpp
@@ -592,7 +592,7 @@ namespace mrn {
       error = false;
       break;
     default:
-      error = MRN_ITEM_GET_DATE_FUZZY(real_value_item, mysql_time, thread_);
+      error = mrn_item_get_date_fuzzy(real_value_item, mysql_time, thread_);
       break;
     }
 

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -780,8 +780,8 @@ mrn_item_get_date_fuzzy(Item* item, MYSQL_TIME* my_time, THD* thd)
 {
 #  if MYSQL_VERSION_ID >= 90700
   Date_val date;
-  /* The argument of TIME_NO_FLAGS(0) shows default behavior.
-   * The default behaviror does not check for zero parts in dates.
+  /* The argument TIME_NO_FLAGS(=0x00) shows default behavior.
+   * The default behavior does not check for zero parts in dates.
    * So, MySQL can accept incomplete date by using TIME_NO_FLAGS.
    */
   bool result = item->val_date(&date, TIME_NO_FLAGS);

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -757,8 +757,11 @@ static inline bool mrn_item_get_time(Item* item, MYSQL_TIME* my_time, THD* thd)
   return item->get_date(thd, my_time, Time::Options(thd));
 }
 
-#  define MRN_ITEM_GET_DATE_FUZZY(item, time, thd)                             \
-    ((item)->get_date((thd), (time), Time::Options(TIME_FUZZY_DATES, (thd))))
+static inline bool
+mrn_item_get_date_fuzzy(Item* item, MYSQL_TIME* my_time, THD* thd)
+{
+  return item->get_date(thd, my_time, Time::Options(TIME_FUZZY_DATES, thd));
+}
 #else
 static inline bool mrn_item_get_time(Item* item, MYSQL_TIME* my_time, THD* thd)
 {
@@ -772,8 +775,22 @@ static inline bool mrn_item_get_time(Item* item, MYSQL_TIME* my_time, THD* thd)
 #  endif
 }
 
-#  define MRN_ITEM_GET_DATE_FUZZY(item, time, thd)                             \
-    ((item)->get_date((time), TIME_FUZZY_DATE))
+static inline bool
+mrn_item_get_date_fuzzy(Item* item, MYSQL_TIME* my_time, THD* thd)
+{
+#  if MYSQL_VERSION_ID >= 90700
+  Date_val date;
+  /* The argument of TIME_NO_FLAGS(0) shows default behavior.
+   * The default behaviror does not check for zero parts in dates.
+   * So, MySQL can accept incomplete date by using TIME_NO_FLAGS.
+   */
+  bool result = item->val_date(&date, TIME_NO_FLAGS);
+  *my_time = MYSQL_TIME(date);
+  return result;
+#  else
+  return item->get_date(my_time, TIME_FUZZY_DATE);
+#  endif
+}
 #endif
 
 #ifdef MRN_MARIADB_P


### PR DESCRIPTION
Ref:
- https://github.com/mysql/mysql-server/commit/876fd7ffe0db517a03b2ddc86176b148b44b8d6b
- https://github.com/mysql/mysql-server/commit/fcec2d0fc13916d790da787884a11ef3138a93a0

Use Item::val_date() instead of get_date() since MySQL 9.7. Item::val_date() is removed in MySQL 9.7.

The following error is resolved by this change.

```
/mroonga/lib/mrn_condition_converter.cpp: In member function ‘bool mrn::ConditionConverter::get_time_value(const Item_field*, Item*, MYSQL_TIME*)’:
/mroonga/mrn_mysql_compat.h:776:14: error: ‘class Item’ has no member named ‘get_date’
  776 |     ((item)->get_date((time), TIME_FUZZY_DATE))
      |              ^~~~~~~~
/mroonga/lib/mrn_condition_converter.cpp:595:15: note: in expansion of macro ‘MRN_ITEM_GET_DATE_FUZZY’
  595 |       error = MRN_ITEM_GET_DATE_FUZZY(real_value_item, mysql_time, thread_);
      |               ^~~~~~~~~~~~~~~~~~~~~~~
/mroonga/mrn_mysql_compat.h:776:31: error: ‘TIME_FUZZY_DATE’ was not declared in this scope; did you mean ‘TIME_NO_ZERO_DATE’?
  776 |     ((item)->get_date((time), TIME_FUZZY_DATE))
      |                               ^~~~~~~~~~~~~~~
/mroonga/lib/mrn_condition_converter.cpp:595:15: note: in expansion of macro ‘MRN_ITEM_GET_DATE_FUZZY’
  595 |       error = MRN_ITEM_GET_DATE_FUZZY(real_value_item, mysql_time, thread_);
      |               ^~~~~~~~~~~~~~~~~~~~~~~
```