### PR TITLE
mysql-server-9.7: follow refactor TIME handring

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12337,7 +12337,7 @@ int ha_mroonga::generic_store_bulk_time(Field* field, grn_obj* buf)
   bool truncated = false;
   Field_time* time_field = (Field_time*)field;
   MYSQL_TIME mysql_time;
-  MRN_FIELD_GET_TIME(time_field, &mysql_time, current_thd);
+  mrn_field_get_time(time_field, &mysql_time, current_thd);
   mrn::TimeConverter time_converter;
   long long int time =
     time_converter.mysql_time_to_grn_time(&mysql_time, &truncated);
@@ -12356,7 +12356,7 @@ int ha_mroonga::generic_store_bulk_datetime(Field* field, grn_obj* buf)
   bool truncated = false;
   Field_datetime* datetime_field = (Field_datetime*)field;
   MYSQL_TIME mysql_time;
-  MRN_FIELD_GET_TIME(datetime_field, &mysql_time, current_thd);
+  mrn_field_get_time(datetime_field, &mysql_time, current_thd);
   long long int time = 0;
   if (!field->is_null()) {
     mrn::TimeConverter time_converter;
@@ -12446,7 +12446,7 @@ int ha_mroonga::generic_store_bulk_datetime2(Field* field, grn_obj* buf)
   bool truncated = false;
   mrn_field_datetime* datetime_field = (mrn_field_datetime*)field;
   MYSQL_TIME mysql_time;
-  MRN_FIELD_GET_TIME(datetime_field, &mysql_time, current_thd);
+  mrn_field_get_time(datetime_field, &mysql_time, current_thd);
   long long int time = 0;
   mrn::TimeConverter time_converter;
   if (!field->is_null()) {
@@ -12471,7 +12471,7 @@ int ha_mroonga::generic_store_bulk_time2(Field* field, grn_obj* buf)
   int error = 0;
   bool truncated = false;
   MYSQL_TIME mysql_time;
-  MRN_FIELD_GET_TIME(field, &mysql_time, current_thd);
+  mrn_field_get_time(field, &mysql_time, current_thd);
   mrn::TimeConverter time_converter;
   long long int time = 0;
   if (!field->is_null()) {
@@ -12499,7 +12499,7 @@ int ha_mroonga::generic_store_bulk_new_date(Field* field, grn_obj* buf)
   if (!field->is_null()) {
     auto newdate_field = static_cast<mrn_field_date*>(field);
     MYSQL_TIME mysql_date;
-    MRN_FIELD_GET_TIME(newdate_field, &mysql_date, current_thd);
+    mrn_field_get_time(newdate_field, &mysql_date, current_thd);
     mrn::TimeConverter time_converter;
     time = time_converter.mysql_time_to_grn_time(&mysql_date, &truncated);
   }

--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12337,7 +12337,8 @@ int ha_mroonga::generic_store_bulk_time(Field* field, grn_obj* buf)
   bool truncated = false;
   Field_time* time_field = (Field_time*)field;
   MYSQL_TIME mysql_time;
-  mrn_field_get_time(time_field, &mysql_time, current_thd);
+  THD* thd = current_thd;
+  mrn_field_get_time(time_field, &mysql_time, thd);
   mrn::TimeConverter time_converter;
   long long int time =
     time_converter.mysql_time_to_grn_time(&mysql_time, &truncated);
@@ -12356,7 +12357,8 @@ int ha_mroonga::generic_store_bulk_datetime(Field* field, grn_obj* buf)
   bool truncated = false;
   Field_datetime* datetime_field = (Field_datetime*)field;
   MYSQL_TIME mysql_time;
-  mrn_field_get_time(datetime_field, &mysql_time, current_thd);
+  THD* thd = current_thd;
+  mrn_field_get_time(datetime_field, &mysql_time, thd);
   long long int time = 0;
   if (!field->is_null()) {
     mrn::TimeConverter time_converter;
@@ -12446,7 +12448,8 @@ int ha_mroonga::generic_store_bulk_datetime2(Field* field, grn_obj* buf)
   bool truncated = false;
   mrn_field_datetime* datetime_field = (mrn_field_datetime*)field;
   MYSQL_TIME mysql_time;
-  mrn_field_get_time(datetime_field, &mysql_time, current_thd);
+  THD* thd = current_thd;
+  mrn_field_get_time(datetime_field, &mysql_time, thd);
   long long int time = 0;
   mrn::TimeConverter time_converter;
   if (!field->is_null()) {
@@ -12471,7 +12474,8 @@ int ha_mroonga::generic_store_bulk_time2(Field* field, grn_obj* buf)
   int error = 0;
   bool truncated = false;
   MYSQL_TIME mysql_time;
-  mrn_field_get_time(field, &mysql_time, current_thd);
+  THD* thd = current_thd;
+  mrn_field_get_time(field, &mysql_time, thd);
   mrn::TimeConverter time_converter;
   long long int time = 0;
   if (!field->is_null()) {
@@ -12499,7 +12503,8 @@ int ha_mroonga::generic_store_bulk_new_date(Field* field, grn_obj* buf)
   if (!field->is_null()) {
     auto newdate_field = static_cast<mrn_field_date*>(field);
     MYSQL_TIME mysql_date;
-    mrn_field_get_time(newdate_field, &mysql_date, current_thd);
+    THD* thd = current_thd;
+    mrn_field_get_time(newdate_field, &mysql_date, thd);
     mrn::TimeConverter time_converter;
     time = time_converter.mysql_time_to_grn_time(&mysql_date, &truncated);
   }

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -795,16 +795,16 @@ mrn_item_get_date_fuzzy(Item* item, MYSQL_TIME* my_time, THD* thd)
 
 #ifdef MRN_MARIADB_P
 static inline bool
-mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* current_thd)
+mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* thd)
 {
-  return time_field->get_date(my_time, Time::Options(current_thd));
+  return time_field->get_date(my_time, Time::Options(thd));
 }
 
 #  define MRN_FIELD_GET_DATE_NO_FUZZY(field, time, thd)                        \
     ((field)->get_date((time), Time::Options(TIME_CONV_NONE, (thd))))
 #else
 static inline bool
-mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* current_thd)
+mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* thd)
 {
 #  if MYSQL_VERSION_ID >= 90700
   Time_val time;

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -794,12 +794,28 @@ mrn_item_get_date_fuzzy(Item* item, MYSQL_TIME* my_time, THD* thd)
 #endif
 
 #ifdef MRN_MARIADB_P
-#  define MRN_FIELD_GET_TIME(field, time, thd)                                 \
-    ((field)->get_date((time), Time::Options((thd))))
+static inline bool
+mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* current_thd)
+{
+  return time_field->get_date(my_time, Time::Options(current_thd));
+}
+
 #  define MRN_FIELD_GET_DATE_NO_FUZZY(field, time, thd)                        \
     ((field)->get_date((time), Time::Options(TIME_CONV_NONE, (thd))))
 #else
-#  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
+static inline bool
+mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* current_thd)
+{
+#  if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
+  Time_val time;
+  bool result = time_field->val_time(&time);
+  *my_time = MYSQL_TIME(time);
+  return result;
+#  else
+  return time_field->get_time(my_time);
+#  endif
+}
+
 #  define MRN_FIELD_GET_DATE_NO_FUZZY(field, time, thd)                        \
     ((field)->get_date((time), 0))
 #endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -806,7 +806,7 @@ mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* current_thd)
 static inline bool
 mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* current_thd)
 {
-#  if (MYSQL_VERSION_ID >= 90700 && !defined(MRN_MARIADB_P))
+#  if MYSQL_VERSION_ID >= 90700
   Time_val time;
   bool result = time_field->val_time(&time);
   *my_time = MYSQL_TIME(time);


### PR DESCRIPTION
Ref: mysql/mysql-server@6b5b6f5

Use Item::val_time() instead of Item::get_time() since MySQL 9.7. Field::get_time() is removed in MySQL 9.7.

The following error is resolved by this modification.

```
/root/rpmbuild/BUILD/mroonga-16.08/ha_mroonga.cpp: In member function 'int ha_mroonga::generic_store_bulk_time(Field*, grn_obj*)':
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: error: 'class Field_time' has no member named 'get_time'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: note: in definition of macro 'MRN_FIELD_GET_TIME'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/ha_mroonga.cpp: In member function 'int ha_mroonga::generic_store_bulk_datetime(Field*, grn_obj*)':
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: error: 'class Field_datetime' has no member named 'get_time'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: note: in definition of macro 'MRN_FIELD_GET_TIME'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/ha_mroonga.cpp: In member function 'int ha_mroonga::generic_store_bulk_datetime2(Field*, grn_obj*)':
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: error: 'using mrn_field_datetime = class Field_datetime' {aka 'class Field_datetime'} has no member named 'get_time'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: note: in definition of macro 'MRN_FIELD_GET_TIME'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/ha_mroonga.cpp: In member function 'int ha_mroonga::generic_store_bulk_time2(Field*, grn_obj*)':
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: error: 'class Field' has no member named 'get_time'; did you mean 'get_image'?
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: note: in definition of macro 'MRN_FIELD_GET_TIME'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/ha_mroonga.cpp: In member function 'int ha_mroonga::generic_store_bulk_new_date(Field*, grn_obj*)':
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: error: 'class Field_date' has no member named 'get_time'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
/root/rpmbuild/BUILD/mroonga-16.08/mrn_mysql_compat.h:802:58: note: in definition of macro 'MRN_FIELD_GET_TIME'
  802 | #  define MRN_FIELD_GET_TIME(field, time, thd) ((field)->get_time((time)))
      |                                                          ^~~~~~~~
```