### PR TITLE
mysql-server-9.7: follow refactor DATE handling

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12567,7 +12567,7 @@ int ha_mroonga::generic_store_bulk_new_date(Field* field, grn_obj* buf)
     auto newdate_field = static_cast<mrn_field_date*>(field);
     MYSQL_TIME mysql_date;
     THD* thd = current_thd;
-    mrn_field_get_time(newdate_field, &mysql_date, thd);
+    mrn_field_get_date(newdate_field, &mysql_date, thd);
     mrn::TimeConverter time_converter;
     time = time_converter.mysql_time_to_grn_time(&mysql_date, &truncated);
   }
@@ -12983,7 +12983,7 @@ void ha_mroonga::storage_store_field_new_date(Field* field,
   mysql_date.time_type = MYSQL_TIMESTAMP_DATE;
   mrn::TimeConverter time_converter;
   time_converter.grn_time_to_mysql_time(time, &mysql_date);
-  field->store_time(&mysql_date);
+  mrn_store_field_date(field, &mysql_date);
   DBUG_VOID_RETURN;
 }
 

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -800,6 +800,17 @@ mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* thd)
   return time_field->get_date(my_time, Time::Options(thd));
 }
 
+static inline bool
+mrn_field_get_date(Field* time_field, MYSQL_TIME* my_time, THD* thd)
+{
+  return time_field->get_date(my_time, Time::Options(thd));
+}
+
+static inline void mrn_store_field_date(Field* field, MYSQL_TIME* my_field_date)
+{
+  field->store_time(my_field_date);
+}
+
 #  define MRN_FIELD_GET_DATE_NO_FUZZY(field, time, thd)                        \
     ((field)->get_date((time), Time::Options(TIME_CONV_NONE, (thd))))
 #else
@@ -813,6 +824,34 @@ mrn_field_get_time(Field* time_field, MYSQL_TIME* my_time, THD* thd)
   return result;
 #  else
   return time_field->get_time(my_time);
+#  endif
+}
+
+static inline bool
+mrn_field_get_date(Field* time_field, MYSQL_TIME* my_time, THD* thd)
+{
+#  if MYSQL_VERSION_ID >= 90700
+  Date_val date;
+  /*
+   * The argument TIME_NO_FLAGS(=0x00) shows default behavior.
+   * The default behavior does not check for zero parts in dates.
+   * So, MySQL can accept incomplete date by using TIME_NO_FLAGS.
+   */
+  bool result = time_field->val_date(&date, TIME_NO_FLAGS);
+  *my_time = MYSQL_TIME(date);
+  return result;
+#  else
+  return time_field->get_time(my_time);
+#  endif
+}
+
+static inline void mrn_store_field_date(Field* field, MYSQL_TIME* my_field_date)
+{
+#  if MYSQL_VERSION_ID >= 90700
+  Date_val date = Date_val(*my_field_date);
+  field->store_date(date);
+#  else
+  field->store_time(my_field_date);
 #  endif
 }
 


### PR DESCRIPTION
See: https://github.com/mysql/mysql-server/commit/876fd7ffe0db517a03b2ddc86176b148b44b8d6b

We need to use "val_date()" when inserting DATE type value in MySQL 9.7.
Otherwise, we cannot correctly insert DATE values.

If we use get_time() same as before, MySQL does not return HH:MM:SS only. YYYY-MM-DD is not returned.

---

We need to use "store_date()" when reading DATE values in MySQL 9.7.
Otherwise, we cannot correctly read DATE values.

If we use store_time() same as before, store_time() store HH:MM:SS only. YYYY-MM-DD is not stored.