### PR TITLE
mysql-server-9.7: follow refactor DATETIME handling

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12421,7 +12421,7 @@ int ha_mroonga::generic_store_bulk_datetime(Field* field, grn_obj* buf)
   Field_datetime* datetime_field = (Field_datetime*)field;
   MYSQL_TIME mysql_time;
   THD* thd = current_thd;
-  mrn_field_get_time(datetime_field, &mysql_time, thd);
+  mrn_field_get_datetime(datetime_field, &mysql_time, thd);
   long long int time = 0;
   if (!field->is_null()) {
     mrn::TimeConverter time_converter;
@@ -12512,7 +12512,7 @@ int ha_mroonga::generic_store_bulk_datetime2(Field* field, grn_obj* buf)
   mrn_field_datetime* datetime_field = (mrn_field_datetime*)field;
   MYSQL_TIME mysql_time;
   THD* thd = current_thd;
-  mrn_field_get_time(datetime_field, &mysql_time, thd);
+  mrn_field_get_datetime(datetime_field, &mysql_time, thd);
   long long int time = 0;
   mrn::TimeConverter time_converter;
   if (!field->is_null()) {
@@ -12952,7 +12952,7 @@ void ha_mroonga::storage_store_field_datetime(Field* field,
   mysql_datetime.time_type = MYSQL_TIMESTAMP_DATETIME;
   mrn::TimeConverter time_converter;
   time_converter.grn_time_to_mysql_time(time, &mysql_datetime);
-  field->store_time(&mysql_datetime);
+  mrn_store_field_datetime(field, &mysql_datetime);
   DBUG_VOID_RETURN;
 }
 
@@ -12998,7 +12998,7 @@ void ha_mroonga::storage_store_field_datetime2(Field* field,
   mysql_datetime.time_type = MYSQL_TIMESTAMP_DATETIME;
   mrn::TimeConverter time_converter;
   time_converter.grn_time_to_mysql_time(time, &mysql_datetime);
-  field->store_time(&mysql_datetime);
+  mrn_store_field_datetime(field, &mysql_datetime);
   DBUG_VOID_RETURN;
 }
 

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -806,9 +806,21 @@ mrn_field_get_date(Field* time_field, MYSQL_TIME* my_time, THD* thd)
   return time_field->get_date(my_time, Time::Options(thd));
 }
 
+static inline bool
+mrn_field_get_datetime(Field* time_field, MYSQL_TIME* my_time, THD* thd)
+{
+  return time_field->get_date(my_time, Time::Options(thd));
+}
+
 static inline void mrn_store_field_date(Field* field, MYSQL_TIME* my_field_date)
 {
   field->store_time(my_field_date);
+}
+
+static inline void mrn_store_field_datetime(Field* field,
+                                            MYSQL_TIME* my_field_datetime)
+{
+  field->store_time(my_field_datetime);
 }
 
 #  define MRN_FIELD_GET_DATE_NO_FUZZY(field, time, thd)                        \
@@ -845,6 +857,24 @@ mrn_field_get_date(Field* time_field, MYSQL_TIME* my_time, THD* thd)
 #  endif
 }
 
+static inline bool
+mrn_field_get_datetime(Field* time_field, MYSQL_TIME* my_time, THD* thd)
+{
+#  if MYSQL_VERSION_ID >= 90700
+  Datetime_val datetime;
+  /*
+   * The argument TIME_NO_FLAGS(=0x00) shows default behavior.
+   * The default behavior does not check for zero parts in dates.
+   * So, MySQL can accept incomplete date by using TIME_NO_FLAGS.
+   */
+  bool result = time_field->val_datetime(&datetime, TIME_NO_FLAGS);
+  *my_time = MYSQL_TIME(datetime);
+  return result;
+#  else
+  return time_field->get_time(my_time);
+#  endif
+}
+
 static inline void mrn_store_field_date(Field* field, MYSQL_TIME* my_field_date)
 {
 #  if MYSQL_VERSION_ID >= 90700
@@ -852,6 +882,21 @@ static inline void mrn_store_field_date(Field* field, MYSQL_TIME* my_field_date)
   field->store_date(date);
 #  else
   field->store_time(my_field_date);
+#  endif
+}
+
+static inline void mrn_store_field_datetime(Field* field,
+                                            MYSQL_TIME* my_field_datetime)
+{
+#  if MYSQL_VERSION_ID >= 90700
+  /*
+   * store_time() can accept DATETIME values because it internally converts the
+   * input to MYSQL_TIME type. MYSQL_TIME type can represent DATETIME, TIME, and
+   * DATE values without any loss of information.
+   */
+  field->store_time(my_field_datetime, TIME_NO_FLAGS);
+#  else
+  field->store_time(my_field_datetime);
 #  endif
 }
 


### PR DESCRIPTION
See: mysql/mysql-server@876fd7f

We need to use "val_datetime()" when inserting DATETIME type value in MySQL 9.7. Otherwise, we cannot correctly insert DATETIME values.

If we use get_time() same as before, MySQL does not return HH:MM:SS only.
YYYY-MM-DD is not returned.

---

We also use "store_time()" when reading DATETIME values in MySQL 9.7. 
"store_time()" can accept DATETIME values because it internally converts the input to MYSQL_TIME type.
MYSQL_TIME type can represent DATETIME, TIME, and DATE values without any loss of information.