### PR TITLE
mysql-server-9.7: follow refactor TIME handring

### DIFF
--- a/ha_mroonga.cpp
+++ b/ha_mroonga.cpp
@@ -12937,7 +12937,7 @@ void ha_mroonga::storage_store_field_time(Field* field,
   mysql_time.time_type = MYSQL_TIMESTAMP_TIME;
   mrn::TimeConverter time_converter;
   time_converter.grn_time_to_mysql_time(time, &mysql_time);
-  field->store_time(&mysql_time);
+  mrn_store_field_time(field, &mysql_time);
   DBUG_VOID_RETURN;
 }
 
@@ -13014,7 +13014,7 @@ void ha_mroonga::storage_store_field_time2(Field* field,
   mysql_time.time_type = MYSQL_TIMESTAMP_TIME;
   mrn::TimeConverter time_converter;
   time_converter.grn_time_to_mysql_time(time, &mysql_time);
-  field->store_time(&mysql_time);
+  mrn_store_field_time(field, &mysql_time);
   DBUG_VOID_RETURN;
 }
 

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -885,11 +885,18 @@ static inline void mrn_store_field_time(Field* field, MYSQL_TIME* my_field_time)
 #  if MYSQL_VERSION_ID >= 90700
   Time_val time = Time_val(*my_field_time);
   /*
-   * The argument TIME_NO_FLAGS(=0x00) shows default behavior.
-   * The default behavior does not check for zero parts in dates.
-   * So, MySQL can accept incomplete date by using TIME_NO_FLAGS.
+   * The second argument specifies the number of fractional digits in ltime.
+   * However, it is meaningful only when storing the value into a
+   * CHAR/VARCHAR/TEXT field.
+   * See: https://github.com/mysql/mysql-server/blob/9.7/sql/field.h#L960-L964
+   *
+   * For TIME, DATE, and DATETIME fields, this argument is ignored because
+   * those field types already store their own fractional-seconds precision.
+   *
+   * Since this function handles the TIME values, the argument is ignored.
+   * So, we always pass 0.
    */
-  field->store_time(time, TIME_NO_FLAGS);
+  field->store_time(time, 0);
 #  else
   field->store_time(my_field_time);
 #  endif
@@ -913,8 +920,19 @@ static inline void mrn_store_field_datetime(Field* field,
    * store_time() can accept DATETIME values because it internally converts the
    * input to MYSQL_TIME type. MYSQL_TIME type can represent DATETIME, TIME, and
    * DATE values without any loss of information.
+   *
+   * The second argument specifies the number of fractional digits in ltime.
+   * However, it is meaningful only when storing the value into a
+   * CHAR/VARCHAR/TEXT field.
+   * See: https://github.com/mysql/mysql-server/blob/9.7/sql/field.h#L960-L964
+   *
+   * For TIME, DATE, and DATETIME fields, this argument is ignored because
+   * those field types already store their own fractional-seconds precision.
+   *
+   * Since this function handles the DATETIME values, the argument is ignored.
+   * So, we always pass 0.
    */
-  field->store_time(my_field_datetime, TIME_NO_FLAGS);
+  field->store_time(my_field_datetime, 0);
 #  else
   field->store_time(my_field_datetime);
 #  endif

--- a/mrn_mysql_compat.h
+++ b/mrn_mysql_compat.h
@@ -812,6 +812,11 @@ mrn_field_get_datetime(Field* time_field, MYSQL_TIME* my_time, THD* thd)
   return time_field->get_date(my_time, Time::Options(thd));
 }
 
+static inline void mrn_store_field_time(Field* field, MYSQL_TIME* my_field_time)
+{
+  field->store_time(my_field_time);
+}
+
 static inline void mrn_store_field_date(Field* field, MYSQL_TIME* my_field_date)
 {
   field->store_time(my_field_date);
@@ -872,6 +877,21 @@ mrn_field_get_datetime(Field* time_field, MYSQL_TIME* my_time, THD* thd)
   return result;
 #  else
   return time_field->get_time(my_time);
+#  endif
+}
+
+static inline void mrn_store_field_time(Field* field, MYSQL_TIME* my_field_time)
+{
+#  if MYSQL_VERSION_ID >= 90700
+  Time_val time = Time_val(*my_field_time);
+  /*
+   * The argument TIME_NO_FLAGS(=0x00) shows default behavior.
+   * The default behavior does not check for zero parts in dates.
+   * So, MySQL can accept incomplete date by using TIME_NO_FLAGS.
+   */
+  field->store_time(time, TIME_NO_FLAGS);
+#  else
+  field->store_time(my_field_time);
 #  endif
 }
 


### PR DESCRIPTION
This is an omission in GH-1120.

We need to also change store_time() function.
Otherwise, we cannot correctly read TIME values.