### PR TITLE
packages debian-trixie: add MySQL 9.7 LTS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -177,6 +177,13 @@ jobs:
           - os: almalinux-10
             package: mysql-community-9.7
             test-image: "images:almalinux/10"
+          # This is a temporary workaround.
+          # Currently, the Mroonga debian package cannot be installed with MySQL 9.7 due to a dependency issue.
+          # For details, refer to https://bugs.mysql.com/bug.php?id=120697.
+          # We can remove this workaround when this issue is resolved upstream.
+          #- os: debian-trixie
+          #  package: mysql-community-9.7
+          #  test-image: "images:debian/13"
           - os: ubuntu-jammy
             package: mysql-community-9.7
             test-image: "images:ubuntu/22.04"

--- a/packages/mysql-community-9.7-mroonga/Rakefile
+++ b/packages/mysql-community-9.7-mroonga/Rakefile
@@ -7,6 +7,7 @@ class MySQLCommunity97MroongaPackageTask < MroongaPackageTask
 
   def apt_targets_default
     [
+      "debian-trixie",
       "ubuntu-jammy",
       "ubuntu-noble",
     ]

--- a/packages/mysql-community-9.7-mroonga/apt/debian-trixie/Dockerfile
+++ b/packages/mysql-community-9.7-mroonga/apt/debian-trixie/Dockerfile
@@ -1,0 +1,50 @@
+ARG FROM=debian:trixie
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ENV \
+  DEBIAN_FRONTEND=noninteractive \
+  MYSQL_SERVER_VERSION=mysql-9.7-lts
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V --no-install-recommends ${quiet} lsb-release && \
+  distribution=$(lsb_release --id --short | tr 'A-Z' 'a-z') && \
+  code_name=$(lsb_release --codename --short) && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    ca-certificates \
+    wget && \
+  wget https://packages.apache.org/artifactory/arrow/${distribution}/apache-arrow-apt-source-latest-${code_name}.deb && \
+  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-${code_name}.deb && \
+  wget https://packages.groonga.org/${distribution}/groonga-apt-source-latest-${code_name}.deb && \
+  # Normally, we should use https://repo.mysql.com/mysql-apt-config.deb.
+  # However, it currently does not support MySQL 9.7.
+  # MySQL 9.7 support is currently available only in mysql-apt-config_0.8.39-1_all.deb.
+  # Therefore, we use mysql-apt-config_0.8.39-1_all.deb.
+  wget https://repo.mysql.com/mysql-apt-config_0.8.39-1_all.deb && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    ./*.deb && \
+  rm *.deb && \
+  apt update ${quiet} && \
+  apt build-dep -y --no-install-recommends ${quiet} \
+    mysql-community && \
+  apt source ${quiet} \
+    mysql-community && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    build-essential \
+    ccache \
+    cmake \
+    devscripts \
+    dh-apparmor \
+    groonga-normalizer-mysql \
+    libgroonga-dev \
+    libmysqlclient-dev \
+    libtirpc-dev \
+    mysql-router-community \
+    ninja-build


### PR DESCRIPTION
This change adds support for MySQL 9.7 LTS on Debian 13 (Trixie).

However, the Mroonga Debian package cannot be installed with MySQL 9.7 because of a dependency issue.
For details, see: https://bugs.mysql.com/bug.php?id=120697.

Therefore, we do not provide the package now.
 This change only adds the necessary definitions.